### PR TITLE
fix: render buddy cards as markdown in MCP tool responses

### DIFF
--- a/server/art.ts
+++ b/server/art.ts
@@ -276,6 +276,90 @@ export function renderCompanionCard(
   return lines.join("\n");
 }
 
+// ─── Markdown-native render (for MCP tool responses) ───────────────────────
+//
+// Claude Code's UI doesn't render raw ANSI escape codes properly — it strips
+// the ESC byte but leaves "[38;2;...m" as literal text, making the output
+// unreadable. This renderer produces pure markdown with unicode rarity dots
+// instead of ANSI colors, so it renders cleanly in any MCP client UI.
+
+const RARITY_DOT: Record<Rarity, string> = {
+  common:    "\u26AA",  // ⚪ white circle
+  uncommon:  "\uD83D\uDFE2",  // 🟢 green circle
+  rare:      "\uD83D\uDD35",  // 🔵 blue circle
+  epic:      "\uD83D\uDFE3",  // 🟣 purple circle
+  legendary: "\uD83D\uDFE1",  // 🟡 yellow circle
+};
+
+export function renderCompanionCardMarkdown(
+  bones: BuddyBones,
+  name: string,
+  personality: string,
+  reaction?: string,
+  frame: number = 0,
+): string {
+  const dot = RARITY_DOT[bones.rarity];
+  const stars = RARITY_STARS[bones.rarity];
+  const shiny = bones.shiny ? " \u2728" : "";
+  const art = getArtFrame(bones.species, bones.eye, frame);
+
+  // Hat: replace first empty art line
+  const hatLine = HAT_ART[bones.hat];
+  if (hatLine && !art[0].trim()) {
+    art[0] = hatLine;
+  }
+
+  // Strip empty lines from art for cleaner rendering
+  const artLines = art.filter((l) => l.trim().length > 0);
+
+  const STAT_NAMES: StatName[] = ["DEBUGGING", "PATIENCE", "CHAOS", "WISDOM", "SNARK"];
+  const statRows = STAT_NAMES.map((stat) => {
+    const val = bones.stats[stat];
+    const filled = Math.round(val / 10);
+    const bar = "\u2588".repeat(filled) + "\u2591".repeat(10 - filled);
+    const marker = stat === bones.peak ? " \u25B2" : stat === bones.dump ? " \u25BC" : "";
+    const label = `**${stat.slice(0, 3)}**${stat.slice(3)}`;
+    return `| ${label} | ${val}${marker} | \`${bar}\` |`;
+  }).join("\n");
+
+  const parts: string[] = [];
+
+  // Header: rarity dot, name, species+rarity, stars, shiny
+  parts.push(`### ${dot} ${name} · \`${bones.rarity.toUpperCase()} ${bones.species}\` · ${stars}${shiny}`);
+  parts.push("");
+
+  // ASCII art in a code block (preserves monospaced formatting)
+  parts.push("```");
+  parts.push(artLines.join("\n"));
+  parts.push("```");
+  parts.push("");
+
+  // Identity line
+  parts.push(`**Identity:** eye \`${bones.eye}\` · hat \`${bones.hat}\``);
+  parts.push("");
+
+  // Stats table
+  parts.push("| Stat | Value | Bar |");
+  parts.push("|---|---|---|");
+  parts.push(statRows);
+  parts.push("");
+
+  // Reaction (if any) — reactions often already contain asterisks
+  // for actions like "*blinks slowly*", so render them verbatim to avoid
+  // accidentally turning italics into bold.
+  if (reaction) {
+    parts.push(`\ud83d\udcac ${reaction}`);
+    parts.push("");
+  }
+
+  // Personality as blockquote
+  if (personality) {
+    parts.push(`> ${personality}`);
+  }
+
+  return parts.join("\n");
+}
+
 // ─── Compact status line render ─────────────────────────────────────────────
 
 export function renderStatusLine(

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,7 +25,7 @@ import {
 import {
   getReaction, generatePersonalityPrompt,
 } from "./reactions.ts";
-import { renderCompanionCard } from "./art.ts";
+import { renderCompanionCardMarkdown } from "./art.ts";
 
 function getInstructions(): string {
   const companion = loadCompanion();
@@ -100,7 +100,10 @@ server.tool(
     const reaction = loadReaction();
     const reactionText = reaction?.reaction ?? `*${companion.name} watches your code quietly*`;
 
-    const card = renderCompanionCard(
+    // Use markdown rendering for the MCP tool response — Claude Code's UI
+    // doesn't render raw ANSI escape codes, so we return pure markdown with
+    // unicode rarity dots instead of RGB-colored borders.
+    const card = renderCompanionCardMarkdown(
       companion.bones,
       companion.name,
       companion.personality,
@@ -141,8 +144,9 @@ server.tool(
   async () => {
     const companion = ensureCompanion();
 
-    // Stats-only card (no personality, no reaction — just the numbers)
-    const card = renderCompanionCard(
+    // Stats-only card (no personality, no reaction — just the numbers).
+    // Uses markdown renderer so the card displays cleanly in Claude Code's UI.
+    const card = renderCompanionCardMarkdown(
       companion.bones,
       companion.name,
       "",  // no personality in stats view
@@ -367,7 +371,8 @@ server.tool(
     saveActiveSlot(targetSlot);
     writeStatusState(companion, `*${companion.name} arrives*`);
 
-    const card = renderCompanionCard(
+    // Uses markdown renderer so the card displays cleanly in Claude Code's UI.
+    const card = renderCompanionCardMarkdown(
       companion.bones,
       companion.name,
       companion.personality,


### PR DESCRIPTION
## The problem

The MCP tools `buddy_show`, `buddy_stats`, and `buddy_summon` returned text that embedded raw ANSI escape sequences (e.g. `\x1b[38;2;175;135;255m` for 24-bit RGB colors). This renders cleanly in a real terminal — `bun run show` still looks great — but breaks in Claude Code's UI.

Claude Code's MCP tool output renderer **strips the ESC byte** (`\x1b`) but leaves the rest of the sequence (`[38;2;175;135;255m`) as literal visible text. The result is an unreadable card full of color-code fragments:

```
[38;2;175;135;255m╭──────────────────────────────────────╮[0m
[38;2;175;135;255m│[0m      ,>                              [38;2;175;135;255m│[0m
[38;2;175;135;255m│[0m     _,--._                           [38;2;175;135;255m│[0m
...
```

## The fix

Add a new `renderCompanionCardMarkdown()` function in `server/art.ts` that produces pure markdown with unicode rarity dots instead of ANSI color codes. The card is structured as native markdown elements that render in any MCP client UI:

- **Rarity color** → unicode dot emoji (⚪ common, 🟢 uncommon, 🔵 rare, 🟣 epic, 🟡 legendary)
- **Species ASCII art** → monospaced code block
- **Name + rarity + species + stars** → markdown h3 header with inline formatting
- **Identity (eye + hat)** → plain line with inline code spans
- **Stats** → markdown table with bold stat abbreviations and unicode bar characters
- **Reaction** → inline line with 💬 prefix
- **Personality** → markdown blockquote

### Example output

Before (ANSI codes leaking through as literal text):
```
[38;2;175;135;255m╭───...───╮[0m
[38;2;175;135;255m│[0m  [1mSesame[0m  [38;2;175;135;255m★★★★[0m
...
```

After (clean markdown, renders naturally):

> ### 🟣 Sesame · `EPIC turtle` · ★★★★ ✨
>
> *(ascii art in code block)*
>
> **Identity:** eye `@` · hat `tinyduck`
>
> | Stat | Value | Bar |
> |---|---|---|
> | **DEB**UGGING | 59 | `██████░░░░` |
> | ... | ... | ... |

## Scope — which tools were updated

All three MCP tools that render buddy cards now go through the markdown renderer:

| Tool | Slash command | What it shows |
|---|---|---|
| `buddy_show` | `/buddy` | Full card — stats + reaction + personality |
| `buddy_stats` | `/buddy stats` | Stats-only — no personality, no reaction |
| `buddy_summon` | `/buddy summon [slot]` | Full card with arrival reaction, switches active buddy |

## Scope — what is NOT affected

The original `renderCompanionCard()` function (with ANSI colors) is preserved **unchanged** because several code paths still need it for contexts where ANSI actually works:

- **`cli/pick.ts`** — interactive two-pane TUI picker that runs in a real terminal
- **`cli/show.ts`, `cli/hunt.ts`, `cli/verify.ts`, `cli/install.ts`** — these use a different renderer (`renderBuddy` from `engine.ts`), not touched at all
- **`statusline/buddy-status.sh`** — shell-native rendering, no dependency on TypeScript renderers
- **`popup/buddy-popup.sh` + `popup/popup-manager.sh`** — tmux popup overlay is also shell-native

This means:

- ✅ `bun run show` still outputs ANSI colors in your terminal
- ✅ `bun run pick` TUI still works with colors
- ✅ Claude Code status line still animates with rarity colors
- ✅ tmux popup overlay is unchanged and continues working
- ✅ `/buddy`, `/buddy stats`, `/buddy summon` inside Claude Code now render cleanly

## Files changed

- `server/art.ts` — adds `renderCompanionCardMarkdown()` (+84 lines, no deletions)
- `server/index.ts` — routes three MCP tools through the new renderer, drops unused import (+10 / -5)

## Test plan

- [x] Restart Claude Code to reload the MCP server
- [x] Run `/buddy` → card renders as clean markdown (rarity dot, ASCII art in code block, stats table, reaction, personality blockquote)
- [x] Run `/buddy stats` → same card **without** the reaction line and personality blockquote
- [x] Run `/buddy summon <existing-slot>` → active buddy switches and the new buddy's card is shown with `*{name} arrives*` reaction
- [x] Verify `bun run show` still outputs ANSI colors in the terminal (unchanged)
- [x] Verify `bun run pick` still works (unchanged)
- [ ] Verify tmux popup mode still works (unchanged)
- [ ] Verify Claude Code status line still shows colored buddy with animation (unchanged)