### PR TITLE
ci: add bun test suite and GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs on the same ref when a new commit is pushed.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Bun ${{ matrix.bun-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bun-version: [latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "disable": "bun run cli/disable.ts",
         "enable": "bun run cli/install.ts",
         "uninstall": "bun run cli/uninstall.ts",
-        "help": "bun run cli/index.ts help"
+        "help": "bun run cli/index.ts help",
+        "test": "bun test"
     },
     "files": [
         "server/",

--- a/server/engine.test.ts
+++ b/server/engine.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for the deterministic companion-generation engine.
+ *
+ * The whole point of engine.ts is that generateBones() is a pure function of
+ * (userId, salt): the same inputs must always yield the exact same companion,
+ * regardless of runtime (Bun or pure-JS wyhash fallback). These tests pin
+ * that contract down.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  SALT,
+  SPECIES,
+  RARITIES,
+  STAT_NAMES,
+  EYES,
+  HATS,
+  RARITY_FLOOR,
+  hashString,
+  mulberry32,
+  generateBones,
+  renderFace,
+  renderCompact,
+  type BuddyBones,
+} from "./engine.ts";
+
+// ─── hashString ────────────────────────────────────────────────────────────
+
+describe("hashString", () => {
+  test("is deterministic for the same input", () => {
+    expect(hashString("hello")).toBe(hashString("hello"));
+    expect(hashString("claude-buddy")).toBe(hashString("claude-buddy"));
+  });
+
+  test("returns a 32-bit unsigned integer", () => {
+    const h = hashString("whatever");
+    expect(Number.isInteger(h)).toBe(true);
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThanOrEqual(0xffffffff);
+  });
+
+  test("different inputs produce different hashes (basic collision check)", () => {
+    const samples = ["a", "b", "c", "hello", "world", "claude", "buddy"];
+    const hashes = new Set(samples.map(hashString));
+    expect(hashes.size).toBe(samples.length);
+  });
+});
+
+// ─── mulberry32 ────────────────────────────────────────────────────────────
+
+describe("mulberry32", () => {
+  test("is deterministic for the same seed", () => {
+    const rngA = mulberry32(42);
+    const rngB = mulberry32(42);
+    for (let i = 0; i < 20; i++) {
+      expect(rngA()).toBe(rngB());
+    }
+  });
+
+  test("produces values in [0, 1)", () => {
+    const rng = mulberry32(12345);
+    for (let i = 0; i < 100; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  test("different seeds diverge", () => {
+    const a = mulberry32(1);
+    const b = mulberry32(2);
+    // Extremely unlikely that 10 values match by chance
+    let matches = 0;
+    for (let i = 0; i < 10; i++) {
+      if (a() === b()) matches++;
+    }
+    expect(matches).toBeLessThan(10);
+  });
+});
+
+// ─── generateBones — determinism & invariants ─────────────────────────────
+
+describe("generateBones", () => {
+  const SAMPLE_USER_IDS = [
+    "alice",
+    "bob",
+    "claude-buddy-test-user",
+    "00000000-0000-0000-0000-000000000000",
+    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  ];
+
+  test("is deterministic: same userId yields identical bones", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const a = generateBones(id);
+      const b = generateBones(id);
+      expect(a).toEqual(b);
+    }
+  });
+
+  test("custom salt changes the output", () => {
+    const a = generateBones("alice", SALT);
+    const b = generateBones("alice", "different-salt");
+    // The salt must meaningfully perturb the result. It's theoretically
+    // possible but astronomically unlikely that every field matches.
+    expect(a).not.toEqual(b);
+  });
+
+  test("rarity is always one of the allowed values", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      expect(RARITIES).toContain(bones.rarity);
+    }
+  });
+
+  test("species is always one of the allowed values", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      expect(SPECIES).toContain(bones.species);
+    }
+  });
+
+  test("eye is always one of the allowed eye glyphs", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      expect(EYES).toContain(bones.eye);
+    }
+  });
+
+  test("hat is always one of the allowed hats", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      expect(HATS).toContain(bones.hat);
+    }
+  });
+
+  test("common rarity always has no hat", () => {
+    // Brute-force: generate enough buddies to find some commons and check them
+    let commonsFound = 0;
+    for (let i = 0; i < 200 && commonsFound < 5; i++) {
+      const bones = generateBones(`common-check-${i}`);
+      if (bones.rarity === "common") {
+        commonsFound++;
+        expect(bones.hat).toBe("none");
+      }
+    }
+    expect(commonsFound).toBeGreaterThan(0);
+  });
+
+  test("peak and dump stats are never the same", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      expect(bones.peak).not.toBe(bones.dump);
+    }
+  });
+
+  test("all stats are integers", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      for (const name of STAT_NAMES) {
+        expect(Number.isInteger(bones.stats[name])).toBe(true);
+      }
+    }
+  });
+
+  test("peak stat respects its formula: floor + 50..79, capped at 100", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      const floor = RARITY_FLOOR[bones.rarity];
+      const peakValue = bones.stats[bones.peak];
+      // Formula: min(100, floor + 50 + floor(rng() * 30))  →  range [floor+50, min(100, floor+79)]
+      expect(peakValue).toBeGreaterThanOrEqual(floor + 50);
+      expect(peakValue).toBeLessThanOrEqual(100);
+    }
+  });
+
+  test("dump stat respects its formula: floor - 10..4, clamped to >= 1", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      const floor = RARITY_FLOOR[bones.rarity];
+      const dumpValue = bones.stats[bones.dump];
+      // Formula: max(1, floor - 10 + floor(rng() * 15))  →  range [max(1, floor-10), floor+4]
+      expect(dumpValue).toBeGreaterThanOrEqual(1);
+      expect(dumpValue).toBeLessThanOrEqual(floor + 4);
+    }
+  });
+
+  test("neutral stats are in [floor, floor + 39]", () => {
+    for (const id of SAMPLE_USER_IDS) {
+      const bones = generateBones(id);
+      const floor = RARITY_FLOOR[bones.rarity];
+      for (const name of STAT_NAMES) {
+        if (name === bones.peak || name === bones.dump) continue;
+        expect(bones.stats[name]).toBeGreaterThanOrEqual(floor);
+        expect(bones.stats[name]).toBeLessThanOrEqual(floor + 39);
+      }
+    }
+  });
+
+  test("different userIds produce different bones (sanity)", () => {
+    // Not a guarantee for any two arbitrary ids, but across 20 distinct ids
+    // we expect several distinct combinations.
+    const signatures = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      const b = generateBones(`user-${i}`);
+      signatures.add(
+        `${b.rarity}|${b.species}|${b.eye}|${b.hat}|${b.peak}|${b.dump}`,
+      );
+    }
+    expect(signatures.size).toBeGreaterThan(1);
+  });
+});
+
+// ─── renderFace ────────────────────────────────────────────────────────────
+
+describe("renderFace", () => {
+  test("substitutes {E} with the eye glyph", () => {
+    expect(renderFace("turtle", "·")).toBe("[·_·]");
+    expect(renderFace("cat", "×")).toBe("=×ω×=");
+  });
+
+  test("uses the right template per species", () => {
+    const eye = "·";
+    expect(renderFace("duck", eye)).toBe("(·>");
+    expect(renderFace("blob", eye)).toBe("(··)");
+    expect(renderFace("robot", eye)).toBe("[··]");
+  });
+
+  test("never leaves a literal {E} in the output", () => {
+    for (const species of SPECIES) {
+      for (const eye of EYES) {
+        expect(renderFace(species, eye)).not.toContain("{E}");
+      }
+    }
+  });
+});
+
+// ─── renderCompact ─────────────────────────────────────────────────────────
+
+describe("renderCompact", () => {
+  // A minimal bones fixture — enough for the renderer to consume
+  const bones: BuddyBones = {
+    rarity: "rare",
+    species: "turtle",
+    eye: "·",
+    hat: "crown",
+    shiny: false,
+    stats: {
+      DEBUGGING: 40,
+      PATIENCE: 40,
+      CHAOS: 40,
+      WISDOM: 85,
+      SNARK: 10,
+    },
+    peak: "WISDOM",
+    dump: "SNARK",
+  };
+
+  test("includes the buddy name and face", () => {
+    const out = renderCompact(bones, "Sesame");
+    expect(out).toContain("Sesame");
+    expect(out).toContain("[·_·]");
+  });
+
+  test("appends the reaction bubble when provided", () => {
+    const out = renderCompact(bones, "Sesame", "hello!");
+    expect(out).toContain("hello!");
+  });
+
+  test("has no reaction bubble when reaction is omitted", () => {
+    const out = renderCompact(bones, "Sesame");
+    expect(out).not.toContain('"');
+  });
+
+  test("shows sparkles for shiny buddies", () => {
+    const shinyOut = renderCompact({ ...bones, shiny: true }, "Sesame");
+    const plainOut = renderCompact({ ...bones, shiny: false }, "Sesame");
+    expect(shinyOut).toContain("\u2728");
+    expect(plainOut).not.toContain("\u2728");
+  });
+});

--- a/server/state.test.ts
+++ b/server/state.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the pure string helpers in state.ts.
+ *
+ * The rest of state.ts is file I/O against ~/.claude-buddy/ and is not
+ * covered here — those integration-style cases belong in a separate suite
+ * with a proper temp directory. slugify() is a pure function though, so
+ * it's easy to pin down.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { slugify } from "./state.ts";
+
+describe("slugify", () => {
+  test("lowercases input", () => {
+    expect(slugify("Sesame")).toBe("sesame");
+    expect(slugify("BIG_BUDDY")).toBe("big-buddy");
+  });
+
+  test("replaces invalid characters with a dash", () => {
+    expect(slugify("hello world")).toBe("hello-world");
+    expect(slugify("foo@bar")).toBe("foo-bar");
+    expect(slugify("a/b/c")).toBe("a-b-c");
+  });
+
+  test("collapses consecutive dashes", () => {
+    expect(slugify("foo   bar")).toBe("foo-bar");
+    expect(slugify("a!!!b")).toBe("a-b");
+  });
+
+  test("trims leading and trailing dashes", () => {
+    expect(slugify("---hi---")).toBe("hi");
+    expect(slugify("  buddy  ")).toBe("buddy");
+  });
+
+  test("truncates to 14 characters", () => {
+    const long = "abcdefghijklmnopqrstuvwxyz";
+    const result = slugify(long);
+    expect(result.length).toBeLessThanOrEqual(14);
+    expect(result).toBe("abcdefghijklmn");
+  });
+
+  test("falls back to 'buddy' for empty or all-invalid input", () => {
+    expect(slugify("")).toBe("buddy");
+    expect(slugify("!!!")).toBe("buddy");
+    expect(slugify("   ")).toBe("buddy");
+  });
+
+  test("preserves digits and internal dashes", () => {
+    expect(slugify("buddy-2")).toBe("buddy-2");
+    expect(slugify("v1-0-3")).toBe("v1-0-3");
+  });
+
+  test("unicode / emoji input falls back to 'buddy'", () => {
+    expect(slugify("🐢")).toBe("buddy");
+    expect(slugify("日本語")).toBe("buddy");
+  });
+});


### PR DESCRIPTION
Closes #28

## Summary

- Adds the first automated test suite for `claude-buddy` using Bun's built-in test runner.
- Adds a GitHub Actions workflow that runs tests on every push to `main` and every PR against `main`.
- **34 tests / 477 expect() calls / ~46ms local run.**

## What's covered

### `server/engine.test.ts` — deterministic engine tests

- **`hashString`**: determinism, 32-bit unsigned range, basic collision sanity.
- **`mulberry32`**: determinism with the same seed, outputs in `[0, 1)`, divergence with different seeds.
- **`generateBones`** (the core contract):
  - same userId → identical bones (determinism, the entire point)
  - different salt → different bones
  - `rarity` / `species` / `eye` / `hat` are always in their allowed sets
  - `common` rarity always has `hat === "none"`
  - `peak !== dump`
  - all stats are integers
  - peak stat respects `min(100, floor + 50..79)`
  - dump stat respects `max(1, floor - 10..4)`
  - neutral stats fall within `[floor, floor + 39]`
- **`renderFace`**: correct substitution of `{E}` with the eye glyph, per-species templates, no leaked placeholders.
- **`renderCompact`**: includes name + face, appends reaction bubble when provided, no bubble otherwise, sparkles for shiny buddies.

### `server/state.test.ts` — pure string helpers

- **`slugify`**: lowercasing, invalid-char replacement, dash collapsing, trimming, 14-char truncation, fallback to `"buddy"` on empty / unicode / emoji input.

I/O-heavy parts of `state.ts` (manifest load/save, reaction files, migrations) are intentionally left out of this PR — those belong in a separate integration-style suite with a proper temp directory.

## CI workflow (`.github/workflows/ci.yml`)

- Triggers on `push` to `main` and on `pull_request` against `main`.
- Uses `oven-sh/setup-bun@v2`, installs with `--frozen-lockfile`, runs `bun test`.
- A concurrency group cancels in-flight runs when new commits are pushed to the same ref.
- Matrix on `bun-version: [latest]` — trivially extendable later to pin a specific version.

## Intentionally NOT in this PR

- **`tsc --noEmit` typecheck.** The project has preexisting typecheck issues (missing node types, `.ts` import extensions without `allowImportingTsExtensions`, unresolved `@modelcontextprotocol/sdk` types). Those are real problems but out of scope here — a dedicated follow-up PR should fix `tsconfig.json` and re-introduce a `typecheck` step.
- **Integration tests against the real filesystem / MCP stdio.** Would need a temp-directory harness; worth a dedicated PR.
- **Lint / format checks.** No linter is currently configured — a future PR could add Biome for zero-config lint + format.

## Test plan

- [x] `bun test` passes locally (34/34)
- [ ] CI workflow runs green on this PR
- [ ] Verify the CI status check appears on the PR
- [ ] After merge: verify the workflow runs on `main` as well