### PR TITLE
fix: hook regressions in name-react and buddy-comment

### DIFF
--- a/hooks/buddy-comment.sh
+++ b/hooks/buddy-comment.sh
@@ -15,11 +15,12 @@ CONFIG_FILE="$STATE_DIR/config.json"
 
 [ -f "$STATUS_FILE" ] || exit 0
 
-# Read cooldown from config (default 30s)
+# Read cooldown from config (default 30s, 0 = disabled)
 COOLDOWN=30
 if [ -f "$CONFIG_FILE" ]; then
   _cd=$(jq -r '.commentCooldown // 30' "$CONFIG_FILE" 2>/dev/null || echo 30)
-  [ "$_cd" -gt 0 ] 2>/dev/null && COOLDOWN=$_cd
+  # Accept any non-negative integer (including 0 to disable cooldown)
+  [[ "$_cd" =~ ^[0-9]+$ ]] && COOLDOWN=$_cd
 fi
 
 INPUT=$(cat)

--- a/hooks/name-react.sh
+++ b/hooks/name-react.sh
@@ -5,6 +5,9 @@
 
 STATE_DIR="$HOME/.claude-buddy"
 STATUS_FILE="$STATE_DIR/status.json"
+# Session ID: sanitized tmux pane number, or "default" outside tmux
+SID="${TMUX_PANE#%}"
+SID="${SID:-default}"
 
 [ -f "$STATUS_FILE" ] || exit 0
 
@@ -102,8 +105,8 @@ mkdir -p "$STATE_DIR"
 TMP=$(mktemp)
 jq --arg r "$REACTION" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
 
-cat > "$STATE_DIR/reaction.json" <<EOJSON
-{"reaction":"$REACTION","timestamp":$(date +%s%3N),"reason":"name"}
-EOJSON
+jq -n --arg r "$REACTION" --arg ts "$(date +%s)000" \
+  '{reaction: $r, timestamp: ($ts | tonumber), reason: "name"}' \
+  > "$STATE_DIR/reaction.$SID.json"
 
 exit 0


### PR DESCRIPTION
## Summary

Fixes two unrelated bugs in the reaction hooks that were discovered while debugging the status-line bubble not updating on buddy name mentions.

### Bug 1 — `hooks/name-react.sh`: name-mention reactions never reach the bubble

The session-isolation refactor in a3e98a2 namespaced per-session reaction files using `$TMUX_PANE` (or `default` as fallback), and updated `hooks/buddy-comment.sh`, `hooks/react.sh`, and `statusline/buddy-status.sh` accordingly — but `hooks/name-react.sh` was not updated. As a result:

- The hook writes reactions to `~/.claude-buddy/reaction.json`
- But `statusline/buddy-status.sh` reads from `~/.claude-buddy/reaction.$SID.json`
- So mentioning the buddy by name never actually updates the bubble

**Fix:**
- Add the same `$SID` handling as the other hooks
- Write to `reaction.$SID.json` instead of `reaction.json`
- Switch from heredoc to `jq` for safer JSON encoding (matches the style already used in `hooks/buddy-comment.sh`)

### Bug 2 — `hooks/buddy-comment.sh`: `commentCooldown: 0` silently ignored

The cooldown config reader uses `[ "$_cd" -gt 0 ]` to validate the configured value, which rejects `0`. Users who set `commentCooldown: 0` in `~/.claude-buddy/config.json` to disable the cooldown get the default 30 seconds instead.

**Fix:** Replace the `-gt 0` check with a non-negative integer regex (`^[0-9]+$`) so `0` is accepted and genuinely disables the cooldown.

## Test plan

- [ ] Mention the buddy's name in a prompt (e.g. `Hi <buddy-name>`) → the speech bubble next to the buddy art updates with a name-mention reaction
- [ ] Set `commentCooldown: 0` in `~/.claude-buddy/config.json` → multiple end-of-turn buddy comments fire in quick succession without being blocked
- [ ] Verify `reaction.$SID.json` is written on name mentions
- [ ] Existing behavior for other species is unchanged