### PR TITLE
docs: complete command reference, add settings CLI, allow cooldown 0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Restart Claude Code and type `/buddy` to verify everything works.
 | `server/` | MCP server -- buddy engine, tools, state, reactions |
 | `skills/` | `/buddy` slash command (SKILL.md) |
 | `hooks/` | Shell scripts for error detection + comment extraction |
-| `statusline/` | Animated status line renderer (fallback mode) |
-| `popup/` | tmux popup overlay mode (requires tmux >= 3.2) |
+| `statusline/` | Animated buddy display (status line mode) |
+| `popup/` | Animated buddy display (tmux popup mode, requires tmux >= 3.2) |
 | `cli/` | Install, uninstall, show, hunt, verify commands |
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ bun run install-buddy
 Then restart Claude Code and type `/buddy`. That's it.
 
 <sub>💡 Need Bun? → `curl -fsSL https://bun.sh/install | bash`</sub>
+<br>
+<sub>💡 Want a global `claude-buddy` command? → `bun link`</sub>
+<br>
+<sub>💡 Need help? → `/buddy help` in Claude Code · `bun run help` or `claude-buddy help` (if linked) in terminal</sub>
 
 <br>
 
@@ -218,10 +222,16 @@ claude-buddy/
 | `/buddy off` / `on` | Mute / unmute reactions |
 | `/buddy rename <name>` | Rename (1–14 chars) |
 | `/buddy personality <text>` | Set custom personality |
+| `/buddy summon [slot]` | Summon a saved buddy (omit slot for random) |
+| `/buddy save [slot]` | Save current buddy to a named slot |
+| `/buddy list` | List all saved buddies |
+| `/buddy dismiss <slot>` | Remove a saved buddy slot |
+| `/buddy pick` | Launch interactive TUI picker (`! bun run pick`) |
 | `/buddy frequency [seconds]` | Show or set comment cooldown |
-| `/buddy style [classic\|round]` | Bubble border style |
-| `/buddy position [top\|left]` | Bubble position |
-| `/buddy rarity [on\|off]` | Show or hide stars + rarity line |
+| `/buddy style [classic\|round]` | Bubble border style (tmux only) |
+| `/buddy position [top\|left]` | Bubble position (tmux only) |
+| `/buddy rarity [on\|off]` | Show or hide stars + rarity line (tmux only) |
+| `/buddy help` | Show all buddy commands |
 
 ### CLI
 
@@ -229,20 +239,28 @@ claude-buddy/
 |---|---|
 | `bun run install-buddy` | Automated setup |
 | `bun run show` | Show buddy in terminal |
-| `bun run hunt` | Interactive search for specific species/rarity/stats |
+| `bun run pick` | Interactive TUI to find and save your dream buddy |
+| `bun run hunt` | Legacy search (use `pick` instead) |
 | `bun run doctor` | Full diagnostic report |
+| `bun run verify` | Verify buddy generation matches expected output |
 | `bun run backup` | Snapshot / restore state |
+| `bun run settings` | View / change buddy settings (TUI settings coming soon) |
+| `bun run disable` | Temporarily deactivate buddy |
+| `bun run enable` | Re-enable buddy |
+| `bun run help` | Full CLI reference |
 | `bun run cli/uninstall.ts` | Clean removal |
 
-### 🎯 Buddy Hunt
+<sub>💡 Want a global `claude-buddy` command? → `cd claude-buddy && bun link`</sub>
+
+### 🎯 Buddy Pick
 
 Want a specific species, rarity, or stat distribution?
 
 ```bash
-bun run hunt
+bun run pick
 ```
 
-Interactive prompts let you brute-force search for a userID that produces your dream buddy. Uses the exact same `wyhash + mulberry32` algorithm as Claude Code.
+Interactive TUI with saved buddies, criteria search, vim keys, and two-pane preview. Uses the exact same `wyhash + mulberry32` algorithm as Claude Code.
 
 </details>
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -43,6 +43,9 @@ switch (command) {
   case "backup":
     await import("./backup.ts");
     break;
+  case "settings":
+    await import("./settings.ts");
+    break;
   case "disable":
     await import("./disable.ts");
     break;
@@ -75,6 +78,10 @@ Buddy:
   pick              Interactive two-pane buddy picker (browse saved + search)
   hunt              Search for a specific buddy (non-interactive)
   verify            Verify what buddy your current ID produces
+
+Settings:
+  settings          Show current settings
+  settings cooldown <n>  Set comment cooldown (0-300 seconds)
 
 Diagnostics:
   doctor            Run diagnostic report (paste output in bug reports)

--- a/cli/settings.ts
+++ b/cli/settings.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+/**
+ * cli/settings.ts — View and update buddy settings
+ *
+ * Usage:
+ *   bun run settings                Show current settings
+ *   bun run settings cooldown 0     Set comment cooldown (0-300 seconds)
+ */
+
+import { loadConfig, saveConfig } from "../server/state.ts";
+
+const args = process.argv.slice(2);
+const key = args[0];
+const value = args[1];
+
+if (!key) {
+  const cfg = loadConfig();
+  console.log(`
+  claude-buddy settings
+  ─────────────────────
+  Comment cooldown:  ${cfg.commentCooldown}s    (0 = no throttling, default 30)
+
+  Change:  bun run settings cooldown <seconds>
+`);
+  process.exit(0);
+}
+
+if (key === "cooldown") {
+  if (value === undefined) {
+    const cfg = loadConfig();
+    console.log(`Comment cooldown: ${cfg.commentCooldown}s`);
+    process.exit(0);
+  }
+
+  const n = parseInt(value, 10);
+  if (isNaN(n) || n < 0 || n > 300) {
+    console.error("Error: cooldown must be 0-300 (seconds)");
+    process.exit(1);
+  }
+
+  const cfg = saveConfig({ commentCooldown: n });
+  console.log(`Updated: comment cooldown → ${cfg.commentCooldown}s`);
+  process.exit(0);
+}
+
+console.error(`Unknown setting: ${key}`);
+console.error("Available: cooldown");
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "doctor": "bun run cli/doctor.ts",
         "test-statusline": "bun run cli/test-statusline.ts",
         "backup": "bun run cli/backup.ts",
+        "settings": "bun run cli/settings.ts",
         "disable": "bun run cli/disable.ts",
         "enable": "bun run cli/install.ts",
         "help": "bun run cli/index.ts help"

--- a/server/index.ts
+++ b/server/index.ts
@@ -263,7 +263,7 @@ server.tool(
   "buddy_frequency",
   "Configure how often buddy comments appear in the speech bubble. Returns current settings if called without arguments.",
   {
-    cooldown: z.number().int().min(5).max(300).optional().describe("Minimum seconds between displayed comments (default 30). The buddy always writes comments, but the display only updates this often."),
+    cooldown: z.number().int().min(0).max(300).optional().describe("Minimum seconds between displayed comments (default 30, 0 = no throttling). The buddy always writes comments, but the display only updates this often."),
   },
   async ({ cooldown }) => {
     if (cooldown === undefined) {


### PR DESCRIPTION
Closes #18 — post-merge cleanup for PR #4 (menagerie) and PR #6 (tmux popup).

- **CONTRIBUTING.md**: rename statusline/popup descriptions for consistency
- **README.md**: add all 5 missing `/buddy` commands (summon, save, list, dismiss, pick), add 3 missing CLI commands (verify, disable, enable, settings), add `bun link` + help tips to Quick Start, promote `pick` over `hunt` (legacy), fix `/buddy frequency` tmux-only annotation (applies to all modes)
- **cli/settings.ts**: new CLI for viewing/setting comment cooldown (`bun run settings cooldown <n>`)
- **server/index.ts**: lower frequency minimum from 5 to 0 (no throttling)

## Test plan

- [x] `bun run settings` — shows current cooldown
- [x] `bun run settings cooldown 0` — sets to 0, verify with `bun run settings`
- [x] `bun run settings cooldown 30` — reset to default
- [x] `/buddy frequency 0` in Claude Code — should accept (previously rejected)
- [x] Verify README renders correctly on GitHub