### PR TITLE
Fix react.sh: PostToolUse hook field is .tool_response, not .tool_result

### DIFF
--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -22,8 +22,10 @@ if [ -f "$COOLDOWN_FILE" ]; then
     [ "$DIFF" -lt 15 ] && exit 0
 fi
 
-# Extract tool result
-RESULT=$(echo "$INPUT" | jq -r '.tool_result // ""' 2>/dev/null)
+# Extract tool response (PostToolUse schema field is .tool_response — not
+# .tool_result, which is the Anthropic SDK's content-block type name and is
+# never a key on the hook input payload).
+RESULT=$(echo "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null)
 [ -z "$RESULT" ] && exit 0
 
 # Read species for species-aware reactions


### PR DESCRIPTION
## Bug

`hooks/react.sh` extracts the PostToolUse tool output via `.tool_result`, but the schema field is `.tool_response`. `jq -r '.tool_result // ""'` always returns empty, the `-z` guard exits, and the hook has been dead code since v0.1.0 — no reactions, no error classification.

`tool_result` is the Anthropic SDK's content-block type (`{type: "tool_result", ...}`), unrelated to hook input payloads. Easy to conflate.

## Evidence

Compiled Zod schema pulled from the installed Claude Code v2.1.100 binary:

```js
N.object({
  hook_event_name: N.literal("PostToolUse"),
  tool_name: N.string(),
  tool_input: N.unknown(),
  tool_response: N.unknown(),
  tool_use_id: N.string()
})
```

Every jq example in the binary's bundled `updateConfig` skill uses `.tool_response.*`.

## Fix

```diff
-RESULT=$(echo "$INPUT" | jq -r '.tool_result // ""' 2>/dev/null)
+RESULT=$(echo "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null)
```