### PR TITLE
feat: tmux popup overlay mode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Auto-detect text files and normalize line endings to LF
+* text=auto eol=lf
+
+# Shell scripts must always use LF
+*.sh text eol=lf
+
+# Keep binary files as-is
+*.png binary
+*.jpg binary
+*.gif binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,11 @@ Restart Claude Code and type `/buddy` to verify everything works.
 
 | Directory | What it does |
 |-----------|-------------|
-| `server/` | MCP server — buddy engine, tools, state, reactions |
+| `server/` | MCP server -- buddy engine, tools, state, reactions |
 | `skills/` | `/buddy` slash command (SKILL.md) |
 | `hooks/` | Shell scripts for error detection + comment extraction |
-| `statusline/` | Animated status line renderer |
+| `statusline/` | Animated status line renderer (fallback mode) |
+| `popup/` | tmux popup overlay mode (requires tmux >= 3.2) |
 | `cli/` | Install, uninstall, show, hunt, verify commands |
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ The mechanism is invisible: Claude appends a hidden HTML comment (`<!-- buddy: .
 | `/buddy on` | Unmute |
 | `/buddy rename <name>` | Rename (1-14 chars) |
 | `/buddy personality <text>` | Set custom personality |
+| `/buddy frequency [seconds]` | Show or set comment cooldown |
+| `/buddy style [classic\|round]` | Show or set bubble border style |
+| `/buddy position [top\|left]` | Show or set bubble position |
+| `/buddy rarity [on\|off]` | Show or hide stars + rarity line |
 
 ### CLI
 
@@ -266,6 +270,44 @@ bun run backup restore      # restore latest
 bun run backup restore <ts> # restore specific
 ```
 
+## tmux Popup Mode
+
+When running inside tmux, buddy appears as a floating popup overlay in the bottom-right corner instead of the status line. The popup supports:
+
+- Animated ASCII art with speech bubbles
+- ESC passthrough (closes popup momentarily, forwards ESC to Claude Code, then reopens)
+- Dynamic resizing when reactions appear/disappear
+- Full keyboard input forwarding to Claude Code
+
+### Requirements
+
+| tmux version | Support |
+|--------------|---------|
+| **3.4+** | Full support (borderless, positioned anchors) |
+| **3.2 -- 3.3** | Supported with border, absolute positioning |
+| **< 3.2** | Falls back to status line mode |
+
+### Recommended tmux config
+
+Add to `~/.tmux.conf`:
+
+```
+set -g set-titles on
+set -g set-titles-string "#{pane_title}"
+set -g mouse on
+set -g history-limit 10000
+```
+
+### Scrolling
+
+The popup is modal -- it captures all input including mouse wheel. To scroll:
+
+1. Press **F12** to enter scroll mode (popup hides, tmux copy-mode activates)
+2. Scroll with **mouse wheel** or **arrow keys** / **Page Up/Down**
+3. Press **q** to exit scroll mode (popup returns)
+
+`set -g mouse on` is required for mouse wheel scrolling in copy-mode. Claude Code captures `Ctrl-b`, so the standard tmux prefix can't be used to enter copy-mode. F12 bypasses this.
+
 ## Troubleshooting
 
 ### Buddy not appearing in status line
@@ -336,7 +378,7 @@ This MVP covers the core: your buddy is back, animated, talking, and permanent. 
 - [ ] **Achievement badges** — milestones like "1000 lines reviewed", "first test-fail caught", "week streak"
 - [ ] **Multi-buddy support** — hatch and switch between multiple companions
 - [ ] **Light theme colors** — auto-detect and match light theme RGB values
-- [ ] **tmux sidebar mode** — true right-side positioning via terminal multiplexer
+- [x] **tmux popup mode** -- floating overlay in bottom-right corner via `tmux display-popup`
 - [ ] **New species + community art** — submit your own species designs
 - [ ] **`npx claude-buddy`** — one-command install without cloning
 

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -152,6 +152,47 @@ function installStatusLine(settings: Record<string, any>) {
   ok("Status line configured (with animation refresh)");
 }
 
+// ─── Step 3b: Configure tmux popup mode (if in tmux) ────────────────────────
+
+function detectTmux(): boolean {
+  if (!process.env.TMUX) return false;
+  try {
+    const ver = execSync("tmux -V 2>/dev/null", { encoding: "utf8" }).trim();
+    const match = ver.match(/(\d+)\.(\d+)/);
+    if (!match) return false;
+    const major = parseInt(match[1]), minor = parseInt(match[2]);
+    return major > 3 || (major === 3 && minor >= 2);
+  } catch {
+    return false;
+  }
+}
+
+function installPopupHooks(settings: Record<string, any>) {
+  const popupManager = join(PROJECT_ROOT, "popup", "popup-manager.sh");
+
+  if (!settings.hooks) settings.hooks = {};
+
+  // SessionStart: open popup
+  if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
+  settings.hooks.SessionStart = settings.hooks.SessionStart.filter(
+    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+  );
+  settings.hooks.SessionStart.push({
+    hooks: [{ type: "command", command: `${popupManager} start` }],
+  });
+
+  // SessionEnd: close popup
+  if (!settings.hooks.SessionEnd) settings.hooks.SessionEnd = [];
+  settings.hooks.SessionEnd = settings.hooks.SessionEnd.filter(
+    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+  );
+  settings.hooks.SessionEnd.push({
+    hooks: [{ type: "command", command: `${popupManager} stop` }],
+  });
+
+  ok("Popup hooks registered: SessionStart + SessionEnd");
+}
+
 // ─── Step 4: Register hooks ─────────────────────────────────────────────────
 
 function installHooks(settings: Record<string, any>) {
@@ -242,7 +283,20 @@ const settings = loadSettings();
 
 installMcp();
 installSkill();
-installStatusLine(settings);
+
+const useTmuxPopup = detectTmux();
+if (useTmuxPopup) {
+  info("tmux detected (>= 3.2) -- using popup overlay mode");
+  installPopupHooks(settings);
+  // Disable status line to avoid duplicate buddy rendering
+  if (settings.statusLine?.command?.includes("buddy")) {
+    delete settings.statusLine;
+    ok("Status line disabled (popup replaces it)");
+  }
+} else {
+  installStatusLine(settings);
+}
+
 installHooks(settings);
 ensurePermissions(settings);
 saveSettings(settings);
@@ -253,12 +307,14 @@ const companion = initCompanion();
 console.log("");
 console.log(renderBuddy(companion.bones));
 console.log("");
-console.log(`  ${BOLD}${companion.name}${NC} — ${companion.personality}`);
+console.log(`  ${BOLD}${companion.name}${NC} -- ${companion.personality}`);
 console.log("");
 
+const modeMsg = useTmuxPopup ? "popup overlay" : "status line";
 console.log(`${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}`);
 console.log(`${GREEN}  Done! Restart Claude Code and type /buddy${NC}`);
-console.log(`${GREEN}  Your companion is now permanent — survives any update.${NC}`);
+console.log(`${GREEN}  Display mode: ${modeMsg}${NC}`);
+console.log(`${GREEN}  Your companion is now permanent -- survives any update.${NC}`);
 console.log(`${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}`);
 console.log("");
 console.log(`${DIM}  /buddy        show your companion`);

--- a/cli/uninstall.ts
+++ b/cli/uninstall.ts
@@ -20,6 +20,28 @@ const STATE_DIR = join(homedir(), ".claude-buddy");
 
 console.log("\nclaude-buddy uninstall\n");
 
+// Stop popup reopen loop and close any running popup
+try {
+  const pidFile = join(STATE_DIR, "popup-reopen-pid");
+  const stopFlag = join(STATE_DIR, "popup-stop");
+  // Signal the reopen loop to stop
+  writeFileSync(stopFlag, "");
+  // Close any open popup
+  if (process.env.TMUX) {
+    const { execSync } = await import("child_process");
+    execSync("tmux display-popup -C 2>/dev/null", { stdio: "ignore" });
+  }
+  // Kill the reopen loop process
+  if (existsSync(pidFile)) {
+    const pid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+    if (pid > 0) {
+      try { process.kill(pid); } catch { /* already dead */ }
+    }
+    rmSync(pidFile, { force: true });
+  }
+  ok("Popup stopped");
+} catch { /* not in tmux or no popup */ }
+
 // Remove MCP server from ~/.claude.json
 try {
   const claudeJsonPath = join(homedir(), ".claude.json");
@@ -45,7 +67,7 @@ try {
     changed = true;
   }
 
-  for (const hookType of ["PostToolUse", "Stop"] as const) {
+  for (const hookType of ["PostToolUse", "Stop", "SessionStart", "SessionEnd"] as const) {
     if (settings.hooks?.[hookType]) {
       const before = settings.hooks[hookType].length;
       settings.hooks[hookType] = settings.hooks[hookType].filter(

--- a/cli/uninstall.ts
+++ b/cli/uninstall.ts
@@ -2,7 +2,7 @@
  * claude-buddy uninstall — remove all integrations
  */
 
-import { readFileSync, writeFileSync, existsSync, rmSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, rmSync, readdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -20,24 +20,29 @@ const STATE_DIR = join(homedir(), ".claude-buddy");
 
 console.log("\nclaude-buddy uninstall\n");
 
-// Stop popup reopen loop and close any running popup
+// Stop all popup reopen loops and close any running popup
 try {
-  const pidFile = join(STATE_DIR, "popup-reopen-pid");
-  const stopFlag = join(STATE_DIR, "popup-stop");
-  // Signal the reopen loop to stop
-  writeFileSync(stopFlag, "");
+  if (existsSync(STATE_DIR)) {
+    // Kill all session popup loops (popup-reopen-pid.*)
+    for (const f of readdirSync(STATE_DIR).filter(f => f.startsWith("popup-reopen-pid."))) {
+      const pidPath = join(STATE_DIR, f);
+      const pid = parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+      if (pid > 0) { try { process.kill(pid); } catch { /* already dead */ } }
+      rmSync(pidPath, { force: true });
+    }
+    // Clean up all session-scoped files
+    const patterns = ["popup-stop.", "popup-resize.", "popup-env.", "popup-scroll.",
+                      "reaction.", ".last_reaction.", ".last_comment."];
+    for (const f of readdirSync(STATE_DIR)) {
+      if (patterns.some(p => f.startsWith(p))) {
+        rmSync(join(STATE_DIR, f), { force: true });
+      }
+    }
+  }
   // Close any open popup
   if (process.env.TMUX) {
     const { execSync } = await import("child_process");
     execSync("tmux display-popup -C 2>/dev/null", { stdio: "ignore" });
-  }
-  // Kill the reopen loop process
-  if (existsSync(pidFile)) {
-    const pid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
-    if (pid > 0) {
-      try { process.kill(pid); } catch { /* already dead */ }
-    }
-    rmSync(pidFile, { force: true });
   }
   ok("Popup stopped");
 } catch { /* not in tmux or no popup */ }

--- a/hooks/buddy-comment.sh
+++ b/hooks/buddy-comment.sh
@@ -6,8 +6,11 @@
 # The HTML comment is invisible in rendered markdown output.
 
 STATE_DIR="$HOME/.claude-buddy"
+# Session ID: sanitized tmux pane number, or "default" outside tmux
+SID="${TMUX_PANE#%}"
+SID="${SID:-default}"
 STATUS_FILE="$STATE_DIR/status.json"
-COOLDOWN_FILE="$STATE_DIR/.last_comment"
+COOLDOWN_FILE="$STATE_DIR/.last_comment.$SID"
 CONFIG_FILE="$STATE_DIR/config.json"
 
 [ -f "$STATUS_FILE" ] || exit 0
@@ -46,6 +49,6 @@ jq --arg r "$COMMENT" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv
 # Also write reaction file (use jq for safe JSON encoding)
 jq -n --arg r "$COMMENT" --arg ts "$(date +%s)000" \
   '{reaction: $r, timestamp: ($ts | tonumber), reason: "turn"}' \
-  > "$STATE_DIR/reaction.json"
+  > "$STATE_DIR/reaction.$SID.json"
 
 exit 0

--- a/hooks/buddy-comment.sh
+++ b/hooks/buddy-comment.sh
@@ -8,8 +8,16 @@
 STATE_DIR="$HOME/.claude-buddy"
 STATUS_FILE="$STATE_DIR/status.json"
 COOLDOWN_FILE="$STATE_DIR/.last_comment"
+CONFIG_FILE="$STATE_DIR/config.json"
 
 [ -f "$STATUS_FILE" ] || exit 0
+
+# Read cooldown from config (default 30s)
+COOLDOWN=30
+if [ -f "$CONFIG_FILE" ]; then
+  _cd=$(jq -r '.commentCooldown // 30' "$CONFIG_FILE" 2>/dev/null || echo 30)
+  [ "$_cd" -gt 0 ] 2>/dev/null && COOLDOWN=$_cd
+fi
 
 INPUT=$(cat)
 
@@ -17,15 +25,15 @@ INPUT=$(cat)
 MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // ""' 2>/dev/null)
 [ -z "$MSG" ] && exit 0
 
-# Extract <!-- buddy: ... --> comment
-COMMENT=$(echo "$MSG" | grep -oP '<!--\s*buddy:\s*\K.+?(?=\s*-->)' | tail -1)
+# Extract <!-- buddy: ... --> comment (portable, no grep -P)
+COMMENT=$(echo "$MSG" | sed -n 's/.*<!-- *buddy: *\(.*[^ ]\) *-->.*/\1/p' | tail -1)
 [ -z "$COMMENT" ] && exit 0
 
-# Cooldown: 20 seconds
+# Cooldown: configurable (default 30s)
 if [ -f "$COOLDOWN_FILE" ]; then
     LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null)
     NOW=$(date +%s)
-    [ $(( NOW - ${LAST:-0} )) -lt 20 ] && exit 0
+    [ $(( NOW - ${LAST:-0} )) -lt "$COOLDOWN" ] && exit 0
 fi
 
 mkdir -p "$STATE_DIR"
@@ -35,9 +43,9 @@ date +%s > "$COOLDOWN_FILE"
 TMP=$(mktemp)
 jq --arg r "$COMMENT" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
 
-# Also write reaction file
-cat > "$STATE_DIR/reaction.json" <<EOJSON
-{"reaction":"$COMMENT","timestamp":$(date +%s%3N),"reason":"turn"}
-EOJSON
+# Also write reaction file (use jq for safe JSON encoding)
+jq -n --arg r "$COMMENT" --arg ts "$(date +%s)000" \
+  '{reaction: $r, timestamp: ($ts | tonumber), reason: "turn"}' \
+  > "$STATE_DIR/reaction.json"
 
 exit 0

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -4,9 +4,12 @@
 # Writes reaction to ~/.claude-buddy/reaction.json for the status line
 
 STATE_DIR="$HOME/.claude-buddy"
-REACTION_FILE="$STATE_DIR/reaction.json"
+# Session ID: sanitized tmux pane number, or "default" outside tmux
+SID="${TMUX_PANE#%}"
+SID="${SID:-default}"
+REACTION_FILE="$STATE_DIR/reaction.$SID.json"
 COMPANION_FILE="$STATE_DIR/companion.json"
-COOLDOWN_FILE="$STATE_DIR/.last_reaction"
+COOLDOWN_FILE="$STATE_DIR/.last_reaction.$SID"
 CONFIG_FILE="$STATE_DIR/config.json"
 
 # Exit if no companion

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -7,6 +7,7 @@ STATE_DIR="$HOME/.claude-buddy"
 REACTION_FILE="$STATE_DIR/reaction.json"
 COMPANION_FILE="$STATE_DIR/companion.json"
 COOLDOWN_FILE="$STATE_DIR/.last_reaction"
+CONFIG_FILE="$STATE_DIR/config.json"
 
 # Exit if no companion
 [ -f "$COMPANION_FILE" ] || exit 0
@@ -14,12 +15,19 @@ COOLDOWN_FILE="$STATE_DIR/.last_reaction"
 # Read hook input from stdin
 INPUT=$(cat)
 
-# Cooldown: max one reaction per 15 seconds
+# Read cooldown from config (default 30s)
+COOLDOWN=30
+if [ -f "$CONFIG_FILE" ]; then
+  _cd=$(jq -r '.commentCooldown // 30' "$CONFIG_FILE" 2>/dev/null || echo 30)
+  [ "$_cd" -gt 0 ] 2>/dev/null && COOLDOWN=$_cd
+fi
+
+# Cooldown: configurable
 if [ -f "$COOLDOWN_FILE" ]; then
     LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null)
     NOW=$(date +%s)
     DIFF=$(( NOW - ${LAST:-0} ))
-    [ "$DIFF" -lt 15 ] && exit 0
+    [ "$DIFF" -lt "$COOLDOWN" ] && exit 0
 fi
 
 # Extract tool result
@@ -75,10 +83,10 @@ if [ -n "$REASON" ]; then
     mkdir -p "$STATE_DIR"
     date +%s > "$COOLDOWN_FILE"
 
-    # Write reaction for status line
-    cat > "$REACTION_FILE" <<EOJSON
-{"reaction":"$REACTION","timestamp":$(date +%s%3N),"reason":"$REASON"}
-EOJSON
+    # Write reaction for status line (use jq for safe JSON encoding)
+    jq -n --arg r "$REACTION" --arg ts "$(date +%s)000" --arg reason "$REASON" \
+      '{reaction: $r, timestamp: ($ts | tonumber), reason: $reason}' \
+      > "$REACTION_FILE"
 
     # Update status.json with reaction
     if [ -f "$STATE_DIR/status.json" ]; then

--- a/popup/buddy-popup.sh
+++ b/popup/buddy-popup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# claude-buddy popup entry point -- runs INSIDE the tmux popup
+#
+# Architecture:
+#   - Render loop runs in BACKGROUND (only writes to stdout, never reads stdin)
+#   - Input forwarder runs in FOREGROUND (owns stdin exclusively)
+#
+# The reopen loop in popup-manager.sh handles:
+#   - ESC forwarding (when tmux closes popup on ESC)
+#   - CC pane death detection
+#   - Dynamic resizing on reopen
+#
+# Env vars (set by popup-manager.sh via -e):
+#   CC_PANE   -- tmux pane ID for Claude Code (e.g. %0)
+#   BUDDY_DIR -- ~/.claude-buddy
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# On tmux 3.2, env vars are passed via file (no -e flag support)
+ENV_FILE="${HOME}/.claude-buddy/popup-env"
+if [ -z "${CC_PANE:-}" ] && [ -f "$ENV_FILE" ]; then
+  . "$ENV_FILE"
+fi
+
+if [ -z "${CC_PANE:-}" ]; then
+  echo "Error: CC_PANE not set" >&2
+  sleep 2
+  exit 1
+fi
+
+# ─── Cleanup on exit ─────────────────────────────────────────────────────────
+cleanup() {
+  [ -n "${RENDER_PID:-}" ] && kill "$RENDER_PID" 2>/dev/null
+  tput cnorm 2>/dev/null
+  stty sane 2>/dev/null
+}
+trap cleanup EXIT INT TERM HUP
+
+# Hide cursor
+tput civis 2>/dev/null
+
+# ─── Render loop in BACKGROUND (stdout only, no stdin) ───────────────────────
+"$SCRIPT_DIR/buddy-render.sh" </dev/null &
+RENDER_PID=$!
+
+# ─── Input forwarder in FOREGROUND ───────────────────────────────────────────
+# Raw mode: all bytes pass through without terminal interpretation.
+# No SIGINT on Ctrl-C, no EOF on Ctrl-D, no CR-to-NL on Enter.
+stty raw -echo 2>/dev/null
+
+# Use perl for raw byte forwarding. bash's read -n1 internally overrides
+# terminal settings on each call (saves/restores tty mode), which undoes
+# stty raw and re-enables signal processing. perl's sysread doesn't touch
+# the terminal at all -- it reads raw bytes from the file descriptor.
+#
+# Batching: first byte is a blocking read, then non-blocking drain of any
+# remaining bytes (paste arrives as a burst). The batch is sent to CC in
+# a single tmux send-keys call for efficiency.
+exec perl -e '
+  use Fcntl qw(F_GETFL F_SETFL O_NONBLOCK);
+  my $pane = $ENV{CC_PANE};
+  while (1) {
+    my $buf;
+    my $n = sysread(STDIN, $buf, 1);
+    last unless $n;
+    # Non-blocking drain for paste batching
+    my $flags = fcntl(STDIN, F_GETFL, 0);
+    fcntl(STDIN, F_SETFL, $flags | O_NONBLOCK);
+    while (sysread(STDIN, my $more, 4096)) {
+      $buf .= $more;
+    }
+    fcntl(STDIN, F_SETFL, $flags);
+
+    # F12 (\e[24~) = close popup and enter scroll mode
+    if ($buf =~ /\e\[24~/) {
+      my $buddy_dir = $ENV{BUDDY_DIR} || "$ENV{HOME}/.claude-buddy";
+      open(my $fh, ">", "$buddy_dir/popup-scroll");
+      close($fh) if $fh;
+      exit 0;
+    }
+
+    system("tmux", "send-keys", "-t", $pane, "-l", "--", $buf);
+  }
+'

--- a/popup/buddy-popup.sh
+++ b/popup/buddy-popup.sh
@@ -11,15 +11,20 @@
 #   - Dynamic resizing on reopen
 #
 # Env vars (set by popup-manager.sh via -e):
-#   CC_PANE   -- tmux pane ID for Claude Code (e.g. %0)
-#   BUDDY_DIR -- ~/.claude-buddy
+#   CC_PANE    -- tmux pane ID for Claude Code (e.g. %0)
+#   BUDDY_DIR  -- ~/.claude-buddy
+#   BUDDY_SID  -- session ID (sanitized pane number, e.g. "0")
+# Args: $1 = SID (fallback for tmux < 3.4 without -e support)
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# On tmux 3.2, env vars are passed via file (no -e flag support)
-ENV_FILE="${HOME}/.claude-buddy/popup-env"
+# Session ID: from env (tmux 3.4+), $1 arg, or "default"
+BUDDY_SID="${BUDDY_SID:-${1:-default}}"
+
+# On tmux 3.2-3.3, env vars are passed via file (no -e flag support)
+ENV_FILE="${HOME}/.claude-buddy/popup-env.$BUDDY_SID"
 if [ -z "${CC_PANE:-}" ] && [ -f "$ENV_FILE" ]; then
   . "$ENV_FILE"
 fi
@@ -76,7 +81,8 @@ exec perl -e '
     # F12 (\e[24~) = close popup and enter scroll mode
     if ($buf =~ /\e\[24~/) {
       my $buddy_dir = $ENV{BUDDY_DIR} || "$ENV{HOME}/.claude-buddy";
-      open(my $fh, ">", "$buddy_dir/popup-scroll");
+      my $sid = $ENV{BUDDY_SID} || "default";
+      open(my $fh, ">", "$buddy_dir/popup-scroll.$sid");
       close($fh) if $fh;
       exit 0;
     }

--- a/popup/buddy-render.sh
+++ b/popup/buddy-render.sh
@@ -1,0 +1,532 @@
+#!/usr/bin/env bash
+# claude-buddy popup render loop -- draws buddy in the tmux popup
+#
+# Runs as BACKGROUND process inside the popup. Stdin is /dev/null.
+# Only writes to stdout (popup display).
+#
+# Env vars:
+#   BUDDY_DIR -- ~/.claude-buddy
+
+set -uo pipefail
+
+# Inner popup dimensions from env (set by popup-manager).
+# POPUP_INNER_W/H account for border on tmux < 3.4.
+PANE_W="${POPUP_INNER_W:-$(tput cols 2>/dev/null || echo 24)}"
+PANE_H="${POPUP_INNER_H:-$(tput lines 2>/dev/null || echo 14)}"
+
+BUDDY_STATE_DIR="${BUDDY_DIR:-$HOME/.claude-buddy}"
+STATE="$BUDDY_STATE_DIR/status.json"
+COMPANION="$BUDDY_STATE_DIR/companion.json"
+REACTION_FILE="$BUDDY_STATE_DIR/reaction.json"
+RESIZE_FLAG="$BUDDY_STATE_DIR/popup-resize"
+REACTION_TTL=20  # seconds
+CONFIG_FILE="$BUDDY_STATE_DIR/config.json"
+
+# Bubble style: "classic" (pipes/dashes like status line) or "round" (parens/tildes)
+BUBBLE_STYLE="classic"
+BUBBLE_POSITION="top"
+SHOW_RARITY=1
+if [ -f "$CONFIG_FILE" ]; then
+  _bs=$(jq -r '.bubbleStyle // "classic"' "$CONFIG_FILE" 2>/dev/null || echo "classic")
+  case "$_bs" in classic|round) BUBBLE_STYLE="$_bs" ;; esac
+  _bp=$(jq -r '.bubblePosition // "top"' "$CONFIG_FILE" 2>/dev/null || echo "top")
+  case "$_bp" in top|left) BUBBLE_POSITION="$_bp" ;; esac
+  _sr=$(jq -r 'if .showRarity == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null || echo "true")
+  [ "$_sr" = "false" ] && SHOW_RARITY=0
+fi
+
+# Track whether we're currently showing a reaction bubble.
+# Initialized after reaction_fresh() is defined (see below main loop).
+SHOWING_REACTION=0
+
+SEQ=(0 0 0 0 1 0 0 0 -1 0 0 2 0 0 0)
+SEQ_LEN=${#SEQ[@]}
+TICK=0
+
+NC=$'\033[0m'
+DIM=$'\033[2;3m'
+BOLD=$'\033[1m'
+
+rarity_color() {
+  case "$1" in
+    common)    echo -n $'\033[38;2;153;153;153m' ;;
+    uncommon)  echo -n $'\033[38;2;78;186;101m'  ;;
+    rare)      echo -n $'\033[38;2;177;185;249m' ;;
+    epic)      echo -n $'\033[38;2;175;135;255m' ;;
+    legendary) echo -n $'\033[38;2;255;193;7m'   ;;
+    *)         echo -n "$NC" ;;
+  esac
+}
+
+rarity_stars() {
+  case "$1" in
+    common)    echo -n "★☆☆☆☆" ;;
+    uncommon)  echo -n "★★☆☆☆" ;;
+    rare)      echo -n "★★★☆☆" ;;
+    epic)      echo -n "★★★★☆" ;;
+    legendary) echo -n "★★★★★" ;;
+  esac
+}
+
+# ─── Check reaction TTL ─────────────────────────────────────────────────────
+
+reaction_fresh() {
+  [ -f "$REACTION_FILE" ] || return 1
+  local ts now age
+  ts=$(jq -r '.timestamp // 0' "$REACTION_FILE" 2>/dev/null || echo 0)
+  [ "$ts" = "0" ] && return 1
+  # timestamp is in milliseconds (JS Date.now())
+  now=$(date +%s)
+  age=$(( now - ts / 1000 ))
+  [ "$age" -lt "$REACTION_TTL" ]
+}
+
+# ─── Species art ─────────────────────────────────────────────────────────────
+
+get_art() {
+  local species="$1" frame="$2" E="$3"
+  case "$species" in
+    duck)
+      case $frame in
+        0) L1="   __";      L2=" <(${E} )___"; L3="  (  ._>";   L4="   \`--'" ;;
+        1) L1="   __";      L2=" <(${E} )___"; L3="  (  ._>";   L4="   \`--'~" ;;
+        2) L1="   __";      L2=" <(${E} )___"; L3="  (  .__>";  L4="   \`--'" ;;
+      esac ;;
+    goose)
+      case $frame in
+        0) L1="  (${E}>";    L2="   ||";       L3=" _(__)_";   L4="  ^^^^" ;;
+        1) L1=" (${E}>";     L2="   ||";       L3=" _(__)_";   L4="  ^^^^" ;;
+        2) L1="  (${E}>>";   L2="   ||";       L3=" _(__)_";   L4="  ^^^^" ;;
+      esac ;;
+    blob)
+      case $frame in
+        0) L1=" .----.";    L2="( ${E}  ${E} )"; L3="(      )";  L4=" \`----'" ;;
+        1) L1=".------.";   L2="( ${E}  ${E} )"; L3="(       )"; L4="\`------'" ;;
+        2) L1="  .--.";     L2=" (${E}  ${E})";  L3=" (    )";   L4="  \`--'" ;;
+      esac ;;
+    cat)
+      case $frame in
+        0) L1=" /\\_/\\";   L2="( ${E}   ${E})"; L3="(  w  )";  L4="(\")_(\")" ;;
+        1) L1=" /\\_/\\";   L2="( ${E}   ${E})"; L3="(  w  )";  L4="(\")_(\")~" ;;
+        2) L1=" /\\-/\\";   L2="( ${E}   ${E})"; L3="(  w  )";  L4="(\")_(\")" ;;
+      esac ;;
+    dragon)
+      case $frame in
+        0) L1="/^\\  /^\\"; L2="< ${E}  ${E} >"; L3="(  ~~  )"; L4=" \`-vvvv-'" ;;
+        1) L1="/^\\  /^\\"; L2="< ${E}  ${E} >"; L3="(      )"; L4=" \`-vvvv-'" ;;
+        2) L1="/^\\  /^\\"; L2="< ${E}  ${E} >"; L3="(  ~~  )"; L4=" \`-vvvv-'" ;;
+      esac ;;
+    octopus)
+      case $frame in
+        0) L1=" .----.";   L2="( ${E}  ${E} )"; L3="(______)"; L4="/\\/\\/\\/\\" ;;
+        1) L1=" .----.";   L2="( ${E}  ${E} )"; L3="(______)"; L4="\\/\\/\\/\\/" ;;
+        2) L1=" .----.";   L2="( ${E}  ${E} )"; L3="(______)"; L4="/\\/\\/\\/\\" ;;
+      esac ;;
+    owl)
+      case $frame in
+        0) L1=" /\\  /\\";  L2="((${E})(${E}))"; L3="(  ><  )"; L4=" \`----'" ;;
+        1) L1=" /\\  /\\";  L2="((${E})(${E}))"; L3="(  ><  )"; L4=" .----." ;;
+        2) L1=" /\\  /\\";  L2="((${E})(-))";    L3="(  ><  )"; L4=" \`----'" ;;
+      esac ;;
+    penguin)
+      case $frame in
+        0) L1=" .---.";    L2=" (${E}>${E})";   L3="/(   )\\"; L4=" \`---'" ;;
+        1) L1=" .---.";    L2=" (${E}>${E})";   L3="|(   )|";  L4=" \`---'" ;;
+        2) L1=" .---.";    L2=" (${E}>${E})";   L3="/(   )\\"; L4=" \`---'" ;;
+      esac ;;
+    turtle)
+      case $frame in
+        0) L1=" _,--._";   L2="( ${E}  ${E} )"; L3="[______]"; L4="\`\`    \`\`" ;;
+        1) L1=" _,--._";   L2="( ${E}  ${E} )"; L3="[______]"; L4=" \`\`  \`\`" ;;
+        2) L1=" _,--._";   L2="( ${E}  ${E} )"; L3="[======]"; L4="\`\`    \`\`" ;;
+      esac ;;
+    snail)
+      case $frame in
+        0) L1="${E}   .--."; L2="\\  ( @ )";   L3=" \\_\`--'"; L4="~~~~~~~" ;;
+        1) L1=" ${E}  .--."; L2="|  ( @ )";   L3=" \\_\`--'"; L4="~~~~~~~" ;;
+        2) L1="${E}   .--."; L2="\\  ( @ )";   L3=" \\_\`--'"; L4=" ~~~~~~" ;;
+      esac ;;
+    ghost)
+      case $frame in
+        0) L1=" .----.";   L2="/ ${E}  ${E} \\"; L3="|      |"; L4="~\`~\`\`~\`~" ;;
+        1) L1=" .----.";   L2="/ ${E}  ${E} \\"; L3="|      |"; L4="\`~\`~~\`~\`" ;;
+        2) L1=" .----.";   L2="/ ${E}  ${E} \\"; L3="|      |"; L4="~~\`~~\`~~" ;;
+      esac ;;
+    axolotl)
+      case $frame in
+        0) L1="}~(____)~{"; L2="}~(${E}..${E})~{"; L3=" (.--.)";  L4=" (_/\\_)" ;;
+        1) L1="~}(____){~"; L2="~}(${E}..${E}){~"; L3=" (.--.)";  L4=" (_/\\_)" ;;
+        2) L1="}~(____)~{"; L2="}~(${E}..${E})~{"; L3=" ( -- )";  L4=" ~_/\\_~" ;;
+      esac ;;
+    capybara)
+      case $frame in
+        0) L1="n______n";  L2="( ${E}    ${E} )"; L3="(  oo  )"; L4="\`------'" ;;
+        1) L1="n______n";  L2="( ${E}    ${E} )"; L3="(  Oo  )"; L4="\`------'" ;;
+        2) L1="u______n";  L2="( ${E}    ${E} )"; L3="(  oo  )"; L4="\`------'" ;;
+      esac ;;
+    cactus)
+      case $frame in
+        0) L1="n ____ n";  L2="||${E}  ${E}||"; L3="|_|  |_|"; L4="  |  |" ;;
+        1) L1="  ____";    L2="n|${E}  ${E}|n"; L3="|_|  |_|"; L4="  |  |" ;;
+        2) L1="n ____ n";  L2="||${E}  ${E}||"; L3="|_|  |_|"; L4="  |  |" ;;
+      esac ;;
+    robot)
+      case $frame in
+        0) L1=" .[||].";   L2="[ ${E}  ${E} ]"; L3="[ ==== ]"; L4="\`------'" ;;
+        1) L1=" .[||].";   L2="[ ${E}  ${E} ]"; L3="[ -==- ]"; L4="\`------'" ;;
+        2) L1=" .[||].";   L2="[ ${E}  ${E} ]"; L3="[ ==== ]"; L4="\`------'" ;;
+      esac ;;
+    rabbit)
+      case $frame in
+        0) L1=" (\\__/)";  L2="( ${E}  ${E} )"; L3="=(  ..  )="; L4="(\")__(\")" ;;
+        1) L1=" (|__/)";   L2="( ${E}  ${E} )"; L3="=(  ..  )="; L4="(\")__(\")" ;;
+        2) L1=" (\\__/)";  L2="( ${E}  ${E} )"; L3="=( .  . )="; L4="(\")__(\")" ;;
+      esac ;;
+    mushroom)
+      case $frame in
+        0) L1="-o-OO-o-";  L2="(________)";  L3="  |${E}${E}|"; L4="  |__|" ;;
+        1) L1="-O-oo-O-";  L2="(________)";  L3="  |${E}${E}|"; L4="  |__|" ;;
+        2) L1="-o-OO-o-";  L2="(________)";  L3="  |${E}${E}|"; L4="  |__|" ;;
+      esac ;;
+    chonk)
+      case $frame in
+        0) L1="/\\    /\\"; L2="( ${E}    ${E} )"; L3="(  ..  )"; L4="\`------'" ;;
+        1) L1="/\\    /|";  L2="( ${E}    ${E} )"; L3="(  ..  )"; L4="\`------'" ;;
+        2) L1="/\\    /\\"; L2="( ${E}    ${E} )"; L3="(  ..  )"; L4="\`------'~" ;;
+      esac ;;
+    *)
+      L1="(${E}${E})"; L2="(  )"; L3=""; L4="" ;;
+  esac
+}
+
+# ─── Center text, pad to full width ──────────────────────────────────────────
+
+center_pad() {
+  local text="$1" width="$2"
+  local len=${#text}
+  local lpad=$(( (width - len) / 2 ))
+  [ "$lpad" -lt 0 ] && lpad=0
+  local rpad=$(( width - len - lpad ))
+  [ "$rpad" -lt 0 ] && rpad=0
+  printf '%*s%s%*s' "$lpad" '' "$text" "$rpad" ''
+}
+
+# Center a line within a block of known max_width, then center the block in pane
+center_block_line() {
+  local text="$1" max_w="$2" pane="$3"
+  local len=${#text}
+  # Left-pad within the block to center each line relative to block width
+  local inner_lpad=$(( (max_w - len) / 2 ))
+  [ "$inner_lpad" -lt 0 ] && inner_lpad=0
+  local inner_rpad=$(( max_w - len - inner_lpad ))
+  [ "$inner_rpad" -lt 0 ] && inner_rpad=0
+  local block_line
+  block_line=$(printf '%*s%s%*s' "$inner_lpad" '' "$text" "$inner_rpad" '')
+  # Now center the block within the pane
+  center_pad "$block_line" "$pane"
+}
+
+# ─── Word wrap ───────────────────────────────────────────────────────────────
+
+word_wrap() {
+  local text="$1" max_w="$2"
+  local -a words=($text)
+  local line=""
+  WRAPPED_LINES=()
+  for word in "${words[@]}"; do
+    if [ -z "$line" ]; then
+      line="$word"
+    elif [ $(( ${#line} + 1 + ${#word} )) -le "$max_w" ]; then
+      line="$line $word"
+    else
+      WRAPPED_LINES+=("$line")
+      line="$word"
+    fi
+  done
+  [ -n "$line" ] && WRAPPED_LINES+=("$line")
+}
+
+# ─── Render one frame ────────────────────────────────────────────────────────
+# Uses cursor positioning (\033[row;1H) for each line.
+# No clear screen, no newlines -- overwrites in place for flicker-free updates.
+
+render() {
+  local frame_idx="$1"
+  local pane_w="$PANE_W"
+
+  [ -f "$STATE" ] || return
+  local name species hat rarity reaction eye
+  name=$(jq -r '.name // ""' "$STATE" 2>/dev/null)
+  [ -z "$name" ] && return
+  species=$(jq -r '.species // ""' "$STATE" 2>/dev/null)
+  hat=$(jq -r '.hat // "none"' "$STATE" 2>/dev/null)
+  rarity=$(jq -r '.rarity // "common"' "$STATE" 2>/dev/null)
+  reaction=$(jq -r '.reaction // ""' "$STATE" 2>/dev/null)
+  # Enforce TTL -- clear stale reactions
+  if [ -n "$reaction" ] && [ "$reaction" != "null" ] && ! reaction_fresh; then
+    reaction=""
+  fi
+  [ -f "$COMPANION" ] && eye=$(jq -r '.bones.eye // "o"' "$COMPANION" 2>/dev/null) || eye="o"
+
+  local C
+  C=$(rarity_color "$rarity")
+
+  local frame=$frame_idx blink=0
+  if [ "$frame" -eq -1 ]; then
+    blink=1
+    frame=0
+  fi
+
+  L1="" L2="" L3="" L4=""
+  get_art "$species" "$frame" "$eye"
+
+  if [ "$blink" -eq 1 ]; then
+    L1="${L1//$eye/-}"; L2="${L2//$eye/-}"
+    L3="${L3//$eye/-}"; L4="${L4//$eye/-}"
+  fi
+
+  # Build all output lines into an array, then write in one shot
+  local -a OUT=()
+  local row=1
+
+  # Bubble style chars
+  local bchar lside rside
+  if [ "$BUBBLE_STYLE" = "round" ]; then
+    bchar='~'; lside='('; rside=')'
+  else
+    bchar='-'; lside='|'; rside='|'
+  fi
+
+  # Collect art lines (hat + species art)
+  local -a ART_LINES=()
+  local hat_line=""
+  case "$hat" in
+    crown)     hat_line="\\^^^/" ;;
+    tophat)    hat_line="[___]" ;;
+    propeller) hat_line="-+-" ;;
+    halo)      hat_line="(   )" ;;
+    wizard)    hat_line="/^\\" ;;
+    beanie)    hat_line="(___)" ;;
+    tinyduck)  hat_line=",>" ;;
+  esac
+  [ -n "$hat_line" ] && ART_LINES+=("$hat_line")
+  for line in "$L1" "$L2" "$L3" "$L4"; do
+    [ -n "$line" ] && ART_LINES+=("$line")
+  done
+
+  # Find widest art line for block centering
+  local art_max_w=0
+  for al in "${ART_LINES[@]}"; do
+    [ ${#al} -gt "$art_max_w" ] && art_max_w=${#al}
+  done
+
+  # Determine if we have a reaction to show
+  local has_reaction=0
+  local -a BUBBLE_LINES_ARR=()
+  local -a BUBBLE_TYPES=()
+  if [ -n "$reaction" ] && [ "$reaction" != "null" ]; then
+    has_reaction=1
+  fi
+
+  if [ "$has_reaction" -eq 1 ] && [ "$BUBBLE_POSITION" = "left" ]; then
+    # ─── Left bubble: art stays in fixed right section, bubble on left ──
+    local art_w="${POPUP_ART_W:-$pane_w}"  # art area = base popup width
+    local bubble_area=$(( pane_w - art_w ))  # 0 when no extra width
+
+    if [ "$bubble_area" -gt 6 ]; then
+      local inner_w=$(( bubble_area - 6 ))  # lside(1)+space(1)+text+space(1)+rside(1) + gap(2)
+      [ "$inner_w" -lt 4 ] && inner_w=4
+      local box_w=$(( inner_w + 4 ))  # "| " + text + " |"
+      local gap=1
+
+      word_wrap "$reaction" "$inner_w"
+
+      # Build bubble box lines
+      local border
+      border=$(printf '%*s' "$((inner_w + 2))" '' | tr ' ' "$bchar")
+      BUBBLE_LINES_ARR+=(".${border}.")
+      BUBBLE_TYPES+=("border")
+      for tl in "${WRAPPED_LINES[@]}"; do
+        local tpad=$(( inner_w - ${#tl} ))
+        [ "$tpad" -lt 0 ] && tpad=0
+        local padding
+        padding=$(printf '%*s' "$tpad" '')
+        BUBBLE_LINES_ARR+=("${lside} ${tl}${padding} ${rside}")
+        BUBBLE_TYPES+=("text")
+      done
+      BUBBLE_LINES_ARR+=("\`${border}'")
+      BUBBLE_TYPES+=("border")
+
+      local bubble_count=${#BUBBLE_LINES_ARR[@]}
+      local art_count=${#ART_LINES[@]}
+
+      # Find connector line (middle text row)
+      local connector_bi=-1
+      if [ "$bubble_count" -gt 2 ]; then
+        connector_bi=$(( (1 + bubble_count - 2) / 2 ))
+      fi
+
+      # Vertically center bubble on art
+      local bubble_start=0
+      if [ "$bubble_count" -lt "$art_count" ]; then
+        bubble_start=$(( (art_count - bubble_count) / 2 ))
+      fi
+
+      local total_rows=$art_count
+      [ "$((bubble_start + bubble_count))" -gt "$total_rows" ] && total_rows=$((bubble_start + bubble_count))
+      local gap_str
+      for (( i=0; i<total_rows; i++ )); do
+        local bi=$(( i - bubble_start ))
+        local art_part=""
+        if [ "$i" -lt "$art_count" ]; then
+          art_part="${ART_LINES[$i]}"
+        fi
+
+        if [ "$bi" -ge 0 ] && [ "$bi" -lt "$bubble_count" ]; then
+          local bline="${BUBBLE_LINES_ARR[$bi]}"
+          local btype="${BUBBLE_TYPES[$bi]}"
+          # Pad bubble line to box_w
+          local bline_padded
+          bline_padded=$(printf '%-*s' "$box_w" "$bline")
+          if [ "$bi" -eq "$connector_bi" ]; then
+            gap_str="${C}--${NC}"
+          else
+            gap_str="  "
+          fi
+          if [ "$btype" = "border" ]; then
+            OUT+=("$(printf '\033[%d;1H' "$row")${DIM}${bline_padded}${NC}${gap_str}${C}$(center_block_line "$art_part" "$art_max_w" "$art_w")${NC}")
+          else
+            OUT+=("$(printf '\033[%d;1H' "$row")${DIM}${bline_padded}${NC}${gap_str}${C}$(center_block_line "$art_part" "$art_max_w" "$art_w")${NC}")
+          fi
+        else
+          local empty
+          empty=$(printf '%*s' "$((box_w + 2))" '')
+          OUT+=("$(printf '\033[%d;1H' "$row")${empty}${C}$(center_block_line "$art_part" "$art_max_w" "$art_w")${NC}")
+        fi
+        row=$((row + 1))
+      done
+    else
+      # Bubble area too narrow, fall back to art-only
+      for line in "${ART_LINES[@]}"; do
+        OUT+=("$(printf '\033[%d;1H%s%s%s' "$row" "$C" "$(center_pad "$line" "$pane_w")" "$NC")")
+        row=$((row + 1))
+      done
+    fi
+
+  else
+    # ─── Top bubble (or no bubble): original layout ─────────────────────
+    local bubble_w=$(( pane_w - 5 ))
+    [ "$bubble_w" -lt 8 ] && bubble_w=8
+
+    if [ "$has_reaction" -eq 1 ]; then
+      word_wrap "$reaction" "$bubble_w"
+      if [ ${#WRAPPED_LINES[@]} -gt 0 ]; then
+        local border
+        border=$(printf '%*s' "$((bubble_w + 2))" '' | tr ' ' "$bchar")
+        OUT+=("$(printf '\033[%d;1H%-*s' "$row" "$pane_w" " ${DIM}.${border}.${NC}")")
+        row=$((row + 1))
+        for tl in "${WRAPPED_LINES[@]}"; do
+          local tpad=$(( bubble_w - ${#tl} ))
+          [ "$tpad" -lt 0 ] && tpad=0
+          local padding
+          padding=$(printf '%*s' "$tpad" '')
+          OUT+=("$(printf '\033[%d;1H%-*s' "$row" "$pane_w" " ${DIM}${lside}${NC} ${tl}${padding} ${DIM}${rside}${NC}")")
+          row=$((row + 1))
+        done
+        OUT+=("$(printf '\033[%d;1H%-*s' "$row" "$pane_w" " ${DIM}\`${border}'${NC}")")
+        row=$((row + 1))
+        OUT+=("$(printf '\033[%d;1H%-*s' "$row" "$pane_w" "$(center_pad '\' "$pane_w")")")
+        row=$((row + 1))
+      fi
+    fi
+
+    # Art lines (hat + species) -- centered as a block
+    for line in "${ART_LINES[@]}"; do
+      OUT+=("$(printf '\033[%d;1H%s%s%s' "$row" "$C" "$(center_block_line "$line" "$art_max_w" "$pane_w")" "$NC")")
+      row=$((row + 1))
+    done
+  fi
+
+  # Width for name/stars: in left mode, keep them under the art area (right side)
+  local label_w="$pane_w"
+  local label_offset=""
+  local art_base="${POPUP_ART_W:-$pane_w}"
+  if [ "$BUBBLE_POSITION" = "left" ] && [ "$pane_w" -gt "$art_base" ]; then
+    label_w=$art_base
+    local offset_cols=$(( pane_w - art_base ))
+    label_offset=$(printf '%*s' "$offset_cols" '')
+  fi
+
+  # Blank line
+  OUT+=("$(printf '\033[%d;1H%*s' "$row" "$pane_w" '')")
+  row=$((row + 1))
+
+  # Name
+  OUT+=("$(printf '\033[%d;1H%s%s%s%s' "$row" "$label_offset" "${BOLD}${C}" "$(center_pad "$name" "$label_w")" "$NC")")
+  row=$((row + 1))
+
+  # Stars + rarity (uses SHOW_RARITY from startup config)
+  if [ "$SHOW_RARITY" -eq 1 ]; then
+    local stars
+    stars=$(rarity_stars "$rarity")
+    OUT+=("$(printf '\033[%d;1H%s%s%s%s' "$row" "$label_offset" "$DIM" "$(center_pad "$stars $rarity" "$label_w")" "$NC")")
+    row=$((row + 1))
+  fi
+
+  # Clear remaining rows
+  while [ "$row" -le "$PANE_H" ]; do
+    OUT+=("$(printf '\033[%d;1H%*s' "$row" "$pane_w" '')")
+    row=$((row + 1))
+  done
+
+  # Write everything at once (minimize flicker)
+  printf '%s' "${OUT[@]}"
+}
+
+# ─── Resize trigger ─────────────────────────────────────────────────────────
+# When reaction state changes (appears/disappears), request a popup resize
+# by writing a flag and killing the parent (perl forwarder). The reopen loop
+# sees the flag and reopens with the new height without forwarding ESC.
+
+request_resize() {
+  touch "$RESIZE_FLAG"
+  kill $PPID 2>/dev/null
+  exit 0
+}
+
+# ─── Main loop ───────────────────────────────────────────────────────────────
+
+# Initialize SHOWING_REACTION to match current state so we don't
+# trigger a spurious resize on startup (which causes flicker loops).
+if [ -f "$REACTION_FILE" ] && [ -f "$STATE" ]; then
+  _init_reaction=$(jq -r '.reaction // ""' "$STATE" 2>/dev/null || true)
+  if [ -n "$_init_reaction" ] && [ "$_init_reaction" != "null" ] && reaction_fresh; then
+    SHOWING_REACTION=1
+  fi
+fi
+
+# Initial clear
+printf '\033[2J'
+
+while true; do
+  [ -f "$STATE" ] || { sleep 0.5; continue; }
+
+  # Check if reaction state changed (need resize)
+  HAS_REACTION=0
+  if [ -f "$REACTION_FILE" ] && [ -f "$STATE" ]; then
+    local_reaction=$(jq -r '.reaction // ""' "$STATE" 2>/dev/null || true)
+    if [ -n "$local_reaction" ] && [ "$local_reaction" != "null" ] && reaction_fresh; then
+      HAS_REACTION=1
+    fi
+  fi
+
+  if [ "$HAS_REACTION" -ne "$SHOWING_REACTION" ]; then
+    SHOWING_REACTION=$HAS_REACTION
+    request_resize
+  fi
+
+  FRAME_IDX=${SEQ[$((TICK % SEQ_LEN))]}
+  render "$FRAME_IDX"
+  TICK=$((TICK + 1))
+  sleep 0.5
+done

--- a/popup/buddy-render.sh
+++ b/popup/buddy-render.sh
@@ -15,10 +15,14 @@ PANE_W="${POPUP_INNER_W:-$(tput cols 2>/dev/null || echo 24)}"
 PANE_H="${POPUP_INNER_H:-$(tput lines 2>/dev/null || echo 14)}"
 
 BUDDY_STATE_DIR="${BUDDY_DIR:-$HOME/.claude-buddy}"
+# Session ID from env (set by popup-manager via -e or env file)
+_SID="${BUDDY_SID:-${CC_PANE#%}}"
+_SID="${_SID:-default}"
+
 STATE="$BUDDY_STATE_DIR/status.json"
 COMPANION="$BUDDY_STATE_DIR/companion.json"
-REACTION_FILE="$BUDDY_STATE_DIR/reaction.json"
-RESIZE_FLAG="$BUDDY_STATE_DIR/popup-resize"
+REACTION_FILE="$BUDDY_STATE_DIR/reaction.$_SID.json"
+RESIZE_FLAG="$BUDDY_STATE_DIR/popup-resize.$_SID"
 REACTION_TTL=20  # seconds
 CONFIG_FILE="$BUDDY_STATE_DIR/config.json"
 

--- a/popup/popup-manager.sh
+++ b/popup/popup-manager.sh
@@ -17,8 +17,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BUDDY_DIR="$HOME/.claude-buddy"
-STOP_FLAG="$BUDDY_DIR/popup-stop"
-REOPEN_PID_FILE="$BUDDY_DIR/popup-reopen-pid"
+
+# Session ID: sanitized tmux pane number, or "default" outside tmux
+SID="${TMUX_PANE#%}"
+SID="${SID:-default}"
+
+STOP_FLAG="$BUDDY_DIR/popup-stop.$SID"
+REOPEN_PID_FILE="$BUDDY_DIR/popup-reopen-pid.$SID"
 STATE_FILE="$BUDDY_DIR/status.json"
 
 POPUP_W=12       # minimum / fallback
@@ -26,8 +31,8 @@ ART_W=12         # updated dynamically by compute_art_width
 BUBBLE_EXTRA=3 # border top + border bottom + connector line
 BORDER_EXTRA=0 # +2 on tmux < 3.3 (popup has a border)
 REACTION_TTL=20 # seconds
-REACTION_FILE="$BUDDY_DIR/reaction.json"
-RESIZE_FLAG="$BUDDY_DIR/popup-resize"
+REACTION_FILE="$BUDDY_DIR/reaction.$SID.json"
+RESIZE_FLAG="$BUDDY_DIR/popup-resize.$SID"
 CONFIG_FILE="$BUDDY_DIR/config.json"
 LEFT_BUBBLE_W=22 # bubble box width in left mode (including frame chars)
 
@@ -178,8 +183,7 @@ start_popup() {
   is_tmux || { echo "Not in tmux" >&2; return 1; }
   tmux_version_ok || { echo "tmux >= 3.2 required for popup" >&2; return 1; }
 
-  # Kill any existing reopen loop (stale from a previous CC session).
-  # SessionStart fires once per session, so any running loop is from an old session.
+  # Kill stale reopen loop for THIS session (e.g., CC restarted in same pane)
   if [ -f "$REOPEN_PID_FILE" ]; then
     local old_pid
     old_pid=$(cat "$REOPEN_PID_FILE" 2>/dev/null)
@@ -190,6 +194,21 @@ start_popup() {
     tmux display-popup -C 2>/dev/null || true
     sleep 0.2
   fi
+
+  # Clean up orphaned per-session files (from crashed sessions)
+  for pidfile in "$BUDDY_DIR"/popup-reopen-pid.*; do
+    [ -f "$pidfile" ] || continue
+    local orphan_sid="${pidfile##*.}"
+    local orphan_pane="%${orphan_sid}"
+    if ! cc_pane_alive "$orphan_pane"; then
+      local orphan_pid
+      orphan_pid=$(cat "$pidfile" 2>/dev/null)
+      [ -n "$orphan_pid" ] && kill "$orphan_pid" 2>/dev/null || true
+      rm -f "$pidfile" "$BUDDY_DIR/popup-stop.$orphan_sid" "$BUDDY_DIR/popup-resize.$orphan_sid"
+      rm -f "$BUDDY_DIR/popup-env.$orphan_sid" "$BUDDY_DIR/popup-scroll.$orphan_sid"
+      rm -f "$BUDDY_DIR/reaction.$orphan_sid.json" "$BUDDY_DIR/.last_reaction.$orphan_sid" "$BUDDY_DIR/.last_comment.$orphan_sid"
+    fi
+  done
 
   mkdir -p "$BUDDY_DIR"
   rm -f "$STOP_FLAG" "$RESIZE_FLAG"
@@ -232,7 +251,7 @@ start_popup() {
         th=$(tmux display-message -p '#{window_height}' 2>/dev/null || echo 24)
         popup_args+=(-B -s 'bg=default')
         popup_args+=(-x $(( tw - COMPUTED_W )) -y $(( th )))
-        popup_args+=(-e "CC_PANE=$cc_pane" -e "BUDDY_DIR=$BUDDY_DIR")
+        popup_args+=(-e "CC_PANE=$cc_pane" -e "BUDDY_DIR=$BUDDY_DIR" -e "BUDDY_SID=$SID")
         popup_args+=(-e "POPUP_INNER_W=$COMPUTED_W" -e "POPUP_INNER_H=$COMPUTED_H")
         popup_args+=(-e "POPUP_ART_W=$ART_W")
       else
@@ -245,9 +264,10 @@ start_popup() {
         local inner_w=$(( COMPUTED_W - 2 ))
         local inner_h=$(( COMPUTED_H - 2 ))
         # Write env vars to file (tmux 3.2-3.3 lack -e flag)
-        cat > "$BUDDY_DIR/popup-env" <<ENVEOF
+        cat > "$BUDDY_DIR/popup-env.$SID" <<ENVEOF
 CC_PANE=$cc_pane
 BUDDY_DIR=$BUDDY_DIR
+BUDDY_SID=$SID
 POPUP_INNER_W=$inner_w
 POPUP_INNER_H=$inner_h
 POPUP_ART_W=$ART_W
@@ -260,7 +280,7 @@ ENVEOF
         "${popup_args[@]}" \
         -w "$COMPUTED_W" -h "$COMPUTED_H" \
         -E \
-        "$SCRIPT_DIR/buddy-popup.sh" \
+        "$SCRIPT_DIR/buddy-popup.sh" "$SID" \
         2>/dev/null || true
 
       # Popup closed. Check why.
@@ -268,8 +288,8 @@ ENVEOF
       cc_pane_alive "$cc_pane" || break
 
       # Scroll flag = F12 pressed, enter copy-mode and wait
-      if [ -f "$BUDDY_DIR/popup-scroll" ]; then
-        rm -f "$BUDDY_DIR/popup-scroll"
+      if [ -f "$BUDDY_DIR/popup-scroll.$SID" ]; then
+        rm -f "$BUDDY_DIR/popup-scroll.$SID"
         tmux copy-mode -t "$cc_pane" 2>/dev/null || true
         # Wait until copy-mode ends before reopening popup
         while tmux display-message -t "$cc_pane" -p '#{pane_in_mode}' 2>/dev/null | grep -q '^1$'; do
@@ -309,6 +329,10 @@ stop_popup() {
     kill "$pid" 2>/dev/null || true
     rm -f "$REOPEN_PID_FILE"
   fi
+  # Clean up per-session files
+  rm -f "$BUDDY_DIR/popup-stop.$SID" "$BUDDY_DIR/popup-resize.$SID"
+  rm -f "$BUDDY_DIR/popup-env.$SID" "$BUDDY_DIR/popup-scroll.$SID"
+  rm -f "$BUDDY_DIR/reaction.$SID.json" "$BUDDY_DIR/.last_reaction.$SID" "$BUDDY_DIR/.last_comment.$SID"
 }
 
 # ─── Status ──────────────────────────────────────────────────────────────────

--- a/popup/popup-manager.sh
+++ b/popup/popup-manager.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# claude-buddy popup manager -- create/destroy tmux popup overlay
+#
+# Usage:
+#   popup-manager.sh start   -- open buddy popup (bottom-right corner)
+#   popup-manager.sh stop    -- close buddy popup
+#   popup-manager.sh status  -- check if popup is running
+#
+# Called by SessionStart/SessionEnd hooks.
+#
+# Architecture: The "start" command runs a blocking reopen loop.
+# tmux display-popup blocks until the popup closes. When ESC closes
+# the popup (hardcoded tmux behavior), we forward ESC to CC and
+# reopen. The loop exits when: stop flag is set, or CC pane dies.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUDDY_DIR="$HOME/.claude-buddy"
+STOP_FLAG="$BUDDY_DIR/popup-stop"
+REOPEN_PID_FILE="$BUDDY_DIR/popup-reopen-pid"
+STATE_FILE="$BUDDY_DIR/status.json"
+
+POPUP_W=12       # minimum / fallback
+ART_W=12         # updated dynamically by compute_art_width
+BUBBLE_EXTRA=3 # border top + border bottom + connector line
+BORDER_EXTRA=0 # +2 on tmux < 3.3 (popup has a border)
+REACTION_TTL=20 # seconds
+REACTION_FILE="$BUDDY_DIR/reaction.json"
+RESIZE_FLAG="$BUDDY_DIR/popup-resize"
+CONFIG_FILE="$BUDDY_DIR/config.json"
+LEFT_BUBBLE_W=22 # bubble box width in left mode (including frame chars)
+
+# Read config early (needed for BASE_H calculation)
+BUBBLE_POSITION="top"
+SHOW_RARITY=1
+if [ -f "$CONFIG_FILE" ]; then
+  _bp=$(jq -r '.bubblePosition // "top"' "$CONFIG_FILE" 2>/dev/null || echo "top")
+  case "$_bp" in top|left) BUBBLE_POSITION="$_bp" ;; esac
+  _sr=$(jq -r 'if .showRarity == false then "false" else "true" end' "$CONFIG_FILE" 2>/dev/null || echo "true")
+  [ "$_sr" = "false" ] && SHOW_RARITY=0
+fi
+
+BASE_H=8      # art(4) + blank(1) + name(1) + rarity(1) + padding(1)
+[ "$SHOW_RARITY" -eq 0 ] && BASE_H=7
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+is_tmux() {
+  [ -n "${TMUX:-}" ]
+}
+
+tmux_version_ok() {
+  local ver
+  ver=$(tmux -V 2>/dev/null | grep -oE '[0-9]+\.[0-9a-z]+' | head -1)
+  [ -z "$ver" ] && return 1
+  local major minor
+  major="${ver%%.*}"
+  minor="${ver#*.}"
+  minor="${minor%%[a-z]*}"
+  [ "$major" -gt 3 ] 2>/dev/null && return 0
+  [ "$major" -eq 3 ] && [ "$minor" -ge 2 ] 2>/dev/null && return 0
+  return 1
+}
+
+# tmux 3.4+ supports -B (borderless), -e (env), and -x R/-y S positioning
+tmux_has_borderless() {
+  local ver
+  ver=$(tmux -V 2>/dev/null | grep -oE '[0-9]+\.[0-9a-z]+' | head -1)
+  [ -z "$ver" ] && return 1
+  local major minor
+  major="${ver%%.*}"
+  minor="${ver#*.}"
+  minor="${minor%%[a-z]*}"
+  [ "$major" -gt 3 ] 2>/dev/null && return 0
+  [ "$major" -eq 3 ] && [ "$minor" -ge 4 ] 2>/dev/null && return 0
+  return 1
+}
+
+cc_pane_alive() {
+  tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qF "$1"
+}
+
+# Compute popup width from buddy data (widest of: art, name, stars+rarity)
+compute_art_width() {
+  [ -f "$STATE_FILE" ] || return
+  local name rarity
+  name=$(jq -r '.name // ""' "$STATE_FILE" 2>/dev/null)
+  rarity=$(jq -r '.rarity // "common"' "$STATE_FILE" 2>/dev/null)
+  local w=10  # minimum art width
+  # Name length
+  [ ${#name} -gt "$w" ] && w=${#name}
+  # Stars + rarity line (only if enabled)
+  if [ "$SHOW_RARITY" -eq 1 ]; then
+    local stars_w=$(( 6 + ${#rarity} ))
+    [ "$stars_w" -gt "$w" ] && w=$stars_w
+  fi
+  # Add 2 for padding
+  w=$(( w + 2 ))
+  POPUP_W=$w
+  ART_W=$w
+}
+
+# Compute popup dimensions based on reaction state and bubble position
+# Sets COMPUTED_W and COMPUTED_H
+compute_dimensions() {
+  compute_art_width
+  local h=$BASE_H
+  local w=$POPUP_W
+  h=$(( h + BORDER_EXTRA ))
+  w=$(( w + BORDER_EXTRA ))
+
+  # Account for hat (adds 1 art row beyond the 4 in BASE_H)
+  local art_rows=4
+  if [ -f "$STATE_FILE" ]; then
+    local _hat
+    _hat=$(jq -r '.hat // "none"' "$STATE_FILE" 2>/dev/null || echo "none")
+    if [ "$_hat" != "none" ]; then
+      h=$(( h + 1 ))
+      art_rows=5
+    fi
+  fi
+
+  local fresh=0
+  if [ -f "$STATE_FILE" ]; then
+    local reaction
+    reaction=$(jq -r '.reaction // ""' "$STATE_FILE" 2>/dev/null || true)
+    if [ -n "$reaction" ] && [ "$reaction" != "null" ]; then
+      if [ -f "$REACTION_FILE" ]; then
+        local ts now age
+        ts=$(jq -r '.timestamp // 0' "$REACTION_FILE" 2>/dev/null || echo 0)
+        if [ "$ts" != "0" ]; then
+          now=$(date +%s)
+          age=$(( now - ts / 1000 ))
+          [ "$age" -lt "$REACTION_TTL" ] && fresh=1
+        fi
+      fi
+      if [ "$fresh" -eq 1 ]; then
+        if [ "$BUBBLE_POSITION" = "top" ]; then
+          # Top mode: bubble adds rows above the art
+          local bubble_w=$(( POPUP_W - BORDER_EXTRA - 5 ))
+          [ "$bubble_w" -lt 20 ] && bubble_w=20
+          # Widen popup if bubble needs more room than art
+          local needed_w=$(( bubble_w + 5 + BORDER_EXTRA ))
+          [ "$needed_w" -gt "$w" ] && w=$needed_w
+          local len=${#reaction}
+          local lines=$(( (len + bubble_w - 1) / bubble_w ))
+          [ "$lines" -lt 1 ] && lines=1
+          h=$(( h + lines + BUBBLE_EXTRA ))
+        else
+          # Left mode: dynamic bubble width to fit text within art height
+          local max_text_lines=$(( art_rows - 2 ))  # subtract top/bottom borders
+          [ "$max_text_lines" -lt 1 ] && max_text_lines=1
+          local len=${#reaction}
+          local left_inner=$(( (len + max_text_lines - 1) / max_text_lines + 5 ))
+          [ "$left_inner" -lt 10 ] && left_inner=10
+          [ "$left_inner" -gt 50 ] && left_inner=50
+          local left_box=$(( left_inner + 4 ))  # "| " + text + " |"
+          w=$(( w + left_box + 2 ))  # +2 for connector gap
+        fi
+      fi
+    fi
+  fi
+  COMPUTED_W=$w
+  COMPUTED_H=$h
+}
+
+is_reopen_running() {
+  [ -f "$REOPEN_PID_FILE" ] || return 1
+  local pid
+  pid=$(cat "$REOPEN_PID_FILE")
+  kill -0 "$pid" 2>/dev/null
+}
+
+# ─── Start ───────────────────────────────────────────────────────────────────
+
+start_popup() {
+  is_tmux || { echo "Not in tmux" >&2; return 1; }
+  tmux_version_ok || { echo "tmux >= 3.2 required for popup" >&2; return 1; }
+
+  # Kill any existing reopen loop (stale from a previous CC session).
+  # SessionStart fires once per session, so any running loop is from an old session.
+  if [ -f "$REOPEN_PID_FILE" ]; then
+    local old_pid
+    old_pid=$(cat "$REOPEN_PID_FILE" 2>/dev/null)
+    if [ -n "$old_pid" ]; then
+      kill "$old_pid" 2>/dev/null || true
+    fi
+    rm -f "$REOPEN_PID_FILE"
+    tmux display-popup -C 2>/dev/null || true
+    sleep 0.2
+  fi
+
+  mkdir -p "$BUDDY_DIR"
+  rm -f "$STOP_FLAG" "$RESIZE_FLAG"
+
+  # tmux < 3.4 popups have a border (+2 rows, +2 cols); 3.4+ supports -B borderless
+  if ! tmux_has_borderless; then
+    BORDER_EXTRA=2
+    POPUP_W=$(( POPUP_W + 2 ))
+  fi
+
+  # Capture CC's pane ID before creating the popup
+  local cc_pane
+  cc_pane=$(tmux display-message -p '#{pane_id}')
+
+  # Run the reopen loop in background so the hook returns immediately.
+  # CRITICAL: Redirect stdio to /dev/null so the subshell doesn't inherit
+  # the parent's stdout pipe. CC's hook executor waits for ALL stdio writers
+  # to close before resolving -- without this redirect, the hook hangs forever
+  # because the long-lived subshell keeps the pipe open.
+  (
+    # Write the subshell PID. $BASHPID gives the subshell's PID on bash 4+.
+    # On macOS bash 3.2, $BASHPID doesn't exist, so we use sh -c 'echo $PPID'
+    # which prints the PID of the parent (this subshell) from a child process.
+    echo "${BASHPID:-$(sh -c 'echo $PPID')}" > "$REOPEN_PID_FILE"
+
+    while true; do
+      # Check stop conditions before (re)opening
+      [ -f "$STOP_FLAG" ] && break
+      cc_pane_alive "$cc_pane" || break
+
+      compute_dimensions
+
+      # Build popup args. tmux 3.4+ supports -B (borderless), -x R/-y S,
+      # and -e (env passing). On 3.2-3.3, we fall back to absolute positioning
+      # and pass env vars via a file.
+      local popup_args=()
+      if tmux_has_borderless; then
+        local tw th
+        tw=$(tmux display-message -p '#{window_width}' 2>/dev/null || echo 80)
+        th=$(tmux display-message -p '#{window_height}' 2>/dev/null || echo 24)
+        popup_args+=(-B -s 'bg=default')
+        popup_args+=(-x $(( tw - COMPUTED_W )) -y $(( th )))
+        popup_args+=(-e "CC_PANE=$cc_pane" -e "BUDDY_DIR=$BUDDY_DIR")
+        popup_args+=(-e "POPUP_INNER_W=$COMPUTED_W" -e "POPUP_INNER_H=$COMPUTED_H")
+        popup_args+=(-e "POPUP_ART_W=$ART_W")
+      else
+        # Fallback: position at bottom-right using absolute coords
+        local tw th
+        tw=$(tmux display-message -p '#{window_width}' 2>/dev/null || echo 80)
+        th=$(tmux display-message -p '#{window_height}' 2>/dev/null || echo 24)
+        popup_args+=(-x $(( tw - COMPUTED_W )) -y $(( th - COMPUTED_H )))
+        # Inner dimensions = outer - 2 (border takes 1 on each side)
+        local inner_w=$(( COMPUTED_W - 2 ))
+        local inner_h=$(( COMPUTED_H - 2 ))
+        # Write env vars to file (tmux 3.2-3.3 lack -e flag)
+        cat > "$BUDDY_DIR/popup-env" <<ENVEOF
+CC_PANE=$cc_pane
+BUDDY_DIR=$BUDDY_DIR
+POPUP_INNER_W=$inner_w
+POPUP_INNER_H=$inner_h
+POPUP_ART_W=$ART_W
+ENVEOF
+      fi
+
+      # display-popup blocks until popup closes (ESC or command exit)
+      # -E = close when command exits
+      tmux display-popup \
+        "${popup_args[@]}" \
+        -w "$COMPUTED_W" -h "$COMPUTED_H" \
+        -E \
+        "$SCRIPT_DIR/buddy-popup.sh" \
+        2>/dev/null || true
+
+      # Popup closed. Check why.
+      [ -f "$STOP_FLAG" ] && break
+      cc_pane_alive "$cc_pane" || break
+
+      # Scroll flag = F12 pressed, enter copy-mode and wait
+      if [ -f "$BUDDY_DIR/popup-scroll" ]; then
+        rm -f "$BUDDY_DIR/popup-scroll"
+        tmux copy-mode -t "$cc_pane" 2>/dev/null || true
+        # Wait until copy-mode ends before reopening popup
+        while tmux display-message -t "$cc_pane" -p '#{pane_in_mode}' 2>/dev/null | grep -q '^1$'; do
+          [ -f "$STOP_FLAG" ] && break 2
+          cc_pane_alive "$cc_pane" || break 2
+          sleep 0.3
+        done
+      # Resize flag = render loop requested a resize, not an ESC press
+      elif [ -f "$RESIZE_FLAG" ]; then
+        rm -f "$RESIZE_FLAG"
+      else
+        # ESC closed the popup -- forward ESC to CC
+        tmux send-keys -t "$cc_pane" Escape 2>/dev/null || true
+      fi
+      sleep 0.1
+    done
+
+    rm -f "$REOPEN_PID_FILE"
+  ) </dev/null &>/dev/null &
+  disown
+
+  return 0
+}
+
+# ─── Stop ────────────────────────────────────────────────────────────────────
+
+stop_popup() {
+  mkdir -p "$BUDDY_DIR"
+  # Set stop flag so reopen loop exits
+  touch "$STOP_FLAG"
+  # Close any open popup on the current client
+  tmux display-popup -C 2>/dev/null || true
+  # Kill reopen loop if still running
+  if [ -f "$REOPEN_PID_FILE" ]; then
+    local pid
+    pid=$(cat "$REOPEN_PID_FILE")
+    kill "$pid" 2>/dev/null || true
+    rm -f "$REOPEN_PID_FILE"
+  fi
+}
+
+# ─── Status ──────────────────────────────────────────────────────────────────
+
+popup_status() {
+  if is_reopen_running; then
+    echo "running"
+  else
+    echo "stopped"
+  fi
+}
+
+# ─── Dispatch ────────────────────────────────────────────────────────────────
+
+case "${1:-status}" in
+  start)  start_popup ;;
+  stop)   stop_popup ;;
+  status) popup_status ;;
+  *)      echo "Usage: $0 {start|stop|status}" >&2; exit 1 ;;
+esac

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,7 @@ import {
 import {
   loadCompanion, saveCompanion, resolveUserId,
   loadReaction, saveReaction, writeStatusState,
+  loadConfig, saveConfig,
 } from "./state.ts";
 import {
   getReaction, generateFallbackName, generatePersonalityPrompt,
@@ -193,7 +194,53 @@ server.tool(
   },
 );
 
-// ─── Tool: buddy_mute / buddy_unmute ────────────────────────────────────────
+// ─── Tool: buddy_frequency / buddy_style ─────────────────────────────────────
+
+server.tool(
+  "buddy_frequency",
+  "Configure how often buddy comments appear in the speech bubble. Returns current settings if called without arguments.",
+  {
+    cooldown: z.number().int().min(5).max(300).optional().describe("Minimum seconds between displayed comments (default 30). The buddy always writes comments, but the display only updates this often."),
+  },
+  async ({ cooldown }) => {
+    if (cooldown === undefined) {
+      const cfg = loadConfig();
+      return {
+        content: [{ type: "text", text: `Comment cooldown: ${cfg.commentCooldown}s between displayed comments.\nUse /buddy frequency <seconds> to change.` }],
+      };
+    }
+    const cfg = saveConfig({ commentCooldown: cooldown });
+    return {
+      content: [{ type: "text", text: `Updated: ${cfg.commentCooldown}s cooldown between displayed comments.` }],
+    };
+  },
+);
+
+server.tool(
+  "buddy_style",
+  "Configure the popup appearance. Returns current settings if called without arguments.",
+  {
+    style: z.enum(["classic", "round"]).optional().describe("Bubble border style: classic (pipes/dashes like status line) or round (parens/tildes)"),
+    position: z.enum(["top", "left"]).optional().describe("Bubble position relative to buddy: top (above) or left (beside)"),
+    showRarity: z.boolean().optional().describe("Show or hide the stars + rarity line in the popup"),
+  },
+  async ({ style, position, showRarity }) => {
+    if (style === undefined && position === undefined && showRarity === undefined) {
+      const cfg = loadConfig();
+      return {
+        content: [{ type: "text", text: `Bubble style: ${cfg.bubbleStyle}\nBubble position: ${cfg.bubblePosition}\nShow rarity: ${cfg.showRarity}\nUse /buddy style <classic|round>, /buddy position <top|left>, /buddy rarity <on|off> to change.` }],
+      };
+    }
+    const updates: Record<string, string | boolean> = {};
+    if (style !== undefined) updates.bubbleStyle = style;
+    if (position !== undefined) updates.bubblePosition = position;
+    if (showRarity !== undefined) updates.showRarity = showRarity;
+    const cfg = saveConfig(updates);
+    return {
+      content: [{ type: "text", text: `Updated: style=${cfg.bubbleStyle}, position=${cfg.bubblePosition}, showRarity=${cfg.showRarity}\nRestart Claude Code for changes to take effect.` }],
+    };
+  },
+);
 
 server.tool(
   "buddy_mute",
@@ -252,7 +299,7 @@ server.resource(
       `**${companion.name}'s personality:** ${companion.personality}`,
       `Peak stat: ${companion.bones.peak} (${companion.bones.stats[companion.bones.peak]}). Dump stat: ${companion.bones.dump} (${companion.bones.stats[companion.bones.dump]}).`,
       "",
-      "## End-of-response buddy comment (MANDATORY)",
+      "## End-of-response buddy comment",
       "",
       `At the very end of EVERY response, after your full answer, append an invisible HTML comment:`,
       "",

--- a/server/state.ts
+++ b/server/state.ts
@@ -10,6 +10,7 @@ import type { Companion, BuddyBones } from "./engine.ts";
 const STATE_DIR = join(homedir(), ".claude-buddy");
 const COMPANION_FILE = join(STATE_DIR, "companion.json");
 const REACTION_FILE = join(STATE_DIR, "reaction.json");
+const CONFIG_FILE = join(STATE_DIR, "config.json");
 
 function ensureDir(): void {
   if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
@@ -48,8 +49,8 @@ export interface ReactionState {
 export function loadReaction(): ReactionState | null {
   try {
     const data: ReactionState = JSON.parse(readFileSync(REACTION_FILE, "utf8"));
-    // Reactions expire after 60 seconds
-    if (Date.now() - data.timestamp > 60_000) return null;
+    // Reactions expire after 20 seconds (matches shell display TTL)
+    if (Date.now() - data.timestamp > 20_000) return null;
     return data;
   } catch {
     return null;
@@ -88,6 +89,41 @@ export interface StatusState {
   reaction: string;
   muted: boolean;
 }
+
+// ─── Config persistence ────────────────────────────────────────────────────
+
+export interface BuddyConfig {
+  commentCooldown: number;  // min seconds between displayed comments (default 30)
+  bubbleStyle: "classic" | "round";  // classic = pipes/dashes, round = parens/tildes
+  bubblePosition: "top" | "left";  // top = above buddy, left = beside buddy
+  showRarity: boolean;  // show stars + rarity line in popup
+}
+
+const DEFAULT_CONFIG: BuddyConfig = {
+  commentCooldown: 30,
+  bubbleStyle: "classic",
+  bubblePosition: "top",
+  showRarity: true,
+};
+
+export function loadConfig(): BuddyConfig {
+  try {
+    const data = JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
+    return { ...DEFAULT_CONFIG, ...data };
+  } catch {
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function saveConfig(config: Partial<BuddyConfig>): BuddyConfig {
+  ensureDir();
+  const current = loadConfig();
+  const merged = { ...current, ...config };
+  writeFileSync(CONFIG_FILE, JSON.stringify(merged, null, 2));
+  return merged;
+}
+
+// ─── Status line state (compact JSON for the shell script) ──────────────────
 
 export function writeStatusState(companion: Companion, reaction?: string, muted?: boolean): void {
   ensureDir();

--- a/server/state.ts
+++ b/server/state.ts
@@ -9,8 +9,18 @@ import type { Companion, BuddyBones } from "./engine.ts";
 
 const STATE_DIR = join(homedir(), ".claude-buddy");
 const COMPANION_FILE = join(STATE_DIR, "companion.json");
-const REACTION_FILE = join(STATE_DIR, "reaction.json");
 const CONFIG_FILE = join(STATE_DIR, "config.json");
+
+// Session ID: sanitized tmux pane number, or "default" outside tmux
+function sessionId(): string {
+  const pane = process.env.TMUX_PANE;
+  if (!pane) return "default";
+  return pane.replace(/^%/, "");
+}
+
+function reactionFile(): string {
+  return join(STATE_DIR, `reaction.${sessionId()}.json`);
+}
 
 function ensureDir(): void {
   if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
@@ -48,7 +58,7 @@ export interface ReactionState {
 
 export function loadReaction(): ReactionState | null {
   try {
-    const data: ReactionState = JSON.parse(readFileSync(REACTION_FILE, "utf8"));
+    const data: ReactionState = JSON.parse(readFileSync(reactionFile(), "utf8"));
     // Reactions expire after 20 seconds (matches shell display TTL)
     if (Date.now() - data.timestamp > 20_000) return null;
     return data;
@@ -60,7 +70,7 @@ export function loadReaction(): ReactionState | null {
 export function saveReaction(reaction: string, reason: string): void {
   ensureDir();
   const state: ReactionState = { reaction, timestamp: Date.now(), reason };
-  writeFileSync(REACTION_FILE, JSON.stringify(state));
+  writeFileSync(reactionFile(), JSON.stringify(state));
 }
 
 // ─── Identity resolution ────────────────────────────────────────────────────

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buddy
 description: "Show, pet, or manage your coding companion. Use when the user types /buddy or mentions their companion by name."
-argument-hint: "[show|pet|off|on|stats|rename <name>|personality <text>]"
+argument-hint: "[show|pet|off|on|stats|rename <name>|personality <text>|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]]"
 allowed-tools: mcp__claude_buddy__*
 ---
 
@@ -22,6 +22,14 @@ Based on `$ARGUMENTS`:
 | `on` | Call `buddy_unmute` |
 | `rename <name>` | Call `buddy_rename` with the given name |
 | `personality <text>` | Call `buddy_set_personality` with the given text |
+| `frequency` | Call `buddy_frequency` with no args (show current) |
+| `frequency <seconds>` | Call `buddy_frequency` with cooldown=seconds |
+| `style` | Call `buddy_style` with no args (show current) |
+| `style <classic\|round>` | Call `buddy_style` with style arg |
+| `position` | Call `buddy_style` with no args (show current) |
+| `position <top\|left>` | Call `buddy_style` with position arg |
+| `rarity on` | Call `buddy_style` with showRarity=true |
+| `rarity off` | Call `buddy_style` with showRarity=false |
 
 ## CRITICAL OUTPUT RULES
 

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -11,6 +11,9 @@
 
 STATE="$HOME/.claude-buddy/status.json"
 COMPANION="$HOME/.claude-buddy/companion.json"
+# Session ID: sanitized tmux pane number, or "default" outside tmux
+SID="${TMUX_PANE#%}"
+SID="${SID:-default}"
 
 [ -f "$STATE" ] || exit 0
 [ -f "$COMPANION" ] || exit 0
@@ -209,7 +212,7 @@ esac
 
 # ─── Reaction bubble (with TTL check) ────────────────────────────────────────
 BUBBLE=""
-REACTION_FILE="$HOME/.claude-buddy/reaction.json"
+REACTION_FILE="$HOME/.claude-buddy/reaction.$SID.json"
 if [ -n "$REACTION" ] && [ "$REACTION" != "null" ] && [ "$REACTION" != "" ]; then
     # Only show if reaction is fresh (< 20s old)
     FRESH=0

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -207,10 +207,21 @@ case "$HAT" in
   tinyduck)  HAT_LINE="  ,>" ;;
 esac
 
-# ─── Reaction bubble ─────────────────────────────────────────────────────────
+# ─── Reaction bubble (with TTL check) ────────────────────────────────────────
 BUBBLE=""
+REACTION_FILE="$HOME/.claude-buddy/reaction.json"
 if [ -n "$REACTION" ] && [ "$REACTION" != "null" ] && [ "$REACTION" != "" ]; then
-    BUBBLE="\"${REACTION}\""
+    # Only show if reaction is fresh (< 20s old)
+    FRESH=0
+    if [ -f "$REACTION_FILE" ]; then
+        TS=$(jq -r '.timestamp // 0' "$REACTION_FILE" 2>/dev/null || echo 0)
+        if [ "$TS" != "0" ]; then
+            NOW=$(date +%s)
+            AGE=$(( NOW - TS / 1000 ))
+            [ "$AGE" -lt 20 ] && FRESH=1
+        fi
+    fi
+    [ "$FRESH" -eq 1 ] && BUBBLE="\"${REACTION}\""
 fi
 
 # ─── Build art lines ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #5

- Floating tmux popup overlay in bottom-right corner as alternative to status line
- ESC passthrough (reopens after forwarding ESC to Claude Code)
- Dynamic resizing when reactions appear/disappear
- Keyboard input forwarding via raw perl forwarder
- Configurable appearance: bubble style, position, rarity visibility, comment cooldown
- F12 scroll mode (hides popup, enters tmux copy-mode)
- tmux 3.4+ (borderless), 3.2-3.3 (bordered fallback), no tmux (status line)

## Test plan

- [ ] Install with `bun run install-buddy` inside tmux
- [ ] Verify popup appears in bottom-right corner on restart
- [ ] ESC closes and reopens popup, forwards ESC to CC
- [ ] Buddy reacts to errors/test failures in speech bubble
- [ ] Popup resizes when reaction appears/expires
- [ ] `/buddy style round`, `/buddy position left`, `/buddy rarity off` work
- [ ] `/buddy frequency 60` changes cooldown
- [ ] Install outside tmux falls back to status line
- [ ] `bun run cli/uninstall.ts` cleanly removes everything