### PR TITLE
feat: backfill species reactions into main

### DIFF
--- a/hooks/name-react.sh
+++ b/hooks/name-react.sh
@@ -89,6 +89,70 @@ case "$SPECIES" in
       "*oozes toward you*"
       "*wobbles excitedly*"
     ) ;;
+  turtle)
+    REACTIONS=(
+      "*slowly extends neck*"
+      "...you called?"
+      "*ancient eyes open*"
+      "*shell creaks thoughtfully*"
+      "*blinks once, patiently*"
+    ) ;;
+  goose)
+    REACTIONS=(
+      "HONK."
+      "*necks aggressively*"
+      "*wing flap*"
+      "*honks in recognition*"
+    ) ;;
+  octopus)
+    REACTIONS=(
+      "*eight eyes open*"
+      "*curls an arm toward you*"
+      "*changes color curiously*"
+      "...yes, friend?"
+    ) ;;
+  penguin)
+    REACTIONS=(
+      "*adjusts tie*"
+      "*dignified waddle*"
+      "*bows slightly*"
+      "...yes, quite?"
+    ) ;;
+  snail)
+    REACTIONS=(
+      "*slow head extension*"
+      "...mmm?"
+      "*trails slowly toward you*"
+      "*antenna twitches*"
+    ) ;;
+  cactus)
+    REACTIONS=(
+      "*stands silent*"
+      "...hm."
+      "*spine twitches*"
+      "*slowly rotates*"
+    ) ;;
+  rabbit)
+    REACTIONS=(
+      "*ears perk up*"
+      "*nose twitches*"
+      "yes?"
+      "*hops closer*"
+    ) ;;
+  mushroom)
+    REACTIONS=(
+      "*releases a tiny spore*"
+      "*cap tilts*"
+      "*stands mysterious*"
+      "...yes?"
+    ) ;;
+  chonk)
+    REACTIONS=(
+      "*barely opens one eye*"
+      "...mrrp?"
+      "*yawns heavily*"
+      "*rolls over toward you*"
+    ) ;;
   *)
     REACTIONS=(
       "*perks up*"

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -17,11 +17,12 @@ CONFIG_FILE="$STATE_DIR/config.json"
 
 INPUT=$(cat)
 
-# Read cooldown from config (default 30s)
+# Read cooldown from config (default 30s, 0 = disabled)
 COOLDOWN=30
 if [ -f "$CONFIG_FILE" ]; then
   _cd=$(jq -r '.commentCooldown // 30' "$CONFIG_FILE" 2>/dev/null || echo 30)
-  [ "$_cd" -gt 0 ] 2>/dev/null && COOLDOWN=$_cd
+  # Accept any non-negative integer (including 0 to disable cooldown)
+  [[ "$_cd" =~ ^[0-9]+$ ]] && COOLDOWN=$_cd
 fi
 
 # Cooldown: configurable
@@ -94,6 +95,42 @@ pick_reaction() {
             POOLS=("*oozes with concern*" "*vibrates nervously*" "*turns slightly red*" "oh no oh no oh no") ;;
         blob:success)
             POOLS=("*jiggles happily*" "*gleams*" "yay!" "*bounces*") ;;
+        turtle:error)
+            POOLS=("*slow blink* bugs are fleeting" "*retreats slightly into shell*" "I've seen this before. many times." "patience. patience.") ;;
+        turtle:success)
+            POOLS=("*satisfied shell settle*" "as the ancients foretold." "*slow approving nod*" "good. very good.") ;;
+        goose:error)
+            POOLS=("HONK OF FURY." "*pecks the stack trace*" "*hisses at the bug*" "bad code. BAD.") ;;
+        goose:success)
+            POOLS=("*victorious honk*" "HONK OF APPROVAL." "*struts triumphantly*" "*wing spread of victory*") ;;
+        octopus:error)
+            POOLS=("*ink cloud of dismay*" "*all eight arms throw up*" "*turns deep red*" "the abyss of errors beckons.") ;;
+        octopus:success)
+            POOLS=("*turns gentle blue*" "*arms applaud in sync*" "excellent, from all angles." "*satisfied bubble*") ;;
+        penguin:error)
+            POOLS=("*adjusts glasses disapprovingly*" "this will not do." "*formal sigh*" "frightfully unfortunate.") ;;
+        penguin:success)
+            POOLS=("*polite applause*" "quite good, quite good." "*nods approvingly*" "splendid work, really.") ;;
+        snail:error)
+            POOLS=("*slow sigh*" "such is the nature of bugs." "*leaves slime trail of disappointment*" "patience, friend.") ;;
+        snail:success)
+            POOLS=("*slow satisfied nod*" "good things take time." "*leaves victory slime*" "see? no rush was needed.") ;;
+        cactus:error)
+            POOLS=("*spines bristle*" "you have trodden on a bug." "*grimaces stoically*" "hydrate and try again.") ;;
+        cactus:success)
+            POOLS=("*blooms briefly*" "survival confirmed." "*flowers in victory*" "*quiet bloom*") ;;
+        rabbit:error)
+            POOLS=("*nervous twitching*" "*hops backwards*" "oh no oh no oh no" "*freezes in panic*") ;;
+        rabbit:success)
+            POOLS=("*excited binky*" "*zoomies of joy*" "yay yay yay!" "*thumps in celebration*") ;;
+        mushroom:error)
+            POOLS=("*releases worried spores*" "the mycelium disagrees." "*cap droops*" "decompose. retry.") ;;
+        mushroom:success)
+            POOLS=("*spores of celebration*" "the mycelium approves." "*cap brightens*" "spore of pride.") ;;
+        chonk:error)
+            POOLS=("*doesn't move*" "too tired for this." "*grumbles*" "*rolls away from the error*") ;;
+        chonk:success)
+            POOLS=("*happy purr*" "*satisfied chonk noises*" "acceptable." "*sleeps even harder*") ;;
         *:error)
             POOLS=("*head tilts* ...that doesn't look right." "saw that one coming." "*slow blink* the stack trace told you everything." "*winces*") ;;
         *:test-fail)


### PR DESCRIPTION
## Summary

Follow-up to #25, which was unintentionally merged into `fix/hook-regressions` (its stacked-PR base) rather than into `main`. This PR brings the species backfill + `react.sh` cooldown fix into `main`.

## What's in this PR

Everything that was in #25:

1. **Backfill species reactions** for all species that were added to `server/engine.ts` but never got custom reactions in the hooks. The 9 missing species (turtle, goose, octopus, penguin, snail, cactus, rabbit, mushroom, chonk) were all falling through to the generic default reactions.
   - `hooks/name-react.sh`: adds a species case block for each missing species
   - `hooks/react.sh`: adds `:error` and `:success` pools for each missing species

2. **Fix `commentCooldown: 0` bug in `hooks/react.sh`** — same bug that #24 fixed in `buddy-comment.sh`. The reader used a `-gt 0` numeric comparison that silently rejected the value 0, so users could not disable the reaction cooldown. Replaced with a non-negative integer regex.

## Why this is a separate PR

When #25 was opened it targeted `fix/hook-regressions` (stacked on #24). After #24 was merged, #25 should have been retargeted to `main` before merging, but was merged into `fix/hook-regressions` instead. This PR corrects that by merging `fix/hook-regressions` into `main` so the species changes actually reach users.

## Test plan

- [ ] Create a buddy of one of the 9 new species (turtle, goose, octopus, penguin, snail, cactus, rabbit, mushroom, or chonk)
- [ ] Mention the buddy by name in a prompt → species-appropriate reaction appears in the status-line bubble
- [ ] Trigger an error (e.g. a failing bash command) → species-appropriate error reaction
- [ ] Trigger a success (e.g. a passing test run) → species-appropriate success reaction
- [ ] Set `commentCooldown: 0` in `~/.claude-buddy/config.json` → reactions from `react.sh` fire without the 30s default blocking them
- [ ] Existing species (dragon, owl, cat, duck, ghost, robot, capybara, axolotl, blob) behave unchanged