### PR TITLE
feat: add disable/enable, help command, and /buddy helpFeat/disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ bun run install-buddy
 
 Fully automated. No manual config. Backup is optional but recommended — restore anytime with `bun run backup restore`.
 
+**Optional:** Make `claude-buddy` available as a global command:
+
+```bash
+bun link
+```
+
+Then you can use `claude-buddy <command>` from anywhere instead of `bun run <command>`. Try `claude-buddy help` for all available commands.
+
 ### What the installer does
 
 | Step | Target file | What it configures |

--- a/cli/disable.ts
+++ b/cli/disable.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+/**
+ * claude-buddy disable — temporarily deactivate buddy without losing data
+ *
+ * Removes: MCP server, status line, hooks
+ * Keeps: companion data, backups, skill files
+ *
+ * Re-enable with: bun run install-buddy
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const NC = "\x1b[0m";
+
+function ok(msg: string) { console.log(`${GREEN}✓${NC}  ${msg}`); }
+function warn(msg: string) { console.log(`${YELLOW}⚠${NC}  ${msg}`); }
+
+const HOME = homedir();
+const CLAUDE_JSON = join(HOME, ".claude.json");
+const SETTINGS = join(HOME, ".claude", "settings.json");
+
+console.log(`\n${BOLD}Disabling claude-buddy...${NC}\n`);
+
+// 1. Remove MCP server from ~/.claude.json
+try {
+  const claudeJson = JSON.parse(readFileSync(CLAUDE_JSON, "utf8"));
+  if (claudeJson.mcpServers?.["claude-buddy"]) {
+    delete claudeJson.mcpServers["claude-buddy"];
+    if (Object.keys(claudeJson.mcpServers).length === 0) delete claudeJson.mcpServers;
+    writeFileSync(CLAUDE_JSON, JSON.stringify(claudeJson, null, 2));
+    ok("MCP server removed from ~/.claude.json");
+  } else {
+    warn("MCP server was not registered");
+  }
+} catch {
+  warn("Could not update ~/.claude.json");
+}
+
+// 2. Remove status line + hooks from settings.json
+try {
+  const settings = JSON.parse(readFileSync(SETTINGS, "utf8"));
+  let changed = false;
+
+  if (settings.statusLine?.command?.includes("buddy")) {
+    delete settings.statusLine;
+    ok("Status line removed");
+    changed = true;
+  }
+
+  if (settings.hooks) {
+    for (const hookType of ["PostToolUse", "Stop", "SessionStart", "SessionEnd"]) {
+      if (settings.hooks[hookType]) {
+        const before = settings.hooks[hookType].length;
+        settings.hooks[hookType] = settings.hooks[hookType].filter(
+          (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+        );
+        if (settings.hooks[hookType].length < before) changed = true;
+        if (settings.hooks[hookType].length === 0) delete settings.hooks[hookType];
+      }
+    }
+    if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+  }
+
+  if (changed) {
+    writeFileSync(SETTINGS, JSON.stringify(settings, null, 2) + "\n");
+    ok("Hooks and status line removed from settings.json");
+  }
+} catch {
+  warn("Could not update settings.json");
+}
+
+// 3. Stop tmux popup if running
+try {
+  if (process.env.TMUX) {
+    const { execSync } = await import("child_process");
+    execSync("tmux display-popup -C 2>/dev/null", { stdio: "ignore" });
+  }
+} catch { /* not in tmux */ }
+
+console.log(`
+${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
+${GREEN}  Buddy disabled.${NC}
+${GREEN}  Companion data is preserved at ~/.claude-buddy/${NC}
+${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
+
+${DIM}  Restart Claude Code for changes to take effect.
+  Re-enable anytime with: bun run install-buddy${NC}
+`);

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -39,6 +39,9 @@ switch (command) {
   case "backup":
     await import("./backup.ts");
     break;
+  case "disable":
+    await import("./disable.ts");
+    break;
   case "--help":
   case "-h":
     console.log(`
@@ -52,6 +55,7 @@ Commands:
   doctor            Run diagnostic report (paste output in bug reports)
   test-statusline   Install temporary diagnostic status line in Claude Code
   backup            Snapshot or restore all claude-buddy state
+  disable           Temporarily deactivate buddy (re-enable with install-buddy)
   uninstall         Remove all claude-buddy integrations
 
 Options:

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -42,27 +42,56 @@ switch (command) {
   case "disable":
     await import("./disable.ts");
     break;
+  case "enable":
+    await import("./install.ts");
+    break;
+  case "help":
   case "--help":
   case "-h":
-    console.log(`
+    showHelp();
+    break;
+  default:
+    console.error(`Unknown command: ${command}\n`);
+    showHelp();
+    process.exit(1);
+}
+
+function showHelp() {
+  console.log(`
 claude-buddy — permanent coding companion for Claude Code
 
-Commands:
-  install           Set up MCP server, skill, hooks, and status line
+Setup:
+  install-buddy     Set up MCP server, skill, hooks, and status line
+  enable            Same as install-buddy (re-enable after disable)
+  disable           Temporarily deactivate buddy (data preserved)
+  uninstall         Remove all claude-buddy integrations
+
+Buddy:
   show              Display your current buddy
   hunt              Search for a specific buddy (species, rarity, stats)
   verify            Verify what buddy your current ID produces
-  doctor            Run diagnostic report (paste output in bug reports)
-  test-statusline   Install temporary diagnostic status line in Claude Code
-  backup            Snapshot or restore all claude-buddy state
-  disable           Temporarily deactivate buddy (re-enable with install-buddy)
-  uninstall         Remove all claude-buddy integrations
 
-Options:
-  --help, -h        Show this help
+Diagnostics:
+  doctor            Run diagnostic report (paste output in bug reports)
+  test-statusline   Test status line rendering in Claude Code
+  backup            Snapshot or restore all claude-buddy state
+
+In Claude Code:
+  /buddy            Show companion card with ASCII art + stats
+  /buddy pet        Pet your companion
+  /buddy stats      Detailed stat card
+  /buddy off        Mute reactions
+  /buddy on         Unmute reactions
+  /buddy rename     Rename companion (1-14 chars)
+  /buddy personality  Set custom personality text
+  /buddy frequency  Show or set comment cooldown (tmux only)
+  /buddy style      Show or set bubble style (tmux only)
+  /buddy position   Show or set bubble position (tmux only)
+  /buddy rarity     Show or hide rarity stars (tmux only)
+
+Usage:
+  bun run <command>           e.g. bun run show, bun run doctor
+  claude-buddy <command>      if globally linked (bun link)
+  bun run help                Show this help
 `);
-    break;
-  default:
-    console.error(`Unknown command: ${command}\nRun 'claude-buddy --help' for usage.`);
-    process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "show": "bun run cli/show.ts",
     "doctor": "bun run cli/doctor.ts",
     "test-statusline": "bun run cli/test-statusline.ts",
-    "backup": "bun run cli/backup.ts"
+    "backup": "bun run cli/backup.ts",
+    "disable": "bun run cli/disable.ts"
   },
   "files": [
     "server/",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "doctor": "bun run cli/doctor.ts",
     "test-statusline": "bun run cli/test-statusline.ts",
     "backup": "bun run cli/backup.ts",
-    "disable": "bun run cli/disable.ts"
+    "disable": "bun run cli/disable.ts",
+    "enable": "bun run cli/install.ts",
+    "help": "bun run cli/index.ts help"
   },
   "files": [
     "server/",

--- a/server/index.ts
+++ b/server/index.ts
@@ -194,6 +194,44 @@ server.tool(
   },
 );
 
+// ─── Tool: buddy_help ────────────────────────────────────────────────────────
+
+server.tool(
+  "buddy_help",
+  "Show all available /buddy commands",
+  {},
+  async () => {
+    const help = [
+      "claude-buddy commands",
+      "",
+      "In Claude Code:",
+      "  /buddy            Show companion card with ASCII art + stats",
+      "  /buddy help       Show this help",
+      "  /buddy pet        Pet your companion",
+      "  /buddy stats      Detailed stat card",
+      "  /buddy off        Mute reactions",
+      "  /buddy on         Unmute reactions",
+      "  /buddy rename     Rename companion (1-14 chars)",
+      "  /buddy personality  Set custom personality text",
+      "  /buddy frequency  Show or set comment cooldown (tmux only)",
+      "  /buddy style      Show or set bubble style (tmux only)",
+      "  /buddy position   Show or set bubble position (tmux only)",
+      "  /buddy rarity     Show or hide rarity stars (tmux only)",
+      "",
+      "CLI:",
+      "  bun run help            Show full CLI help",
+      "  bun run show            Display buddy in terminal",
+      "  bun run hunt            Search for specific buddy",
+      "  bun run doctor          Diagnostic report",
+      "  bun run disable         Temporarily deactivate buddy",
+      "  bun run enable          Re-enable buddy",
+      "  bun run backup          Snapshot/restore state",
+    ].join("\n");
+
+    return { content: [{ type: "text", text: help }] };
+  },
+);
+
 // ─── Tool: buddy_frequency / buddy_style ─────────────────────────────────────
 
 server.tool(

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buddy
 description: "Show, pet, or manage your coding companion. Use when the user types /buddy or mentions their companion by name."
-argument-hint: "[show|pet|off|on|stats|rename <name>|personality <text>|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]]"
+argument-hint: "[show|pet|off|on|stats|help|rename <name>|personality <text>|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]]"
 allowed-tools: mcp__claude_buddy__*
 ---
 
@@ -16,6 +16,7 @@ Based on `$ARGUMENTS`:
 | Input | Action |
 |-------|--------|
 | *(empty)* or `show` | Call `buddy_show` |
+| `help` | Call `buddy_help` |
 | `pet` | Call `buddy_pet` |
 | `stats` | Call `buddy_stats` |
 | `off` | Call `buddy_mute` |


### PR DESCRIPTION
add quality-of-life CLI commands: disable/enable toggle, help overview, and `/buddy help` in Claude Code.

### New commands

**CLI:**
- `bun run disable` - temporarily deactivate buddy (removes MCP, hooks, status line; keeps companion data)
- `bun run enable` - re-enable buddy (alias for install-buddy)
- `bun run help` - grouped overview of all CLI + Claude Code commands
- `bun link` - optional global install, documented in README

**In Claude Code:**
- `/buddy help` - shows all available commands via MCP tool

### Changes

| File | What changed |
|------|-------------|
| `cli/disable.ts` | New: removes MCP server, hooks, status line without touching companion data |
| `cli/index.ts` | Added enable alias, help command, unknown command shows help (global CLI only) |
| `package.json` | Added disable, enable, help scripts |
| `server/index.ts` | Added buddy_help MCP tool |
| `skills/buddy/SKILL.md` | Added help route |
| `README.md` | Added bun link instructions |

### Testing

- `bun run disable` → verified MCP, hooks, status line removed; companion data preserved
- `bun run enable` → verified full re-install works, Mira restored
- `bun run help` → shows grouped commands (Setup, Buddy, Diagnostics, In Claude Code)
- `claude-buddy help` → works after `bun link`
- `/buddy help` → MCP tool returns all commands
- Unknown command → shows help (only with global CLI)
