### PR TITLE
fix: F12 scroll mode broken in pane %0 (Perl "0" falsiness)

### DIFF
--- a/popup/buddy-popup.sh
+++ b/popup/buddy-popup.sh
@@ -81,7 +81,7 @@ exec perl -e '
     # F12 (\e[24~) = close popup and enter scroll mode
     if ($buf =~ /\e\[24~/) {
       my $buddy_dir = $ENV{BUDDY_DIR} || "$ENV{HOME}/.claude-buddy";
-      my $sid = $ENV{BUDDY_SID} || "default";
+      my $sid = $ENV{BUDDY_SID} // "default";
       open(my $fh, ">", "$buddy_dir/popup-scroll.$sid");
       close($fh) if $fh;
       exit 0;


### PR DESCRIPTION
## Summary

Fixes #38

- F12 scroll mode silently fails when Claude Code runs in tmux pane `%0`
- `BUDDY_SID` is `"0"` for the first pane. Perl's `||` treats `"0"` as falsy, so `$ENV{BUDDY_SID} || "default"` evaluates to `"default"`
- Scroll flag is written as `popup-scroll.default` but the manager checks `popup-scroll.0` -- F12 forwards ESC to Claude Code instead of entering copy-mode

One-char fix: `||` to `//` (Perl's defined-or operator, which only falls through on `undef`).

## Test plan

- [ ] Open Claude Code in tmux pane `%0`
- [ ] Press F12 -- should enter copy-mode, not forward ESC
- [ ] Verify `~/.claude-buddy/popup-scroll.0` is created (not `popup-scroll.default`)