### PR TITLE
docs: replace hardcoded contributors table with contrib.rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,31 +396,11 @@ The popup is modal. To scroll:
 
 Thank you to everyone who helped bring buddies back to life.
 
-<table>
-<tr>
-<td align="center">
-<a href="https://github.com/doctor-ew">
-<img src="https://github.com/doctor-ew.png" width="80" style="border-radius:50%" alt="doctor-ew" /><br>
-<sub><b>doctor-ew</b></sub>
-</a><br>
-<sub>multi-buddy menagerie</sub>
-</td>
-<td align="center">
-<a href="https://github.com/gzenz">
-<img src="https://github.com/gzenz.png" width="80" style="border-radius:50%" alt="gzenz" /><br>
-<sub><b>gzenz</b></sub>
-</a><br>
-<sub>tmux popup mode</sub>
-</td>
-<td align="center">
-<a href="https://github.com/birkdev">
-<img src="https://github.com/birkdev.png" width="80" style="border-radius:50%" alt="birkdev" /><br>
-<sub><b>birkdev</b></sub>
-</a><br>
-<sub>PostToolUse hook fix</sub>
-</td>
-</tr>
-</table>
+<a href="https://github.com/1270011/claude-buddy/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=1270011/claude-buddy" alt="Contributors" />
+</a>
+
+<sub>Automatically generated from the [contributors graph](https://github.com/1270011/claude-buddy/graphs/contributors) via [contrib.rocks](https://contrib.rocks).</sub>
 
 <br>
 


### PR DESCRIPTION
## Summary

Replaces the manually maintained `<table>` of contributors with a single `contrib.rocks` image reference. The image is generated on-the-fly from the GitHub contributors graph, so new contributors appear automatically without any README edits.

## Why

The manual table in the current README is already stale:

| Login | Commits in main | In README table? |
|---|---|---|
| doctor-ew | 4 | ✅ |
| **grlee** | **3** | ❌ **missing** |
| gzenz | 2 | ✅ |
| birkdev | 1 | ✅ |

**grlee has more merged contributions than gzenz and birkdev but is nowhere listed.** Every new contributor requires a manual README edit, which is easy to forget — as this example shows.

## What changes

Before (25 lines of hardcoded HTML table):

```html
<table>
<tr>
<td align="center">
<a href="https://github.com/doctor-ew">
<img src="https://github.com/doctor-ew.png" width="80" ... />
<sub><b>doctor-ew</b></sub>
</a><br>
<sub>multi-buddy menagerie</sub>
</td>
<td align="center">
<a href="https://github.com/gzenz">...</td>
<td align="center">
<a href="https://github.com/birkdev">...</td>
</tr>
</table>
```

After (5 lines):

```html
<a href="https://github.com/1270011/claude-buddy/graphs/contributors">
  <img src="https://contrib.rocks/image?repo=1270011/claude-buddy" alt="Contributors" />
</a>

<sub>Automatically generated from the contributors graph via contrib.rocks.</sub>
```

## Trade-offs

**Gained:**
- Auto-updates: new contributors appear without README edits
- `grlee` immediately shows up
- 20 fewer lines of README

**Lost:**
- Per-contributor contribution summaries (what they worked on, e.g. "multi-buddy menagerie")
- Only code contributors are recognized (no docs/design/bug-reporter credit)
- Depends on the external [contrib.rocks](https://contrib.rocks) service

These trade-offs are acceptable for an MVP-stage project. If fine-grained contributor recognition becomes important later, migrating to the [all-contributors bot](https://allcontributors.org/) is a natural follow-up — it supports 20+ contribution types (code, docs, design, ideas, bug reports, etc.).

## Test plan

- [ ] Open README on github.com/1270011/claude-buddy/tree/docs/contributors-automation → contrib.rocks image renders and shows all 4+ contributors including `grlee`
- [ ] Click the image → links to the contributors graph
- [ ] Existing README structure is unchanged (only the contributors section)