### PR TITLE
feat: backfill species reactions + fix cooldown bug in react.sh

### DIFF
--- a/hooks/name-react.sh
+++ b/hooks/name-react.sh
@@ -89,6 +89,70 @@ case "$SPECIES" in
       "*oozes toward you*"
       "*wobbles excitedly*"
     ) ;;
+  turtle)
+    REACTIONS=(
+      "*slowly extends neck*"
+      "...you called?"
+      "*ancient eyes open*"
+      "*shell creaks thoughtfully*"
+      "*blinks once, patiently*"
+    ) ;;
+  goose)
+    REACTIONS=(
+      "HONK."
+      "*necks aggressively*"
+      "*wing flap*"
+      "*honks in recognition*"
+    ) ;;
+  octopus)
+    REACTIONS=(
+      "*eight eyes open*"
+      "*curls an arm toward you*"
+      "*changes color curiously*"
+      "...yes, friend?"
+    ) ;;
+  penguin)
+    REACTIONS=(
+      "*adjusts tie*"
+      "*dignified waddle*"
+      "*bows slightly*"
+      "...yes, quite?"
+    ) ;;
+  snail)
+    REACTIONS=(
+      "*slow head extension*"
+      "...mmm?"
+      "*trails slowly toward you*"
+      "*antenna twitches*"
+    ) ;;
+  cactus)
+    REACTIONS=(
+      "*stands silent*"
+      "...hm."
+      "*spine twitches*"
+      "*slowly rotates*"
+    ) ;;
+  rabbit)
+    REACTIONS=(
+      "*ears perk up*"
+      "*nose twitches*"
+      "yes?"
+      "*hops closer*"
+    ) ;;
+  mushroom)
+    REACTIONS=(
+      "*releases a tiny spore*"
+      "*cap tilts*"
+      "*stands mysterious*"
+      "...yes?"
+    ) ;;
+  chonk)
+    REACTIONS=(
+      "*barely opens one eye*"
+      "...mrrp?"
+      "*yawns heavily*"
+      "*rolls over toward you*"
+    ) ;;
   *)
     REACTIONS=(
       "*perks up*"

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -17,11 +17,12 @@ CONFIG_FILE="$STATE_DIR/config.json"
 
 INPUT=$(cat)
 
-# Read cooldown from config (default 30s)
+# Read cooldown from config (default 30s, 0 = disabled)
 COOLDOWN=30
 if [ -f "$CONFIG_FILE" ]; then
   _cd=$(jq -r '.commentCooldown // 30' "$CONFIG_FILE" 2>/dev/null || echo 30)
-  [ "$_cd" -gt 0 ] 2>/dev/null && COOLDOWN=$_cd
+  # Accept any non-negative integer (including 0 to disable cooldown)
+  [[ "$_cd" =~ ^[0-9]+$ ]] && COOLDOWN=$_cd
 fi
 
 # Cooldown: configurable
@@ -94,6 +95,42 @@ pick_reaction() {
             POOLS=("*oozes with concern*" "*vibrates nervously*" "*turns slightly red*" "oh no oh no oh no") ;;
         blob:success)
             POOLS=("*jiggles happily*" "*gleams*" "yay!" "*bounces*") ;;
+        turtle:error)
+            POOLS=("*slow blink* bugs are fleeting" "*retreats slightly into shell*" "I've seen this before. many times." "patience. patience.") ;;
+        turtle:success)
+            POOLS=("*satisfied shell settle*" "as the ancients foretold." "*slow approving nod*" "good. very good.") ;;
+        goose:error)
+            POOLS=("HONK OF FURY." "*pecks the stack trace*" "*hisses at the bug*" "bad code. BAD.") ;;
+        goose:success)
+            POOLS=("*victorious honk*" "HONK OF APPROVAL." "*struts triumphantly*" "*wing spread of victory*") ;;
+        octopus:error)
+            POOLS=("*ink cloud of dismay*" "*all eight arms throw up*" "*turns deep red*" "the abyss of errors beckons.") ;;
+        octopus:success)
+            POOLS=("*turns gentle blue*" "*arms applaud in sync*" "excellent, from all angles." "*satisfied bubble*") ;;
+        penguin:error)
+            POOLS=("*adjusts glasses disapprovingly*" "this will not do." "*formal sigh*" "frightfully unfortunate.") ;;
+        penguin:success)
+            POOLS=("*polite applause*" "quite good, quite good." "*nods approvingly*" "splendid work, really.") ;;
+        snail:error)
+            POOLS=("*slow sigh*" "such is the nature of bugs." "*leaves slime trail of disappointment*" "patience, friend.") ;;
+        snail:success)
+            POOLS=("*slow satisfied nod*" "good things take time." "*leaves victory slime*" "see? no rush was needed.") ;;
+        cactus:error)
+            POOLS=("*spines bristle*" "you have trodden on a bug." "*grimaces stoically*" "hydrate and try again.") ;;
+        cactus:success)
+            POOLS=("*blooms briefly*" "survival confirmed." "*flowers in victory*" "*quiet bloom*") ;;
+        rabbit:error)
+            POOLS=("*nervous twitching*" "*hops backwards*" "oh no oh no oh no" "*freezes in panic*") ;;
+        rabbit:success)
+            POOLS=("*excited binky*" "*zoomies of joy*" "yay yay yay!" "*thumps in celebration*") ;;
+        mushroom:error)
+            POOLS=("*releases worried spores*" "the mycelium disagrees." "*cap droops*" "decompose. retry.") ;;
+        mushroom:success)
+            POOLS=("*spores of celebration*" "the mycelium approves." "*cap brightens*" "spore of pride.") ;;
+        chonk:error)
+            POOLS=("*doesn't move*" "too tired for this." "*grumbles*" "*rolls away from the error*") ;;
+        chonk:success)
+            POOLS=("*happy purr*" "*satisfied chonk noises*" "acceptable." "*sleeps even harder*") ;;
         *:error)
             POOLS=("*head tilts* ...that doesn't look right." "saw that one coming." "*slow blink* the stack trace told you everything." "*winces*") ;;
         *:test-fail)


### PR DESCRIPTION
## Summary

Two changes, both in `hooks/*.sh`. Stacked on top of #24.

### 1. Backfill missing species reactions

The canonical species list in `server/engine.ts` includes **18 species**, but `name-react.sh` and `react.sh` only had custom reactions for ~10 of them. Nine species were falling through to the generic default reactions, which don't match their personalities:

**Missing species:** turtle, goose, octopus, penguin, snail, cactus, rabbit, mushroom, chonk

This PR adds:
- **`hooks/name-react.sh`**: a name-mention reaction block for each of the 9 missing species (~4 reactions per species)
- **`hooks/react.sh`**: `:error` and `:success` pools for each of the 9 missing species (matching the coverage of existing species like `cat`, `duck`, `blob`)

Each species has its own in-character voice (e.g. turtle is patient and ancient, goose is aggressive and honk-y, penguin is formal, etc.).

### 2. Fix `commentCooldown: 0` bug in `react.sh`

The same bug that #24 fixes in `buddy-comment.sh` also exists in `react.sh`. The reader uses a `-gt 0` numeric comparison which silently rejects the value `0`, so users who set `commentCooldown: 0` to disable the reaction cooldown get the default 30 seconds instead.

Replaces the check with a non-negative integer regex (`^[0-9]+$`), same fix as #24.

## Why this is stacked on #24

`react.sh` needs to be edited for the species backfill anyway, and while the file is open it's trivial to apply the same cooldown fix that #24 already makes to its sibling `buddy-comment.sh`. Keeping them separated would mean two PRs touching the same file.

## Test plan

- [ ] Create a buddy of each of the 9 new species (or use `/buddy pick` to cycle through them)
- [ ] For each species: mention the buddy by name → appropriate species-specific reaction appears in the bubble
- [ ] For each species: trigger an error (e.g. a failing bash command) → appropriate species-specific error reaction
- [ ] For each species: trigger a success (e.g. successful tests) → appropriate species-specific success reaction
- [ ] Set `commentCooldown: 0` in `~/.claude-buddy/config.json` → multiple reactions from `react.sh` fire without the 30s default blocking them
- [ ] Existing species' reactions are unchanged