### PR TITLE
fix: add missing uninstall script alias, reorder help tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Then restart Claude Code and type `/buddy`. That's it.
 <br>
 <sub>💡 Want a global `claude-buddy` command? → `bun link`</sub>
 <br>
-<sub>💡 Need help? → `/buddy help` in Claude Code · `bun run help` or `claude-buddy help` (if linked) in terminal</sub>
+<sub>💡 Need help? → `bun run help` or `claude-buddy help` (if linked) in terminal · `/buddy help` in Claude Code</sub>
 
 <br>
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "settings": "bun run cli/settings.ts",
         "disable": "bun run cli/disable.ts",
         "enable": "bun run cli/install.ts",
+        "uninstall": "bun run cli/uninstall.ts",
         "help": "bun run cli/index.ts help"
     },
     "files": [


### PR DESCRIPTION
- package.json: add "uninstall" script so `bun run uninstall` works
- README.md: reorder help tip to list CLI before Claude Code