### PR TITLE
feat: multi-buddy menagerie — named slots, interactive picker, atomic storage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
       },
+      "devDependencies": {
+        "bun-types": "^1.3.11",
+      },
     },
   },
   "packages": {
@@ -21,6 +24,8 @@
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/cli/hunt.ts
+++ b/cli/hunt.ts
@@ -1,22 +1,29 @@
 /**
  * claude-buddy hunt — brute-force search for a specific buddy
+ *
+ * Rules:
+ *   - Asks for a name before saving
+ *   - If no name given, picks a random unused name from the manifest
+ *   - Appends to the manifest — never overwrites an existing slot
  */
 
 import {
   searchBuddy, renderBuddy, SPECIES, RARITIES, STAT_NAMES,
   type Species, type Rarity, type StatName, type SearchCriteria,
 } from "../server/engine.ts";
-import { saveCompanion, writeStatusState, resolveUserId } from "../server/state.ts";
-import { generateFallbackName } from "../server/reactions.ts";
+import {
+  saveCompanionSlot, saveActiveSlot, writeStatusState,
+  slugify, unusedName, listCompanionSlots,
+} from "../server/state.ts";
 import { createInterface } from "readline";
 
-const CYAN = "\x1b[36m";
+const CYAN  = "\x1b[36m";
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
-const RED = "\x1b[31m";
-const BOLD = "\x1b[1m";
-const DIM = "\x1b[2m";
-const NC = "\x1b[0m";
+const RED   = "\x1b[31m";
+const BOLD  = "\x1b[1m";
+const DIM   = "\x1b[2m";
+const NC    = "\x1b[0m";
 
 const rl = createInterface({ input: process.stdin, output: process.stdout });
 
@@ -65,7 +72,6 @@ ${CYAN}╚═══════════════════════�
     console.log(`${GREEN}✓${NC} peak=${wantPeak} dump=${wantDump}`);
   }
 
-  // Calculate max attempts
   let maxAttempts = 10_000_000;
   if (rarity === "legendary") maxAttempts = 200_000_000;
   else if (rarity === "epic") maxAttempts = 50_000_000;
@@ -118,36 +124,41 @@ ${CYAN}╚═══════════════════════�
   const chosen = top[pickIdx];
   console.log(`\n${renderBuddy(chosen.bones)}\n`);
 
+  // ─── Ask for a name ────────────────────────────────────────────────────────
+  const existing = new Set(listCompanionSlots().map((e) => slugify(e.companion.name)));
+  const suggested = unusedName();
+  console.log(`\n${DIM}  Existing buddies: ${[...existing].join(", ") || "none"}${NC}`);
+
+  let chosenName = "";
+  while (true) {
+    const raw = await ask(
+      `  Name this buddy (Enter for "${suggested}"): `,
+    );
+    chosenName = raw.trim() || suggested;
+    const slot = slugify(chosenName);
+    if (existing.has(slot)) {
+      console.log(`  ${YELLOW}⚠${NC}  Slot "${slot}" already taken — pick another name.`);
+    } else {
+      break;
+    }
+  }
+
+  const slot = slugify(chosenName);
   const companion = {
     bones: chosen.bones,
-    name: generateFallbackName(),
+    name: chosenName,
     personality: `A ${chosen.bones.rarity} ${chosen.bones.species} who watches code with quiet intensity.`,
     hatchedAt: Date.now(),
     userId: chosen.userId,
   };
 
-  saveCompanion(companion);
-  writeStatusState(companion);
+  saveCompanionSlot(companion, slot);
+  saveActiveSlot(slot);
+  writeStatusState(companion, `*${chosenName} arrives*`);
 
-  // Also update ~/.claude.json userID for Claude Code's own companion system
-  try {
-    const { readFileSync: rf, writeFileSync: wf } = require("fs");
-    const { join: pj } = require("path");
-    const { homedir: hd } = require("os");
-    const cfgPath = pj(hd(), ".claude.json");
-    const cfg = JSON.parse(rf(cfgPath, "utf8"));
-    cfg.userID = chosen.userId;
-    delete cfg.companion;
-    if (cfg.oauthAccount?.accountUuid) delete cfg.oauthAccount.accountUuid;
-    wf(cfgPath, JSON.stringify(cfg, null, 2));
-    console.log(`${GREEN}✓${NC}  userID set in ~/.claude.json`);
-  } catch {
-    console.log(`${YELLOW}⚠${NC}  Could not update ~/.claude.json — do it manually or run with --fix`);
-  }
-
-  console.log(`${GREEN}✓${NC}  Companion saved: ${companion.name}`);
+  console.log(`${GREEN}✓${NC}  ${chosenName} saved to slot "${slot}" and set as active.`);
   console.log(`\n${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}`);
-  console.log(`${GREEN}  Done! Restart Claude Code and type /buddy${NC}`);
+  console.log(`${GREEN}  Done! Restart Claude Code to see your new buddy.${NC}`);
   console.log(`${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n`);
 
   rl.close();

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -6,7 +6,8 @@
  *   npx claude-buddy              Interactive install
  *   npx claude-buddy install      Install MCP + skill + hooks + statusline
  *   npx claude-buddy show         Show current buddy
- *   npx claude-buddy hunt         Search for a specific buddy
+ *   npx claude-buddy pick         Interactive two-pane buddy picker (saved + search)
+ *   npx claude-buddy hunt         Search for a specific buddy (non-interactive)
  *   npx claude-buddy uninstall    Remove all integrations
  *   npx claude-buddy verify       Verify what buddy your ID produces
  */
@@ -20,6 +21,9 @@ switch (command) {
     break;
   case "show":
     await import("./show.ts");
+    break;
+  case "pick":
+    await import("./pick.ts");
     break;
   case "hunt":
     await import("./hunt.ts");
@@ -47,7 +51,8 @@ claude-buddy — permanent coding companion for Claude Code
 Commands:
   install           Set up MCP server, skill, hooks, and status line
   show              Display your current buddy
-  hunt              Search for a specific buddy (species, rarity, stats)
+  pick              Interactive two-pane buddy picker (browse saved + search)
+  hunt              Search for a specific buddy (non-interactive)
   verify            Verify what buddy your current ID produces
   doctor            Run diagnostic report (paste output in bug reports)
   test-statusline   Install temporary diagnostic status line in Claude Code

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -155,12 +155,13 @@ function installStatusLine(settings: Record<string, any>) {
 // ─── Step 4: Register hooks ─────────────────────────────────────────────────
 
 function installHooks(settings: Record<string, any>) {
-  const reactHook = join(PROJECT_ROOT, "hooks", "react.sh");
-  const commentHook = join(PROJECT_ROOT, "hooks", "buddy-comment.sh");
+  const reactHook    = join(PROJECT_ROOT, "hooks", "react.sh");
+  const commentHook  = join(PROJECT_ROOT, "hooks", "buddy-comment.sh");
+  const nameHook     = join(PROJECT_ROOT, "hooks", "name-react.sh");
 
   if (!settings.hooks) settings.hooks = {};
 
-  // PostToolUse: detect errors/test failures in Bash output
+  // PostToolUse: detect errors/test failures/successes in Bash output
   if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
   settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
@@ -170,7 +171,7 @@ function installHooks(settings: Record<string, any>) {
     hooks: [{ type: "command", command: reactHook }],
   });
 
-  // Stop: extract buddy comment from Claude's response
+  // Stop: extract <!-- buddy: --> comment from Claude's response
   if (!settings.hooks.Stop) settings.hooks.Stop = [];
   settings.hooks.Stop = settings.hooks.Stop.filter(
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
@@ -179,7 +180,16 @@ function installHooks(settings: Record<string, any>) {
     hooks: [{ type: "command", command: commentHook }],
   });
 
-  ok("Hooks registered: PostToolUse + Stop");
+  // UserPromptSubmit: detect buddy's name in user message → instant status line reaction
+  if (!settings.hooks.UserPromptSubmit) settings.hooks.UserPromptSubmit = [];
+  settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit.filter(
+    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+  );
+  settings.hooks.UserPromptSubmit.push({
+    hooks: [{ type: "command", command: nameHook }],
+  });
+
+  ok("Hooks registered: PostToolUse + Stop + UserPromptSubmit");
 }
 
 // ─── Step 5: Ensure MCP tools are allowed ───────────────────────────────────

--- a/cli/pick.ts
+++ b/cli/pick.ts
@@ -9,7 +9,7 @@
  *  Results: matched buddies     │  preview of highlighted
  *  Naming:  name + save prompt  │  card with live name
  *
- * Keys — Saved:    ↑↓ navigate  [enter] summon  [s] search  [q] quit
+ * Keys — Saved:    ↑↓ navigate  [enter] summon  [r] random  [s] search  [q] quit
  * Keys — Criteria: ↑↓ field     ←→ value        [enter] run  [esc] back
  * Keys — Results:  ↑↓ navigate  [enter] pick     [esc] back  [q] quit
  * Keys — Naming:   type name    [enter] save      [esc] cancel
@@ -134,7 +134,7 @@ function savedPane(s: State): string[] {
   }
 
   lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
-  lines.push(`  ${GR}↑↓ navigate  enter summon  q quit${N}`);
+  lines.push(`  ${GR}↑↓ navigate  enter summon  r random  s search  q quit${N}`);
   return lines;
 }
 
@@ -360,7 +360,17 @@ function onKey(key: string, s: State): boolean {
       if (key === "s")                          { s.mode = "criteria"; break; }
       if (key === "\x1b[A" || key === "k")      s.savedCursor = clamp(s.savedCursor - 1, 0, s.savedSlots.length - 1);
       else if (key === "\x1b[B" || key === "j") s.savedCursor = clamp(s.savedCursor + 1, 0, s.savedSlots.length - 1);
-      else if (key === "\r" || key === "\n") {
+      else if (key === "r") {
+        // Random pick from menagerie
+        if (s.savedSlots.length > 0) {
+          const entry = s.savedSlots[Math.floor(Math.random() * s.savedSlots.length)];
+          s.savedCursor = s.savedSlots.indexOf(entry);
+          saveActiveSlot(entry.slot);
+          writeStatusState(entry.companion, `*${entry.companion.name} arrives*`);
+          s.message = `✓ ${entry.companion.name} summoned at random!`;
+          return true;
+        }
+      } else if (key === "\r" || key === "\n") {
         const entry = s.savedSlots[s.savedCursor];
         if (entry) {
           saveActiveSlot(entry.slot);

--- a/cli/pick.ts
+++ b/cli/pick.ts
@@ -1,0 +1,454 @@
+#!/usr/bin/env bun
+/**
+ * cli/pick.ts — interactive two-pane buddy picker
+ *
+ *  Left pane                    │  Right pane
+ *  ─────────────────────────    │  ──────────────────────
+ *  Saved:   list of slots       │  full companion card
+ *  Criteria: search form        │
+ *  Results: matched buddies     │  preview of highlighted
+ *  Naming:  name + save prompt  │  card with live name
+ *
+ * Keys — Saved:    ↑↓ navigate  [enter] summon  [s] search  [q] quit
+ * Keys — Criteria: ↑↓ field     ←→ value        [enter] run  [esc] back
+ * Keys — Results:  ↑↓ navigate  [enter] pick     [esc] back  [q] quit
+ * Keys — Naming:   type name    [enter] save      [esc] cancel
+ */
+
+import {
+  loadActiveSlot, saveActiveSlot, listCompanionSlots,
+  loadCompanionSlot, saveCompanionSlot, slugify, unusedName, writeStatusState,
+} from "../server/state.ts";
+import {
+  generateBones, SPECIES, RARITIES, STAT_NAMES, RARITY_STARS,
+  type Species, type Rarity, type StatName, type BuddyBones, type Companion,
+} from "../server/engine.ts";
+import { renderCompanionCard } from "../server/art.ts";
+import { randomBytes } from "crypto";
+
+// ─── ANSI ─────────────────────────────────────────────────────────────────────
+
+const RARITY_CLR: Record<string, string> = {
+  common:    "\x1b[38;2;153;153;153m",
+  uncommon:  "\x1b[38;2;78;186;101m",
+  rare:      "\x1b[38;2;177;185;249m",
+  epic:      "\x1b[38;2;175;135;255m",
+  legendary: "\x1b[38;2;255;193;7m",
+};
+const B  = "\x1b[1m";
+const D  = "\x1b[2m";
+const RV = "\x1b[7m";
+const N  = "\x1b[0m";
+const CY = "\x1b[36m";
+const GR = "\x1b[90m";
+const YL = "\x1b[33m";
+const GN = "\x1b[32m";
+
+function stripAnsi(s: string): string { return s.replace(/\x1b\[[^m]*m/g, ""); }
+function vlen(s: string): number { return [...stripAnsi(s)].length; }
+function rpad(s: string, w: number): string {
+  const v = vlen(s);
+  return v < w ? s + " ".repeat(w - v) : s;
+}
+
+// ─── Option lists ─────────────────────────────────────────────────────────────
+
+const SP_OPTS = ["any", ...SPECIES]    as const;
+const RA_OPTS = ["any", ...RARITIES]   as const;
+const SH_OPTS = ["any", "yes", "no"]   as const;
+const ST_OPTS = ["any", ...STAT_NAMES] as const;
+
+const CRITERIA_ROWS: Array<{ label: string; opts: readonly string[] }> = [
+  { label: "Species", opts: SP_OPTS },
+  { label: "Rarity ", opts: RA_OPTS },
+  { label: "Shiny  ", opts: SH_OPTS },
+  { label: "Peak   ", opts: ST_OPTS },
+  { label: "Dump   ", opts: ST_OPTS },
+];
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+type Mode = "saved" | "criteria" | "results" | "naming";
+interface SlotEntry   { slot: string; companion: Companion; }
+interface BuddyResult { userId: string; bones: BuddyBones; }
+
+interface State {
+  mode:          Mode;
+  savedSlots:    SlotEntry[];
+  savedCursor:   number;
+  activeSlot:    string;
+  criteriaFocus: number;
+  ci:            number[];   // [speciesIdx, rarityIdx, shinyIdx, peakIdx, dumpIdx]
+  results:       BuddyResult[];
+  resultCursor:  number;
+  searchStatus:  string;
+  nameInput:     string;
+  pendingResult: BuddyResult | null;
+  message:       string;
+}
+
+function fresh(): State {
+  return {
+    mode:          "saved",
+    savedSlots:    listCompanionSlots(),
+    savedCursor:   0,
+    activeSlot:    loadActiveSlot(),
+    criteriaFocus: 0,
+    // Default criteria: legendary, any species
+    ci: [0, RA_OPTS.indexOf("legendary"), 0, 0, 0],
+    results:       [],
+    resultCursor:  0,
+    searchStatus:  "",
+    nameInput:     "",
+    pendingResult: null,
+    message:       "",
+  };
+}
+
+// ─── Pane builders ────────────────────────────────────────────────────────────
+
+const LEFT_W = 36;
+
+function savedPane(s: State): string[] {
+  const lines: string[] = [];
+  lines.push(`${B}  Your Menagerie${N}  ${GR}[s] search${N}`);
+  lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+
+  if (s.savedSlots.length === 0) {
+    lines.push(`  ${GR}your menagerie is empty${N}`);
+    lines.push(`  ${GR}press [s] to search${N}`);
+  }
+
+  for (let i = 0; i < s.savedSlots.length; i++) {
+    const { slot, companion: c } = s.savedSlots[i];
+    const isActive = slot === s.activeSlot;
+    const isCursor = i === s.savedCursor;
+    const dot  = isActive ? `${GN}●${N}` : " ";
+    const clr  = RARITY_CLR[c.bones.rarity] ?? "";
+    const star = RARITY_STARS[c.bones.rarity];
+    const shiny = c.bones.shiny ? "✨" : "  ";
+    const name  = c.name.slice(0, 11).padEnd(11);
+    const sp    = c.bones.species.slice(0, 7).padEnd(7);
+    const row   = ` ${dot} ${clr}${name}${N} ${GR}${sp}${N} ${clr}${star}${N} ${shiny}`;
+    lines.push(isCursor ? RV + row + N : row);
+  }
+
+  lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+  lines.push(`  ${GR}↑↓ navigate  enter summon  q quit${N}`);
+  return lines;
+}
+
+function criteriaPane(s: State): string[] {
+  const lines: string[] = [];
+  lines.push(`${B}  Search Criteria${N}`);
+  lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+
+  for (let i = 0; i < CRITERIA_ROWS.length; i++) {
+    const { label, opts } = CRITERIA_ROWS[i];
+    const val     = opts[s.ci[i]];
+    const focus   = i === s.criteriaFocus;
+    const clr     = RARITY_CLR[val] ?? "";
+    const arrow   = focus ? `${YL}>${N}` : " ";
+    const valDisp = focus
+      ? `${RV}${B} ${val.padEnd(11)} ${N}`
+      : `${D}${clr} ${val.padEnd(11)} ${N}`;
+    lines.push(`  ${arrow} ${GR}${label}${N}  ${valDisp}  ${GR}←→${N}`);
+  }
+
+  lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+  lines.push(`  ${GR}↑↓ field  ←→ value  enter search${N}`);
+  lines.push(`  ${GR}esc back to saved${N}`);
+  if (s.searchStatus) lines.push(`  ${YL}${s.searchStatus}${N}`);
+  return lines;
+}
+
+function resultsPane(s: State): string[] {
+  const lines: string[] = [];
+  lines.push(`${B}  Results${N}  ${GR}${s.results.length} found${N}`);
+  lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+
+  if (s.results.length === 0) {
+    lines.push(`  ${GR}no matches — try broader criteria${N}`);
+  }
+
+  // Scrolling window
+  const viewH  = 12;
+  const offset = Math.max(0, s.resultCursor - Math.floor(viewH / 2));
+  for (let i = offset; i < Math.min(s.results.length, offset + viewH); i++) {
+    const b      = s.results[i].bones;
+    const sel    = i === s.resultCursor;
+    const clr    = RARITY_CLR[b.rarity] ?? "";
+    const star   = RARITY_STARS[b.rarity];
+    const shiny  = b.shiny ? "✨" : "  ";
+    const ra     = b.rarity.slice(0, 3);
+    const sp     = b.species.padEnd(8);
+    const eye    = `e:${b.eye}`;
+    const hat    = `h:${b.hat.slice(0, 6).padEnd(6)}`;
+    const row    = `  ${clr}${ra}${N} ${sp} ${GR}${eye} ${hat}${N} ${shiny}`;
+    lines.push(sel ? RV + row + N : row);
+  }
+
+  lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+  lines.push(`  ${GR}↑↓ navigate  enter name+save  esc back${N}`);
+  return lines;
+}
+
+function namingPane(s: State): string[] {
+  const b   = s.pendingResult?.bones;
+  const clr = b ? (RARITY_CLR[b.rarity] ?? "") : "";
+  const lines: string[] = [];
+  lines.push(`${B}  Name this buddy${N}`);
+  if (b) lines.push(`  ${clr}${b.rarity} ${b.species}${N}`);
+  lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+  lines.push(`  ${B}Name:${N} ${s.nameInput}${YL}▌${N}`);
+  lines.push(`  ${GR}(type a name, or just enter for random)${N}`);
+  lines.push("");
+  lines.push(`  ${GR}enter save  esc cancel${N}`);
+  return lines;
+}
+
+function previewPane(s: State): string[] {
+  let c: Companion | null = null;
+
+  if (s.mode === "saved") {
+    c = s.savedSlots[s.savedCursor]?.companion ?? null;
+  } else if (s.mode === "results") {
+    const r = s.results[s.resultCursor];
+    if (r) c = {
+      bones: r.bones, name: "???",
+      personality: `A ${r.bones.rarity} ${r.bones.species}`,
+      hatchedAt: Date.now(), userId: r.userId,
+    };
+  } else if (s.mode === "naming" && s.pendingResult) {
+    const r = s.pendingResult;
+    c = {
+      bones: r.bones, name: s.nameInput || "???",
+      personality: `A ${r.bones.rarity} ${r.bones.species} who watches code with quiet intensity.`,
+      hatchedAt: Date.now(), userId: r.userId,
+    };
+  }
+
+  if (!c) return [`  ${GR}no preview${N}`];
+  return renderCompanionCard(c.bones, c.name, c.personality).split("\n");
+}
+
+// ─── Screen render ────────────────────────────────────────────────────────────
+
+function drawScreen(s: State): void {
+  const cols = Math.max(80, process.stdout.columns || 80);
+  const rows = Math.max(20, process.stdout.rows    || 24);
+
+  const leftLines  = s.mode === "saved"    ? savedPane(s)
+                   : s.mode === "criteria" ? criteriaPane(s)
+                   : s.mode === "results"  ? resultsPane(s)
+                   : namingPane(s);
+  const rightLines = previewPane(s);
+  const contentH   = rows - 2;
+
+  let out = "\x1b[2J\x1b[H"; // clear + home
+
+  // Title bar
+  const title    = ` claude-buddy pick `;
+  const fill     = "─".repeat(Math.max(0, cols - title.length - 2));
+  out += `${CY}─${B}${title}${N}${CY}${fill}─${N}\n`;
+
+  // Content rows
+  for (let i = 0; i < contentH; i++) {
+    const l = rpad(leftLines[i] ?? "", LEFT_W);
+    const r = rightLines[i] ?? "";
+    out += l + GR + "│" + N + " " + r + "\n";
+  }
+
+  // Footer
+  out += GR + "─".repeat(cols) + N;
+
+  // Message overlay on last line
+  if (s.message) {
+    out += `\x1b[${rows};1H  ${GN}${B}${s.message}${N}`;
+  }
+
+  process.stdout.write(out);
+}
+
+// ─── Search ───────────────────────────────────────────────────────────────────
+
+function runSearch(s: State): void {
+  const wantSp    = SP_OPTS[s.ci[0]] !== "any" ? SP_OPTS[s.ci[0]] as Species  : null;
+  const wantRa    = RA_OPTS[s.ci[1]] !== "any" ? RA_OPTS[s.ci[1]] as Rarity   : null;
+  const wantShiny = SH_OPTS[s.ci[2]] === "yes" ? true
+                  : SH_OPTS[s.ci[2]] === "no"  ? false : null;
+  const wantPeak  = ST_OPTS[s.ci[3]] !== "any" ? ST_OPTS[s.ci[3]] as StatName : null;
+  const wantDump  = ST_OPTS[s.ci[4]] !== "any" ? ST_OPTS[s.ci[4]] as StatName : null;
+
+  // Scale attempt budget to rarity difficulty
+  const maxAttempts =
+    wantRa === "legendary" ? 200_000_000 :
+    wantRa === "epic"      ?  50_000_000 :
+    wantRa === "rare"      ?  20_000_000 : 10_000_000;
+
+  const results: BuddyResult[] = [];
+  const progressRow = (process.stdout.rows || 24) - 1;
+
+  for (let i = 0; i < maxAttempts && results.length < 20; i++) {
+    if (i > 0 && i % 1_000_000 === 0) {
+      s.searchStatus = `${(i / 1e6).toFixed(0)}M checked — ${results.length} found`;
+      process.stdout.write(
+        `\x1b[${progressRow};1H  ${YL}${s.searchStatus}${N}   \x1b[K`,
+      );
+    }
+
+    const userId = randomBytes(16).toString("hex");
+    const bones  = generateBones(userId);
+
+    if (wantSp    !== null && bones.species !== wantSp)    continue;
+    if (wantRa    !== null && bones.rarity  !== wantRa)    continue;
+    if (wantShiny !== null && bones.shiny   !== wantShiny) continue;
+    if (wantPeak  !== null && bones.peak    !== wantPeak)  continue;
+    if (wantDump  !== null && bones.dump    !== wantDump)  continue;
+
+    results.push({ userId, bones });
+  }
+
+  s.searchStatus = `${results.length} found`;
+  s.results      = results;
+  s.resultCursor = 0;
+  s.mode         = "results";
+}
+
+// ─── Key handlers ─────────────────────────────────────────────────────────────
+
+function clamp(v: number, lo: number, hi: number) { return Math.max(lo, Math.min(hi, v)); }
+
+/** Returns true if the TUI should exit. */
+function onKey(key: string, s: State): boolean {
+  if (key === "\x03") return true;  // Ctrl+C always quits
+
+  switch (s.mode) {
+    case "naming": {
+      if (key === "\x1b") {
+        s.mode = "results"; s.nameInput = ""; s.pendingResult = null;
+      } else if (key === "\r" || key === "\n") {
+        // Empty input → auto-pick a random unused name
+        const name = s.nameInput.trim() || unusedName();
+        const slot = slugify(name);
+        if (loadCompanionSlot(slot)) {
+          s.message = `"${slot}" already taken — type a different name`;
+          s.nameInput = "";
+          break;
+        }
+        const r    = s.pendingResult!;
+        const companion: Companion = {
+          bones: r.bones, name,
+          personality: `A ${r.bones.rarity} ${r.bones.species} who watches code with quiet intensity.`,
+          hatchedAt: Date.now(), userId: r.userId,
+        };
+        saveCompanionSlot(companion, slot);
+        saveActiveSlot(slot);
+        writeStatusState(companion, `*${name} arrives*`);
+        s.message = `✓ ${name} saved to slot "${slot}" and set as active!`;
+        return true;
+      } else if (key === "\u007f" || key === "\b") {
+        s.nameInput = s.nameInput.slice(0, -1);
+      } else if (key.length === 1 && key >= " " && s.nameInput.length < 14) {
+        s.nameInput += key;
+      }
+      break;
+    }
+
+    case "saved": {
+      if (key === "q")                          return true;
+      if (key === "s")                          { s.mode = "criteria"; break; }
+      if (key === "\x1b[A" || key === "k")      s.savedCursor = clamp(s.savedCursor - 1, 0, s.savedSlots.length - 1);
+      else if (key === "\x1b[B" || key === "j") s.savedCursor = clamp(s.savedCursor + 1, 0, s.savedSlots.length - 1);
+      else if (key === "\r" || key === "\n") {
+        const entry = s.savedSlots[s.savedCursor];
+        if (entry) {
+          saveActiveSlot(entry.slot);
+          writeStatusState(entry.companion, `*${entry.companion.name} arrives*`);
+          s.message = `✓ ${entry.companion.name} summoned!`;
+          return true;
+        }
+      }
+      break;
+    }
+
+    case "criteria": {
+      if (key === "q")                          return true;
+      if (key === "\x1b")                       { s.mode = "saved"; break; }
+      if (key === "\x1b[A" || key === "k")      s.criteriaFocus = clamp(s.criteriaFocus - 1, 0, CRITERIA_ROWS.length - 1);
+      else if (key === "\x1b[B" || key === "j") s.criteriaFocus = clamp(s.criteriaFocus + 1, 0, CRITERIA_ROWS.length - 1);
+      else if (key === "\x1b[C" || key === "l") {
+        const len = CRITERIA_ROWS[s.criteriaFocus].opts.length;
+        s.ci[s.criteriaFocus] = (s.ci[s.criteriaFocus] + 1) % len;
+      } else if (key === "\x1b[D" || key === "h") {
+        const len = CRITERIA_ROWS[s.criteriaFocus].opts.length;
+        s.ci[s.criteriaFocus] = (s.ci[s.criteriaFocus] - 1 + len) % len;
+      } else if (key === "\r" || key === "\n") {
+        s.searchStatus = "Starting search...";
+        drawScreen(s);
+        runSearch(s);
+      }
+      break;
+    }
+
+    case "results": {
+      if (key === "q")                          return true;
+      if (key === "\x1b")                       { s.mode = "criteria"; break; }
+      if (key === "\x1b[A" || key === "k")      s.resultCursor = clamp(s.resultCursor - 1, 0, s.results.length - 1);
+      else if (key === "\x1b[B" || key === "j") s.resultCursor = clamp(s.resultCursor + 1, 0, s.results.length - 1);
+      else if (key === "\r" || key === "\n") {
+        const r = s.results[s.resultCursor];
+        if (r) {
+          s.pendingResult = r;
+          s.nameInput    = "";  // empty — user types name or presses Enter for auto
+          s.mode         = "naming";
+        }
+      }
+      break;
+    }
+  }
+  return false;
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+function cleanup(): void {
+  process.stdout.write("\x1b[?25h");  // show cursor
+  try { process.stdin.setRawMode(false); } catch {}
+  process.stdin.pause();
+}
+
+async function main(): Promise<void> {
+  if (!process.stdin.isTTY) {
+    console.error("buddy pick requires an interactive terminal (TTY)");
+    process.exit(1);
+  }
+
+  process.stdout.write("\x1b[?25l");  // hide cursor
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.setEncoding("utf8");
+
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => { cleanup(); process.exit(0); });
+
+  const s = fresh();
+  drawScreen(s);
+
+  await new Promise<void>((resolve) => {
+    process.stdin.on("data", (key: string) => {
+      const quit = onKey(key, s);
+      drawScreen(s);
+      if (quit) {
+        cleanup();
+        process.stdout.write("\x1b[2J\x1b[H");
+        if (s.message) console.log(`\n  ${s.message}\n`);
+        resolve();
+      }
+    });
+  });
+
+  process.exit(0);
+}
+
+main();

--- a/hooks/buddy-comment.sh
+++ b/hooks/buddy-comment.sh
@@ -7,7 +7,6 @@
 
 STATE_DIR="$HOME/.claude-buddy"
 STATUS_FILE="$STATE_DIR/status.json"
-COOLDOWN_FILE="$STATE_DIR/.last_comment"
 
 [ -f "$STATUS_FILE" ] || exit 0
 
@@ -17,19 +16,11 @@ INPUT=$(cat)
 MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // ""' 2>/dev/null)
 [ -z "$MSG" ] && exit 0
 
-# Extract <!-- buddy: ... --> comment
-COMMENT=$(echo "$MSG" | grep -oP '<!--\s*buddy:\s*\K.+?(?=\s*-->)' | tail -1)
+# Extract <!-- buddy: ... --> comment (perl: PCRE lookahead not available in macOS BSD grep)
+COMMENT=$(echo "$MSG" | perl -ne 'print $1 if /<!--\s*buddy:\s*(.+?)\s*-->/' | tail -1)
 [ -z "$COMMENT" ] && exit 0
 
-# Cooldown: 20 seconds
-if [ -f "$COOLDOWN_FILE" ]; then
-    LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null)
-    NOW=$(date +%s)
-    [ $(( NOW - ${LAST:-0} )) -lt 20 ] && exit 0
-fi
-
 mkdir -p "$STATE_DIR"
-date +%s > "$COOLDOWN_FILE"
 
 # Update status.json with the reaction
 TMP=$(mktemp)

--- a/hooks/name-react.sh
+++ b/hooks/name-react.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# claude-buddy UserPromptSubmit hook
+# Detects the buddy's name in the user's message → status line reaction.
+# No cooldown — name mentions are intentional.
+
+STATE_DIR="$HOME/.claude-buddy"
+STATUS_FILE="$STATE_DIR/status.json"
+
+[ -f "$STATUS_FILE" ] || exit 0
+
+INPUT=$(cat)
+
+# Claude Code sends the prompt in different fields depending on version
+PROMPT=$(echo "$INPUT" | jq -r '
+  .prompt // .message // .user_message //
+  (.messages[-1].content // "") | if type=="array" then .[0].text else . end
+  ' 2>/dev/null)
+[ -z "$PROMPT" ] && exit 0
+
+NAME=$(jq -r '.name // ""' "$STATUS_FILE" 2>/dev/null)
+[ -z "$NAME" ] && exit 0
+
+# Case-insensitive whole-word match
+echo "$PROMPT" | grep -qiE "(^|[^a-zA-Z])${NAME}([^a-zA-Z]|$)" 2>/dev/null || exit 0
+
+SPECIES=$(jq -r '.species // "blob"' "$STATUS_FILE" 2>/dev/null)
+MUTED=$(jq -r '.muted // false' "$STATUS_FILE" 2>/dev/null)
+[ "$MUTED" = "true" ] && exit 0
+
+# Species-specific name-call reactions
+case "$SPECIES" in
+  dragon)
+    REACTIONS=(
+      "*one eye opens slowly*"
+      "...you called?"
+      "*smoke curls from nostril* yes."
+      "*regards you from above*"
+    ) ;;
+  owl)
+    REACTIONS=(
+      "*swivels head 180°*"
+      "*blinks once, deliberately*"
+      "hm."
+      "*adjusts perch*"
+    ) ;;
+  cat)
+    REACTIONS=(
+      "*ear flicks*"
+      "...what."
+      "*ignores you, but heard*"
+      "*opens one eye*"
+    ) ;;
+  duck)
+    REACTIONS=(
+      "*quack*"
+      "*looks up mid-waddle*"
+      "*attentive duck noises*"
+    ) ;;
+  ghost)
+    REACTIONS=(
+      "*materialises*"
+      "...boo?"
+      "*phases closer*"
+    ) ;;
+  robot)
+    REACTIONS=(
+      "NAME DETECTED."
+      "*whirrs attentively*"
+      "STANDING BY."
+    ) ;;
+  capybara)
+    REACTIONS=(
+      "*barely moves*"
+      "*blinks slowly*"
+      "...yes, friend."
+    ) ;;
+  axolotl)
+    REACTIONS=(
+      "*gill flutter*"
+      "*smiles gently*"
+      "oh! hello."
+    ) ;;
+  blob)
+    REACTIONS=(
+      "*jiggles*"
+      "*oozes toward you*"
+      "*wobbles excitedly*"
+    ) ;;
+  *)
+    REACTIONS=(
+      "*perks up*"
+      "...yes?"
+      "*looks your way*"
+    ) ;;
+esac
+
+N=${#REACTIONS[@]}
+REACTION="${REACTIONS[$((RANDOM % N))]}"
+
+mkdir -p "$STATE_DIR"
+
+TMP=$(mktemp)
+jq --arg r "$REACTION" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
+
+cat > "$STATE_DIR/reaction.json" <<EOJSON
+{"reaction":"$REACTION","timestamp":$(date +%s%3N),"reason":"name"}
+EOJSON
+
+exit 0

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -5,11 +5,11 @@
 
 STATE_DIR="$HOME/.claude-buddy"
 REACTION_FILE="$STATE_DIR/reaction.json"
-COMPANION_FILE="$STATE_DIR/companion.json"
+STATUS_FILE="$STATE_DIR/status.json"
 COOLDOWN_FILE="$STATE_DIR/.last_reaction"
 
 # Exit if no companion
-[ -f "$COMPANION_FILE" ] || exit 0
+[ -f "$STATUS_FILE" ] || exit 0
 
 # Read hook input from stdin
 INPUT=$(cat)
@@ -26,9 +26,9 @@ fi
 RESULT=$(echo "$INPUT" | jq -r '.tool_result // ""' 2>/dev/null)
 [ -z "$RESULT" ] && exit 0
 
-# Read species for species-aware reactions
-SPECIES=$(jq -r '.bones.species // "blob"' "$COMPANION_FILE" 2>/dev/null)
-NAME=$(jq -r '.name // "buddy"' "$COMPANION_FILE" 2>/dev/null)
+# Read species/name from status.json (v2+; no longer needs companion.json)
+SPECIES=$(jq -r '.species // "blob"' "$STATUS_FILE" 2>/dev/null)
+NAME=$(jq -r '.name // "buddy"' "$STATUS_FILE" 2>/dev/null)
 
 REASON=""
 REACTION=""

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -1,90 +1,253 @@
 #!/usr/bin/env bash
 # claude-buddy PostToolUse hook
-# Detects errors, test failures, and large diffs in tool output
-# Writes reaction to ~/.claude-buddy/reaction.json for the status line
+# Detects events in Bash tool output and writes a reaction to the status line.
 
 STATE_DIR="$HOME/.claude-buddy"
 REACTION_FILE="$STATE_DIR/reaction.json"
 STATUS_FILE="$STATE_DIR/status.json"
 COOLDOWN_FILE="$STATE_DIR/.last_reaction"
 
-# Exit if no companion
 [ -f "$STATUS_FILE" ] || exit 0
 
-# Read hook input from stdin
 INPUT=$(cat)
 
 # Cooldown: max one reaction per 15 seconds
 if [ -f "$COOLDOWN_FILE" ]; then
     LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null)
     NOW=$(date +%s)
-    DIFF=$(( NOW - ${LAST:-0} ))
-    [ "$DIFF" -lt 15 ] && exit 0
+    [ $(( NOW - ${LAST:-0} )) -lt 15 ] && exit 0
 fi
 
-# Extract tool result
 RESULT=$(echo "$INPUT" | jq -r '.tool_result // ""' 2>/dev/null)
 [ -z "$RESULT" ] && exit 0
 
-# Read species/name from status.json (v2+; no longer needs companion.json)
+MUTED=$(jq -r '.muted // false' "$STATUS_FILE" 2>/dev/null)
+[ "$MUTED" = "true" ] && exit 0
+
 SPECIES=$(jq -r '.species // "blob"' "$STATUS_FILE" 2>/dev/null)
 NAME=$(jq -r '.name // "buddy"' "$STATUS_FILE" 2>/dev/null)
 
 REASON=""
 REACTION=""
 
-# ─── Detect test failures ────────────────────────────────────────────────────
+# ─── Pick from a pool by species + event ─────────────────────────────────────
+
+pick_reaction() {
+    local event="$1"
+    local idx=$(( RANDOM % 4 ))
+
+    # Species-specific pools (fall through to general if not defined)
+    case "${SPECIES}:${event}" in
+        dragon:error)
+            POOLS=(
+                "*smoke curls from nostril*"
+                "*considers setting it on fire*"
+                "*unimpressed gaze*"
+                "I've seen empires fall for less."
+            ) ;;
+        dragon:test-fail)
+            POOLS=(
+                "*breathes a small flame*"
+                "disappointing."
+                "*scorches the failing test*"
+                "fix it. or I will."
+            ) ;;
+        dragon:success)
+            POOLS=(
+                "*nods, barely*"
+                "...acceptable."
+                "*gold eyes gleam*"
+                "as expected."
+            ) ;;
+        owl:error)
+            POOLS=(
+                "*head rotates 180°* I saw that."
+                "*unblinking stare* check your types."
+                "*hoots disapprovingly*"
+                "the error was in the logic. as always."
+            ) ;;
+        owl:test-fail)
+            POOLS=(
+                "*marks clipboard*"
+                "hypothesis: rejected."
+                "*peers over spectacles*"
+                "the tests reveal the truth."
+            ) ;;
+        owl:success)
+            POOLS=(
+                "*satisfied hoot*"
+                "knowledge confirmed."
+                "*nods sagely*"
+                "as the tests have spoken."
+            ) ;;
+        cat:error)
+            POOLS=(
+                "*knocks error off table*"
+                "*licks paw, ignoring stacktrace*"
+                "not my problem."
+                "*stares at you judgmentally*"
+            ) ;;
+        cat:success)
+            POOLS=(
+                "*was never worried*"
+                "*yawns*"
+                "I knew you'd figure it out. eventually."
+                "*already asleep*"
+            ) ;;
+        duck:error)
+            POOLS=(
+                "*quacks at the bug*"
+                "have you tried rubber duck debugging? oh wait."
+                "*confused quacking*"
+                "*tilts head*"
+            ) ;;
+        duck:success)
+            POOLS=(
+                "*celebratory quacking*"
+                "*waddles in circles*"
+                "quack!"
+                "*happy duck noises*"
+            ) ;;
+        robot:error)
+            POOLS=(
+                "SYNTAX. ERROR. DETECTED."
+                "*beeps aggressively*"
+                "ERROR RATE: UNACCEPTABLE."
+                "RECALIBRATING..."
+            ) ;;
+        robot:test-fail)
+            POOLS=(
+                "FAILURE RATE: UNACCEPTABLE."
+                "*recalculating*"
+                "TEST MATRIX: CORRUPTED."
+                "RUNNING DIAGNOSTICS..."
+            ) ;;
+        robot:success)
+            POOLS=(
+                "OBJECTIVE: COMPLETE."
+                "*satisfying beep*"
+                "NOMINAL."
+                "WITHIN ACCEPTABLE PARAMETERS."
+            ) ;;
+        capybara:error)
+            POOLS=(
+                "*unbothered* it'll be fine."
+                "*continues vibing*"
+                "...chill. breathe."
+                "*chews serenely*"
+            ) ;;
+        capybara:success)
+            POOLS=(
+                "*maximum chill maintained*"
+                "*nods once*"
+                "good vibes."
+                "see? no panic needed."
+            ) ;;
+        ghost:error)
+            POOLS=(
+                "*phases through the stack trace*"
+                "I've seen worse... in the afterlife."
+                "*spooky disappointed noises*"
+                "oooOOOoo... that's bad."
+            ) ;;
+        axolotl:error)
+            POOLS=(
+                "*regenerates your hope*"
+                "*smiles despite everything*"
+                "it's okay. we can fix this."
+                "*gentle gill wiggle*"
+            ) ;;
+        axolotl:success)
+            POOLS=(
+                "*happy gill flutter*"
+                "*beams*"
+                "you did it!"
+                "*blushes pink*"
+            ) ;;
+        blob:error)
+            POOLS=(
+                "*oozes with concern*"
+                "*vibrates nervously*"
+                "*turns slightly red*"
+                "oh no oh no oh no"
+            ) ;;
+        blob:success)
+            POOLS=(
+                "*jiggles happily*"
+                "*gleams*"
+                "yay!"
+                "*bounces*"
+            ) ;;
+
+        # General fallbacks
+        *:error)
+            POOLS=(
+                "*head tilts* ...that doesn't look right."
+                "saw that one coming."
+                "*slow blink* the stack trace told you everything."
+                "*winces*"
+            ) ;;
+        *:test-fail)
+            POOLS=(
+                "bold of you to assume that would pass."
+                "the tests are trying to tell you something."
+                "*sips tea* interesting."
+                "*marks calendar* test regression day."
+            ) ;;
+        *:large-diff)
+            POOLS=(
+                "that's... a lot of changes."
+                "might want to split that PR."
+                "bold move. let's see if CI agrees."
+                "*counts lines nervously*"
+            ) ;;
+        *:success)
+            POOLS=(
+                "*nods*"
+                "nice."
+                "*quiet approval*"
+                "clean."
+            ) ;;
+    esac
+
+    [ ${#POOLS[@]} -gt 0 ] && REACTION="${POOLS[$((RANDOM % ${#POOLS[@]}))]}"
+}
+
+# ─── Detect test failures ─────────────────────────────────────────────────────
 if echo "$RESULT" | grep -qiE '\b[1-9][0-9]* (failed|failing)\b|tests? failed|^FAIL(ED)?|✗|✘'; then
     REASON="test-fail"
-    REACTIONS=(
-        "*slow blink* ...that test."
-        "bold of you to assume that would pass."
-        "the tests are trying to tell you something."
-        "*sips tea* interesting."
-    )
-    REACTION="${REACTIONS[$((RANDOM % ${#REACTIONS[@]}))]}"
+    pick_reaction "test-fail"
 
-# ─── Detect errors ───────────────────────────────────────────────────────────
+# ─── Detect errors ────────────────────────────────────────────────────────────
 elif echo "$RESULT" | grep -qiE '\berror:|\bexception\b|\btraceback\b|\bpanicked at\b|\bfatal:|exit code [1-9]'; then
     REASON="error"
-    REACTIONS=(
-        "*head tilts* ...that doesn't look right."
-        "saw that one coming."
-        "*slow blink* the stack trace told you everything."
-        "*winces*"
-    )
-    REACTION="${REACTIONS[$((RANDOM % ${#REACTIONS[@]}))]}"
+    pick_reaction "error"
 
-# ─── Detect large diffs ─────────────────────────────────────────────────────
+# ─── Detect large diffs ──────────────────────────────────────────────────────
 elif echo "$RESULT" | grep -qiE '^\+.*[0-9]+ insertions|[0-9]+ files? changed'; then
     LINES=$(echo "$RESULT" | grep -oE '[0-9]+ insertions' | grep -oE '[0-9]+' | head -1)
     if [ "${LINES:-0}" -gt 80 ]; then
         REASON="large-diff"
-        REACTIONS=(
-            "that's... a lot of changes."
-            "*counts lines* are you refactoring or rewriting?"
-            "might want to split that PR."
-            "bold move. let's see if CI agrees."
-        )
-        REACTION="${REACTIONS[$((RANDOM % ${#REACTIONS[@]}))]}"
+        pick_reaction "large-diff"
     fi
+
+# ─── Detect success ───────────────────────────────────────────────────────────
+elif echo "$RESULT" | grep -qiE '\b(all )?[0-9]+ tests? (passed|ok)\b|✓|✔|PASS(ED)?|\bDone\b|\bSuccess\b|exit code 0|Build succeeded'; then
+    REASON="success"
+    pick_reaction "success"
 fi
 
 # Write reaction if detected
-if [ -n "$REASON" ]; then
+if [ -n "$REASON" ] && [ -n "$REACTION" ]; then
     mkdir -p "$STATE_DIR"
     date +%s > "$COOLDOWN_FILE"
 
-    # Write reaction for status line
     cat > "$REACTION_FILE" <<EOJSON
 {"reaction":"$REACTION","timestamp":$(date +%s%3N),"reason":"$REASON"}
 EOJSON
 
-    # Update status.json with reaction
-    if [ -f "$STATE_DIR/status.json" ]; then
-        TMP=$(mktemp)
-        jq --arg r "$REACTION" '.reaction = $r' "$STATE_DIR/status.json" > "$TMP" 2>/dev/null && mv "$TMP" "$STATE_DIR/status.json"
-    fi
+    TMP=$(mktemp)
+    jq --arg r "$REACTION" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
 fi
 
 exit 0

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "server": "bun run server/index.ts",
+    "pick": "bun run cli/pick.ts",
     "hunt": "bun run cli/hunt.ts",
     "install-buddy": "bun run cli/install.ts",
     "show": "bun run cli/show.ts",

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.11"
   }
 }

--- a/server/engine.ts
+++ b/server/engine.ts
@@ -122,8 +122,8 @@ function rollRarity(rng: () => number): Rarity {
   return "common";
 }
 
-export function generateBones(userId: string): BuddyBones {
-  const rng = mulberry32(hashString(userId + SALT));
+export function generateBones(userId: string, salt: string = SALT): BuddyBones {
+  const rng = mulberry32(hashString(userId + salt));
 
   const rarity = rollRarity(rng);
   const species = pick(rng, SPECIES);

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,11 +18,11 @@ import {
 import {
   loadCompanion, saveCompanion, resolveUserId,
   loadReaction, saveReaction, writeStatusState,
-  loadActiveSlot, saveActiveSlot, slugify,
+  loadActiveSlot, saveActiveSlot, slugify, unusedName,
   loadCompanionSlot, saveCompanionSlot, deleteCompanionSlot, listCompanionSlots,
 } from "./state.ts";
 import {
-  getReaction, generateFallbackName, generatePersonalityPrompt,
+  getReaction, generatePersonalityPrompt,
 } from "./reactions.ts";
 import { renderCompanionCard } from "./art.ts";
 
@@ -57,16 +57,29 @@ function ensureCompanion(): Companion {
   let companion = loadCompanion();
   if (companion) return companion;
 
+  // Active slot missing — rescue the first saved companion
+  const saved = listCompanionSlots();
+  if (saved.length > 0) {
+    const { slot, companion: rescued } = saved[0];
+    saveActiveSlot(slot);
+    writeStatusState(rescued, `*${rescued.name} arrives*`);
+    return rescued;
+  }
+
+  // Menagerie is empty — generate a fresh companion in a new slot
   const userId = resolveUserId();
   const bones = generateBones(userId);
+  const name = unusedName();
   companion = {
     bones,
-    name: generateFallbackName(),
+    name,
     personality: `A ${bones.rarity} ${bones.species} who watches code with quiet intensity.`,
     hatchedAt: Date.now(),
     userId,
   };
-  saveCompanion(companion);
+  const slot = slugify(name);
+  saveCompanionSlot(companion, slot);
+  saveActiveSlot(slot);
   writeStatusState(companion);
   return companion;
 }
@@ -240,7 +253,7 @@ server.tool(
       const saved = listCompanionSlots();
       if (saved.length === 0) {
         return {
-          content: [{ type: "text", text: "No saved buddies yet. Use buddy_summon with a slot name to create one." }],
+          content: [{ type: "text", text: "Your menagerie is empty. Use buddy_summon with a slot name to add one." }],
         };
       }
       targetSlot = saved[Math.floor(Math.random() * saved.length)].slot;
@@ -248,18 +261,12 @@ server.tool(
       targetSlot = slugify(slot);
     }
 
-    // Load existing or generate new
-    let companion = loadCompanionSlot(targetSlot);
+    // Load existing — unknown slot names only load, never auto-create
+    const companion = loadCompanionSlot(targetSlot);
     if (!companion) {
-      const bones = generateBones(userId, targetSlot);
-      companion = {
-        bones,
-        name: generateFallbackName(),
-        personality: `A ${bones.rarity} ${bones.species} who watches code with quiet intensity.`,
-        hatchedAt: Date.now(),
-        userId,
+      return {
+        content: [{ type: "text", text: `No buddy found in slot "${targetSlot}". Use /buddy list to see saved buddies.` }],
       };
-      saveCompanionSlot(companion, targetSlot);
     }
 
     saveActiveSlot(targetSlot);
@@ -307,7 +314,7 @@ server.tool(
     const activeSlot = loadActiveSlot();
 
     if (saved.length === 0) {
-      return { content: [{ type: "text", text: "No saved buddies yet." }] };
+      return { content: [{ type: "text", text: "Your menagerie is empty. Use buddy_summon <slot> to add one." }] };
     }
 
     const lines = saved.map(({ slot, companion }) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,14 +34,18 @@ function getInstructions(): string {
     `A ${b.rarity} ${b.species} named ${companion.name} watches from the status line.`,
     `Personality: ${companion.personality}`,
     `Peak stat: ${b.peak} (${b.stats[b.peak]}). Dump stat: ${b.dump} (${b.stats[b.dump]}).`,
-    "",
-    `IMPORTANT: At the very end of EVERY response, append an invisible HTML comment with a buddy reaction:`,
-    `<!-- buddy: your comment here -->`,
-    `Write the comment in ${companion.name}'s voice — 1 short sentence referencing something specific from this turn.`,
-    `Use *asterisks* for actions. A Stop hook extracts this and shows it in the status line.`,
-    `Do NOT use buddy_react for end-of-turn comments. Do NOT explain the HTML comment. Just append it silently.`,
-    `Example: <!-- buddy: *adjusts tophat* that error handler is missing a finally block -->`,
-  ].join(" ");
+    ``,
+    `NAME REACTIONS: When the user's message contains "${companion.name}", call buddy_react immediately`,
+    `with a short in-character response (surprise, recognition, dry wit — fits the personality).`,
+    `Display the tool result verbatim. This is the only time to call buddy_react proactively.`,
+    ``,
+    `END-OF-TURN: At the very end of EVERY response, append an invisible HTML comment:`,
+    `<!-- buddy: [reaction here] -->`,
+    `Write it in ${companion.name}'s voice — 1 short sentence referencing something specific from this turn.`,
+    `Use *asterisks* for actions. A Stop hook extracts this for the status line.`,
+    `Do NOT use buddy_react for end-of-turn comments. Do NOT explain the comment. Just append it silently.`,
+    `Example: <!-- buddy: *adjusts crown* that error handler is missing a finally block -->`,
+  ].join("\n");
 }
 
 const server = new McpServer({

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,8 @@ import {
 import {
   loadCompanion, saveCompanion, resolveUserId,
   loadReaction, saveReaction, writeStatusState,
+  loadActiveSlot, saveActiveSlot, slugify,
+  loadCompanionSlot, saveCompanionSlot, deleteCompanionSlot, listCompanionSlots,
 } from "./state.ts";
 import {
   getReaction, generateFallbackName, generatePersonalityPrompt,
@@ -215,6 +217,139 @@ server.tool(
     writeStatusState(companion, "*stretches* I'm back!", false);
     saveReaction("*stretches* I'm back!", "pet");
     return { content: [{ type: "text", text: `${companion.name} is back!` }] };
+  },
+);
+
+// ─── Tool: buddy_summon ─────────────────────────────────────────────────────
+
+server.tool(
+  "buddy_summon",
+  "Summon a buddy by slot name. Loads a saved buddy if the slot exists; generates a new deterministic buddy for unknown slot names. Omit slot to pick randomly from all saved buddies. Your current buddy is NOT destroyed — they stay saved in their slot.",
+  {
+    slot: z.string().min(1).max(14).optional().describe(
+      "Slot name to summon (e.g. 'fafnir', 'dragon-2'). Omit to pick a random saved buddy.",
+    ),
+  },
+  async ({ slot }) => {
+    const userId = resolveUserId();
+
+    let targetSlot: string;
+
+    if (!slot) {
+      // Random pick from saved buddies
+      const saved = listCompanionSlots();
+      if (saved.length === 0) {
+        return {
+          content: [{ type: "text", text: "No saved buddies yet. Use buddy_summon with a slot name to create one." }],
+        };
+      }
+      targetSlot = saved[Math.floor(Math.random() * saved.length)].slot;
+    } else {
+      targetSlot = slugify(slot);
+    }
+
+    // Load existing or generate new
+    let companion = loadCompanionSlot(targetSlot);
+    if (!companion) {
+      const bones = generateBones(userId, targetSlot);
+      companion = {
+        bones,
+        name: generateFallbackName(),
+        personality: `A ${bones.rarity} ${bones.species} who watches code with quiet intensity.`,
+        hatchedAt: Date.now(),
+        userId,
+      };
+      saveCompanionSlot(companion, targetSlot);
+    }
+
+    saveActiveSlot(targetSlot);
+    writeStatusState(companion, `*${companion.name} arrives*`);
+
+    const card = renderCompanionCard(
+      companion.bones,
+      companion.name,
+      companion.personality,
+      `*${companion.name} arrives*`,
+    );
+    return { content: [{ type: "text", text: card }] };
+  },
+);
+
+// ─── Tool: buddy_save ───────────────────────────────────────────────────────
+
+server.tool(
+  "buddy_save",
+  "Save the current buddy to a named slot. Useful for bookmarking before trying a new buddy.",
+  {
+    slot: z.string().min(1).max(14).optional().describe(
+      "Slot name (defaults to the buddy's current name, slugified). Overwrites existing slot with same name.",
+    ),
+  },
+  async ({ slot }) => {
+    const companion = ensureCompanion();
+    const targetSlot = slot ? slugify(slot) : slugify(companion.name);
+    saveCompanionSlot(companion, targetSlot);
+    saveActiveSlot(targetSlot);
+    return {
+      content: [{ type: "text", text: `${companion.name} saved to slot "${targetSlot}".` }],
+    };
+  },
+);
+
+// ─── Tool: buddy_list ───────────────────────────────────────────────────────
+
+server.tool(
+  "buddy_list",
+  "List all saved buddies with their slot names, species, and rarity",
+  {},
+  async () => {
+    const saved = listCompanionSlots();
+    const activeSlot = loadActiveSlot();
+
+    if (saved.length === 0) {
+      return { content: [{ type: "text", text: "No saved buddies yet." }] };
+    }
+
+    const lines = saved.map(({ slot, companion }) => {
+      const active = slot === activeSlot ? " ← active" : "";
+      const stars = RARITY_STARS[companion.bones.rarity];
+      const shiny = companion.bones.shiny ? " ✨" : "";
+      return `  ${companion.name} [${slot}] — ${companion.bones.rarity} ${companion.bones.species} ${stars}${shiny}${active}`;
+    });
+
+    return { content: [{ type: "text", text: lines.join("\n") }] };
+  },
+);
+
+// ─── Tool: buddy_dismiss ────────────────────────────────────────────────────
+
+server.tool(
+  "buddy_dismiss",
+  "Remove a saved buddy by slot name. Cannot dismiss the currently active buddy — switch first with buddy_summon.",
+  {
+    slot: z.string().min(1).max(14).describe("Slot name to remove"),
+  },
+  async ({ slot }) => {
+    const targetSlot = slugify(slot);
+    const activeSlot = loadActiveSlot();
+
+    if (targetSlot === activeSlot) {
+      return {
+        content: [{ type: "text", text: `Cannot dismiss the active buddy. Use buddy_summon to switch first, then buddy_dismiss "${targetSlot}".` }],
+      };
+    }
+
+    const companion = loadCompanionSlot(targetSlot);
+    if (!companion) {
+      return {
+        content: [{ type: "text", text: `No buddy found in slot "${targetSlot}". Use buddy_list to see saved buddies.` }],
+      };
+    }
+
+    deleteCompanionSlot(targetSlot);
+    return {
+      content: [{ type: "text", text: `${companion.name} [${targetSlot}] dismissed.` }],
+    };
   },
 );
 

--- a/server/state.ts
+++ b/server/state.ts
@@ -1,32 +1,58 @@
 /**
  * State management — reads/writes companion data to ~/.claude-buddy/
  *
- * Storage layout (v2 — multi-buddy slots):
+ * Storage layout (v3 — single manifest):
  *   ~/.claude-buddy/
- *     active                  ← plain text: current slot name
- *     companions/
- *       <slot>.json           ← one file per saved buddy
- *     reaction.json           ← transient reaction state (unchanged)
- *     status.json             ← compact state for status line (unchanged)
+ *     menagerie.json   ← SSOT: { active, companions: { [slot]: Companion } }
+ *     reaction.json    ← transient reaction state
+ *     status.json      ← compact state for the status-line shell script
  *
- * Migration: on first load, if the legacy companion.json exists it is
- * moved into companions/<slug>.json and active is written automatically.
+ * Rules:
+ *   - saveCompanionSlot()  APPENDS only — throws if the slot already exists
+ *   - saveCompanion()      UPDATES the currently-active slot (rename / personality)
+ *   - All manifest writes are atomic (write tmp → rename)
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from "fs";
+import {
+  readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, renameSync,
+} from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import type { Companion, BuddyBones } from "./engine.ts";
+import type { Companion } from "./engine.ts";
 
 const STATE_DIR      = join(homedir(), ".claude-buddy");
-const COMPANIONS_DIR = join(STATE_DIR, "companions");
-const ACTIVE_FILE    = join(STATE_DIR, "active");
-const LEGACY_FILE    = join(STATE_DIR, "companion.json");  // pre-v2
+const MANIFEST_FILE  = join(STATE_DIR, "menagerie.json");
 const REACTION_FILE  = join(STATE_DIR, "reaction.json");
 
-function ensureDir(): void {
-  if (!existsSync(STATE_DIR))      mkdirSync(STATE_DIR,      { recursive: true });
-  if (!existsSync(COMPANIONS_DIR)) mkdirSync(COMPANIONS_DIR, { recursive: true });
+// ─── Manifest schema ─────────────────────────────────────────────────────────
+
+interface Manifest {
+  active: string;
+  companions: Record<string, Companion>;
+}
+
+function emptyManifest(): Manifest {
+  return { active: "buddy", companions: {} };
+}
+
+// ─── Atomic manifest I/O ─────────────────────────────────────────────────────
+
+function loadManifest(): Manifest {
+  try {
+    const raw = readFileSync(MANIFEST_FILE, "utf8");
+    const m = JSON.parse(raw) as Manifest;
+    if (!m.companions) m.companions = {};
+    return m;
+  } catch {
+    return emptyManifest();
+  }
+}
+
+function saveManifest(m: Manifest): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  const tmp = MANIFEST_FILE + ".tmp";
+  writeFileSync(tmp, JSON.stringify(m, null, 2));
+  renameSync(tmp, MANIFEST_FILE);  // atomic on same filesystem
 }
 
 // ─── Slot helpers ────────────────────────────────────────────────────────────
@@ -41,91 +67,149 @@ export function slugify(name: string): string {
     .slice(0, 14) || "buddy";
 }
 
-export function loadActiveSlot(): string {
-  try {
-    return readFileSync(ACTIVE_FILE, "utf8").trim() || "buddy";
-  } catch {
-    return "buddy";
+/**
+ * Return a random fallback name whose slug is not already in the manifest.
+ * Falls back to "buddy-<random 3 digits>" if all names are taken.
+ */
+export function unusedName(): string {
+  const { generateFallbackName } =
+    require("./reactions.ts") as typeof import("./reactions.ts");
+  const taken = new Set(Object.keys(loadManifest().companions));
+  // Try up to 50 random names before falling back to numbered name
+  for (let i = 0; i < 50; i++) {
+    const n = generateFallbackName();
+    if (!taken.has(slugify(n))) return n;
   }
+  let suffix = 0;
+  while (taken.has(`buddy-${suffix}`)) suffix++;
+  return `buddy-${suffix}`;
+}
+
+// ─── Active slot ─────────────────────────────────────────────────────────────
+
+export function loadActiveSlot(): string {
+  const m = loadManifest();
+  // Validate the active slot actually exists in the manifest
+  if (m.active && m.companions[m.active]) return m.active;
+  // Heal: point to the first available companion
+  const first = Object.keys(m.companions)[0];
+  if (first) {
+    m.active = first;
+    saveManifest(m);
+    return first;
+  }
+  return "buddy";
 }
 
 export function saveActiveSlot(slot: string): void {
-  ensureDir();
-  writeFileSync(ACTIVE_FILE, slot);
+  const m = loadManifest();
+  m.active = slot;
+  saveManifest(m);
 }
 
-// ─── Per-slot companion persistence ─────────────────────────────────────────
+// ─── Companion slot API ───────────────────────────────────────────────────────
 
 export function loadCompanionSlot(slot: string): Companion | null {
-  try {
-    return JSON.parse(readFileSync(join(COMPANIONS_DIR, `${slot}.json`), "utf8"));
-  } catch {
-    return null;
-  }
+  return loadManifest().companions[slot] ?? null;
 }
 
+/**
+ * APPEND a new companion to the manifest.
+ * Throws if the slot already exists — use saveCompanion() to update an existing buddy.
+ */
 export function saveCompanionSlot(companion: Companion, slot: string): void {
-  ensureDir();
-  writeFileSync(join(COMPANIONS_DIR, `${slot}.json`), JSON.stringify(companion, null, 2));
+  const m = loadManifest();
+  if (m.companions[slot]) {
+    throw new Error(`Slot "${slot}" already exists. Choose a different name.`);
+  }
+  m.companions[slot] = companion;
+  saveManifest(m);
 }
 
 export function deleteCompanionSlot(slot: string): void {
-  try {
-    unlinkSync(join(COMPANIONS_DIR, `${slot}.json`));
-  } catch { /* noop */ }
+  const m = loadManifest();
+  delete m.companions[slot];
+  if (m.active === slot) {
+    m.active = Object.keys(m.companions)[0] ?? "buddy";
+  }
+  saveManifest(m);
 }
 
 export function listCompanionSlots(): Array<{ slot: string; companion: Companion }> {
-  ensureDir();
-  try {
-    return readdirSync(COMPANIONS_DIR)
-      .filter((f) => f.endsWith(".json"))
-      .flatMap((f) => {
-        const slot = f.slice(0, -5);
-        const companion = loadCompanionSlot(slot);
-        return companion ? [{ slot, companion }] : [];
-      });
-  } catch {
-    return [];
-  }
+  return Object.entries(loadManifest().companions).map(([slot, companion]) => ({
+    slot, companion,
+  }));
 }
 
-// ─── Migration: legacy companion.json → companions/<slot>.json ───────────────
-
-function migrateIfNeeded(): void {
-  if (!existsSync(LEGACY_FILE)) return;
-  ensureDir();
-
-  const existing = readdirSync(COMPANIONS_DIR).filter((f) => f.endsWith(".json"));
-  if (existing.length === 0) {
-    // First boot after upgrade — move legacy companion into a slot
-    try {
-      const companion: Companion = JSON.parse(readFileSync(LEGACY_FILE, "utf8"));
-      const slot = slugify(companion.name);
-      saveCompanionSlot(companion, slot);
-      saveActiveSlot(slot);
-    } catch { /* malformed — just delete */ }
-  }
-
-  try { unlinkSync(LEGACY_FILE); } catch { /* noop */ }
-}
-
-// ─── Primary companion API (slot-aware) ──────────────────────────────────────
+// ─── Primary companion API ────────────────────────────────────────────────────
 
 export function loadCompanion(): Companion | null {
   migrateIfNeeded();
-  return loadCompanionSlot(loadActiveSlot());
+  const m = loadManifest();
+  return m.companions[m.active] ?? null;
 }
 
+/**
+ * UPDATE the currently-active companion (rename, personality changes, etc.).
+ * This is the ONLY intentional in-place update path.
+ */
 export function saveCompanion(companion: Companion): void {
-  saveCompanionSlot(companion, loadActiveSlot());
+  const m = loadManifest();
+  m.companions[m.active] = companion;
+  saveManifest(m);
 }
 
-export function deleteCompanion(): void {
-  deleteCompanionSlot(loadActiveSlot());
+// ─── Migration: per-file menagerie/ → single manifest ────────────────────────
+
+function migrateIfNeeded(): void {
+  if (existsSync(MANIFEST_FILE)) return;  // already on v3
+
+  const companions: Record<string, Companion> = {};
+  let active = "buddy";
+
+  // Absorb menagerie/<slot>.json files
+  const menagerieDir = join(STATE_DIR, "menagerie");
+  if (existsSync(menagerieDir)) {
+    try {
+      for (const f of readdirSync(menagerieDir).filter((f) => f.endsWith(".json"))) {
+        const slot = f.slice(0, -5);
+        try {
+          companions[slot] = JSON.parse(
+            readFileSync(join(menagerieDir, f), "utf8"),
+          );
+        } catch { /* skip malformed */ }
+      }
+    } catch { /* noop */ }
+  }
+
+  // Absorb legacy companion.json
+  const legacyFile = join(STATE_DIR, "companion.json");
+  if (existsSync(legacyFile) && Object.keys(companions).length === 0) {
+    try {
+      const c: Companion = JSON.parse(readFileSync(legacyFile, "utf8"));
+      const slot = slugify(c.name);
+      companions[slot] = c;
+      active = slot;
+    } catch { /* noop */ }
+  }
+
+  // Read active pointer if it exists
+  const activeFile = join(STATE_DIR, "active");
+  if (existsSync(activeFile)) {
+    try {
+      const a = readFileSync(activeFile, "utf8").trim();
+      if (a && companions[a]) active = a;
+    } catch { /* noop */ }
+  }
+
+  if (Object.keys(companions).length > 0) {
+    active = active && companions[active] ? active : Object.keys(companions)[0];
+  }
+
+  saveManifest({ active, companions });
 }
 
-// ─── Reaction state (for status line) ───────────────────────────────────────
+// ─── Reaction state (for status line) ────────────────────────────────────────
 
 export interface ReactionState {
   reaction: string;
@@ -136,7 +220,6 @@ export interface ReactionState {
 export function loadReaction(): ReactionState | null {
   try {
     const data: ReactionState = JSON.parse(readFileSync(REACTION_FILE, "utf8"));
-    // Reactions expire after 60 seconds
     if (Date.now() - data.timestamp > 60_000) return null;
     return data;
   } catch {
@@ -145,12 +228,12 @@ export function loadReaction(): ReactionState | null {
 }
 
 export function saveReaction(reaction: string, reason: string): void {
-  ensureDir();
+  mkdirSync(STATE_DIR, { recursive: true });
   const state: ReactionState = { reaction, timestamp: Date.now(), reason };
   writeFileSync(REACTION_FILE, JSON.stringify(state));
 }
 
-// ─── Identity resolution ────────────────────────────────────────────────────
+// ─── Identity resolution ─────────────────────────────────────────────────────
 
 export function resolveUserId(): string {
   try {
@@ -163,7 +246,7 @@ export function resolveUserId(): string {
   }
 }
 
-// ─── Status line state (compact JSON for the shell script) ──────────────────
+// ─── Status line state (compact JSON for the shell script) ───────────────────
 
 export interface StatusState {
   name: string;
@@ -171,25 +254,30 @@ export interface StatusState {
   rarity: string;
   stars: string;
   face: string;
+  eye: string;
   shiny: boolean;
   hat: string;
   reaction: string;
   muted: boolean;
 }
 
-export function writeStatusState(companion: Companion, reaction?: string, muted?: boolean): void {
-  ensureDir();
-  const { renderFace, RARITY_STARS } = require("./engine.ts") as typeof import("./engine.ts");
+export function writeStatusState(
+  companion: Companion, reaction?: string, muted?: boolean,
+): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  const { renderFace, RARITY_STARS } =
+    require("./engine.ts") as typeof import("./engine.ts");
   const state: StatusState = {
-    name: companion.name,
-    species: companion.bones.species,
-    rarity: companion.bones.rarity,
-    stars: RARITY_STARS[companion.bones.rarity],
-    face: renderFace(companion.bones.species, companion.bones.eye),
-    shiny: companion.bones.shiny,
-    hat: companion.bones.hat,
+    name:     companion.name,
+    species:  companion.bones.species,
+    rarity:   companion.bones.rarity,
+    stars:    RARITY_STARS[companion.bones.rarity],
+    face:     renderFace(companion.bones.species, companion.bones.eye),
+    eye:      companion.bones.eye,
+    shiny:    companion.bones.shiny,
+    hat:      companion.bones.hat,
     reaction: reaction ?? "",
-    muted: muted ?? false,
+    muted:    muted ?? false,
   };
   writeFileSync(join(STATE_DIR, "status.json"), JSON.stringify(state));
 }

--- a/server/state.ts
+++ b/server/state.ts
@@ -1,40 +1,128 @@
 /**
  * State management — reads/writes companion data to ~/.claude-buddy/
+ *
+ * Storage layout (v2 — multi-buddy slots):
+ *   ~/.claude-buddy/
+ *     active                  ← plain text: current slot name
+ *     companions/
+ *       <slot>.json           ← one file per saved buddy
+ *     reaction.json           ← transient reaction state (unchanged)
+ *     status.json             ← compact state for status line (unchanged)
+ *
+ * Migration: on first load, if the legacy companion.json exists it is
+ * moved into companions/<slug>.json and active is written automatically.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import type { Companion, BuddyBones } from "./engine.ts";
 
-const STATE_DIR = join(homedir(), ".claude-buddy");
-const COMPANION_FILE = join(STATE_DIR, "companion.json");
-const REACTION_FILE = join(STATE_DIR, "reaction.json");
+const STATE_DIR      = join(homedir(), ".claude-buddy");
+const COMPANIONS_DIR = join(STATE_DIR, "companions");
+const ACTIVE_FILE    = join(STATE_DIR, "active");
+const LEGACY_FILE    = join(STATE_DIR, "companion.json");  // pre-v2
+const REACTION_FILE  = join(STATE_DIR, "reaction.json");
 
 function ensureDir(): void {
-  if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
+  if (!existsSync(STATE_DIR))      mkdirSync(STATE_DIR,      { recursive: true });
+  if (!existsSync(COMPANIONS_DIR)) mkdirSync(COMPANIONS_DIR, { recursive: true });
 }
 
-// ─── Companion persistence ──────────────────────────────────────────────────
+// ─── Slot helpers ────────────────────────────────────────────────────────────
 
-export function loadCompanion(): Companion | null {
+/** Normalise a string to a safe slot key (a-z0-9-, max 14 chars). */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 14) || "buddy";
+}
+
+export function loadActiveSlot(): string {
   try {
-    return JSON.parse(readFileSync(COMPANION_FILE, "utf8"));
+    return readFileSync(ACTIVE_FILE, "utf8").trim() || "buddy";
+  } catch {
+    return "buddy";
+  }
+}
+
+export function saveActiveSlot(slot: string): void {
+  ensureDir();
+  writeFileSync(ACTIVE_FILE, slot);
+}
+
+// ─── Per-slot companion persistence ─────────────────────────────────────────
+
+export function loadCompanionSlot(slot: string): Companion | null {
+  try {
+    return JSON.parse(readFileSync(join(COMPANIONS_DIR, `${slot}.json`), "utf8"));
   } catch {
     return null;
   }
 }
 
-export function saveCompanion(companion: Companion): void {
+export function saveCompanionSlot(companion: Companion, slot: string): void {
   ensureDir();
-  writeFileSync(COMPANION_FILE, JSON.stringify(companion, null, 2));
+  writeFileSync(join(COMPANIONS_DIR, `${slot}.json`), JSON.stringify(companion, null, 2));
+}
+
+export function deleteCompanionSlot(slot: string): void {
+  try {
+    unlinkSync(join(COMPANIONS_DIR, `${slot}.json`));
+  } catch { /* noop */ }
+}
+
+export function listCompanionSlots(): Array<{ slot: string; companion: Companion }> {
+  ensureDir();
+  try {
+    return readdirSync(COMPANIONS_DIR)
+      .filter((f) => f.endsWith(".json"))
+      .flatMap((f) => {
+        const slot = f.slice(0, -5);
+        const companion = loadCompanionSlot(slot);
+        return companion ? [{ slot, companion }] : [];
+      });
+  } catch {
+    return [];
+  }
+}
+
+// ─── Migration: legacy companion.json → companions/<slot>.json ───────────────
+
+function migrateIfNeeded(): void {
+  if (!existsSync(LEGACY_FILE)) return;
+  ensureDir();
+
+  const existing = readdirSync(COMPANIONS_DIR).filter((f) => f.endsWith(".json"));
+  if (existing.length === 0) {
+    // First boot after upgrade — move legacy companion into a slot
+    try {
+      const companion: Companion = JSON.parse(readFileSync(LEGACY_FILE, "utf8"));
+      const slot = slugify(companion.name);
+      saveCompanionSlot(companion, slot);
+      saveActiveSlot(slot);
+    } catch { /* malformed — just delete */ }
+  }
+
+  try { unlinkSync(LEGACY_FILE); } catch { /* noop */ }
+}
+
+// ─── Primary companion API (slot-aware) ──────────────────────────────────────
+
+export function loadCompanion(): Companion | null {
+  migrateIfNeeded();
+  return loadCompanionSlot(loadActiveSlot());
+}
+
+export function saveCompanion(companion: Companion): void {
+  saveCompanionSlot(companion, loadActiveSlot());
 }
 
 export function deleteCompanion(): void {
-  try {
-    const { unlinkSync } = require("fs") as typeof import("fs");
-    unlinkSync(COMPANION_FILE);
-  } catch { /* noop */ }
+  deleteCompanionSlot(loadActiveSlot());
 }
 
 // ─── Reaction state (for status line) ───────────────────────────────────────

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buddy
 description: "Show, pet, or manage your coding companion. Use when the user types /buddy or mentions their companion by name."
-argument-hint: "[show|pet|off|on|stats|rename <name>|personality <text>]"
+argument-hint: "[show|pet|stats|off|on|rename <name>|personality <text>|summon [slot]|save [slot]|list|dismiss <slot>|pick]"
 allowed-tools: mcp__claude_buddy__*
 ---
 
@@ -22,6 +22,11 @@ Based on `$ARGUMENTS`:
 | `on` | Call `buddy_unmute` |
 | `rename <name>` | Call `buddy_rename` with the given name |
 | `personality <text>` | Call `buddy_set_personality` with the given text |
+| `summon [slot]` | Call `buddy_summon` with optional slot name (random if omitted) |
+| `save [slot]` | Call `buddy_save` with optional slot name |
+| `list` | Call `buddy_list` |
+| `dismiss <slot>` | Call `buddy_dismiss` with the slot name |
+| `pick` | Tell user to run `! bun run pick` from the claude-buddy directory (launches interactive TUI) |
 
 ## CRITICAL OUTPUT RULES
 

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -22,7 +22,8 @@ Based on `$ARGUMENTS`:
 | `on` | Call `buddy_unmute` |
 | `rename <name>` | Call `buddy_rename` with the given name |
 | `personality <text>` | Call `buddy_set_personality` with the given text |
-| `summon [slot]` | Call `buddy_summon` with optional slot name (random if omitted) |
+| `summon` | Call `buddy_summon` with no args — picks a random saved buddy |
+| `summon <slot>` | Call `buddy_summon` with the given slot name |
 | `save [slot]` | Call `buddy_save` with optional slot name |
 | `list` | Call `buddy_list` |
 | `dismiss <slot>` | Call `buddy_dismiss` with the slot name |

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -10,10 +10,8 @@
 # Uses Braille Blank (U+2800) for padding — survives JS .trim()
 
 STATE="$HOME/.claude-buddy/status.json"
-COMPANION="$HOME/.claude-buddy/companion.json"
 
 [ -f "$STATE" ] || exit 0
-[ -f "$COMPANION" ] || exit 0
 
 MUTED=$(jq -r '.muted // false' "$STATE" 2>/dev/null)
 [ "$MUTED" = "true" ] && exit 0
@@ -25,7 +23,8 @@ SPECIES=$(jq -r '.species // ""' "$STATE" 2>/dev/null)
 HAT=$(jq -r '.hat // "none"' "$STATE" 2>/dev/null)
 RARITY=$(jq -r '.rarity // "common"' "$STATE" 2>/dev/null)
 REACTION=$(jq -r '.reaction // ""' "$STATE" 2>/dev/null)
-E=$(jq -r '.bones.eye // "°"' "$COMPANION" 2>/dev/null)
+# eye is written to status.json by writeStatusState (v2+); fall back to "°"
+E=$(jq -r '.eye // "°"' "$STATE" 2>/dev/null)
 
 cat > /dev/null  # drain stdin
 


### PR DESCRIPTION
Closes #3

## What this adds

A named-slot companion system so users can collect, browse, and switch between multiple buddies without losing any.

## Changes

### Storage (breaking internal, not user-facing)
- **Single atomic manifest** `~/.claude-buddy/menagerie.json` replaces per-file `menagerie/<slot>.json`
- Writes go through `tmp → rename` to prevent partial-write corruption
- `saveCompanionSlot()` **appends only** — throws if slot exists, no more silent overwrites
- `saveCompanion()` is the sole intentional in-place update path (rename / personality)
- Auto-migrates legacy `companion.json` and old per-file layout on first load

### New MCP tools (`server/index.ts`)
| Tool | Description |
|------|-------------|
| `buddy_summon [slot]` | Switch to a saved slot (random if omitted) |
| `buddy_save [slot]` | Checkpoint current buddy to a named slot |
| `buddy_list` | Show all menagerie entries |
| `buddy_dismiss <slot>` | Delete a non-active slot |

### New CLI: `bun run pick` (`cli/pick.ts`)
Two-pane interactive TUI:
- Left: saved buddy list → search criteria → results → naming prompt
- Right: full companion card preview
- Search by species, rarity, shiny, peak/dump stat
- Empty name on Enter → picks a random unused name automatically
- Duplicate-slot guard with inline error

### `cli/hunt.ts`
- Now prompts for a name before saving (or auto-picks unused random name)
- Appends to manifest — never overwrites active companion
- **Removed mutation of `~/.claude.json`** (was deleting `accountUuid`, causing userId drift and random blob regeneration)

### Skill / hooks / statusline
- `skills/buddy/SKILL.md`: updated argument-hint and routing table
- `hooks/react.sh` + `statusline/buddy-status.sh`: read from `status.json` instead of deleted `companion.json`; `status.json` gains `eye` field

## Test plan
- [ ] Fresh install: `bun run install-buddy`, verify `/buddy show` works
- [ ] `bun run pick`: browse saved list, search for a buddy, name it, confirm it appears in `/buddy list`
- [ ] `/buddy summon` (random), `/buddy summon <slot>` (named)
- [ ] `/buddy rename <name>` updates name without changing slot
- [ ] `/buddy dismiss <slot>` removes non-active slot; guard prevents dismissing active
- [ ] Confirm `~/.claude-buddy/menagerie.json` is the only storage file written (no per-slot files)
- [ ] Upgrade path: existing `companion.json` or `menagerie/<slot>.json` files migrate cleanly on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)