### PR TITLE
docs: expand CONTRIBUTING.md with DCO, CI, and test workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Thanks for wanting to help bring buddies back to life!
 
+New to open source? Don't worry — this guide walks you through everything
+you need: setup, DCO sign-off, tests, and what happens when you open a PR.
+
 ## Quick Setup
 
 ```bash
@@ -24,6 +27,17 @@ Restart Claude Code and type `/buddy` to verify everything works.
 | `popup/` | Animated buddy display (tmux popup mode, requires tmux >= 3.2) |
 | `cli/` | Install, uninstall, show, hunt, verify commands |
 
+## Before opening a PR — quick checklist
+
+- [ ] `bun install` ran clean
+- [ ] `bun test` is green locally (all tests pass)
+- [ ] Every commit is signed off with DCO (`git commit -s`)
+- [ ] Commit messages are in English and prefixed (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`)
+- [ ] Branch pushed to your fork, PR opened against `main`
+- [ ] CI is green on the PR
+
+If any of these feel unclear, the sections below explain them step by step.
+
 ## How to Contribute
 
 ### Bug Fixes
@@ -44,14 +58,136 @@ Species art lives in `server/art.ts` and `statusline/buddy-status.sh`. Each spec
 ### New Reactions
 Reaction templates are in `server/reactions.ts`. Species-specific reactions go in `SPECIES_REACTIONS`, general ones in `REACTIONS`.
 
-## Code Style
+## DCO (Developer Certificate of Origin)
 
-- TypeScript for server/CLI code
-- Bash for hooks and status line (keep it POSIX-friendly where possible)
-- No unnecessary dependencies
-- If it can be simple, keep it simple
+Every commit to this repo must be **signed off** with the Developer
+Certificate of Origin. This is a lightweight affirmation that you wrote
+the code, or have the right to contribute it. It's a single line appended
+to each commit message — no GPG keys, no certificates.
 
-## Testing
+If any commit on your PR is missing the sign-off, the **DCO check** goes
+red and the PR cannot be merged.
+
+### How to sign off
+
+Pass the `-s` flag to `git commit`:
+
+```bash
+git commit -s -m "feat: add sparkle particles to shiny buddies"
+```
+
+That appends a line like this to the commit message:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email come from your local `git config user.name` and
+`git config user.email`.
+
+### Make sign-off automatic (recommended)
+
+So you never forget, set up a short git alias once:
+
+```bash
+git config --global alias.ci "commit -s"
+```
+
+From now on, use `git ci -m "..."` instead of `git commit -m "..."` and
+every commit will be signed off automatically.
+
+Alternatively, if you only want sign-off to apply inside this repo (not
+globally), drop the `--global` flag and run the command from the repo
+directory.
+
+### I forgot to sign off — how do I fix it?
+
+**If it's only the last commit:**
+
+```bash
+git commit --amend --no-edit -s
+git push --force-with-lease
+```
+
+`--force-with-lease` is the safe variant of `--force`: it refuses to
+overwrite remote changes you haven't seen yet.
+
+**If it's several commits:**
+
+```bash
+git rebase --signoff HEAD~N     # replace N with how many commits back
+git push --force-with-lease
+```
+
+For example, `git rebase --signoff HEAD~3` re-signs the last three
+commits.
+
+## Automated tests
+
+Run the full test suite with:
+
+```bash
+bun test
+```
+
+All tests must pass before a PR can be merged — this is enforced by CI.
+Run it locally before pushing to catch failures early.
+
+### Where the tests live
+
+Tests live next to the code they cover:
+
+- `server/engine.test.ts` — pure-function tests for the companion
+  generator (`generateBones`, `hashString`, `mulberry32`, `renderFace`,
+  `renderCompact`)
+- `server/state.test.ts` — pure helper tests (`slugify`)
+
+### Adding new tests
+
+If you add new pure logic, please add a test for it. File-I/O, MCP
+protocol handling, and shell-script code don't need tests in this repo
+for now — those are exercised manually and via the CLI commands below.
+
+Use the built-in [`bun:test`](https://bun.sh/docs/cli/test) runner
+(Jest-compatible `describe` / `test` / `expect`), no extra dependencies
+needed:
+
+```ts
+import { describe, test, expect } from "bun:test";
+import { mulberry32 } from "./engine.ts";
+
+describe("mulberry32", () => {
+  test("is deterministic", () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    expect(a()).toBe(b());
+  });
+});
+```
+
+## What happens when you open a PR
+
+When you push a branch and open a PR against `main`, two checks run
+automatically:
+
+| Check | What it verifies |
+|-------|------------------|
+| **Test (Bun latest)** | Runs `bun test` on Ubuntu with the latest Bun. Must be green. |
+| **DCO** | Verifies every commit has a `Signed-off-by:` line. |
+
+Both are **required** — branch protection blocks the merge button until
+they are green.
+
+If a check fails:
+
+1. Click the check name on the PR to open the full log.
+2. Fix the issue locally.
+3. Commit and push again — CI re-runs automatically. No need to close or
+   reopen the PR.
+
+## Manual testing
+
+These are the sanity checks to run by hand while developing:
 
 ```bash
 # Verify buddy generation
@@ -65,6 +201,40 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 
 # Test status line
 echo '{}' | ./statusline/buddy-status.sh
+```
+
+## Code Style
+
+- TypeScript for server/CLI code
+- Bash for hooks and status line (keep it POSIX-friendly where possible)
+- No unnecessary dependencies
+- If it can be simple, keep it simple
+
+### Commit messages
+
+- Written in **English**
+- Short subject line (50-72 characters), prefixed with the change type:
+  - `feat:` — a new user-visible feature
+  - `fix:` — a bug fix
+  - `chore:` — housekeeping (deps, repo config, no behavior change)
+  - `docs:` — documentation only
+  - `refactor:` — code restructure without behavior change
+  - `test:` — adding or updating tests
+  - `ci:` — CI / workflow changes
+- Body (optional) explains the **why**, not the *what* — the diff already
+  shows the *what*
+- Always signed off (see the DCO section above)
+
+Example:
+
+```
+feat: add sparkle particles to shiny buddies
+
+Shiny buddies are rare enough that they deserve a bit of visual flair.
+This adds a three-frame sparkle animation that renders next to the
+buddy face in the status line.
+
+Signed-off-by: Your Name <your.email@example.com>
 ```
 
 ## Questions?


### PR DESCRIPTION
## Summary

Rewrites and expands `CONTRIBUTING.md` so first-time contributors can discover everything branch protection now requires from them: DCO sign-off, `bun test`, and the two required CI checks.

Before this PR, the file only documented manual CLI testing. After PR #42 introduced `bun test` + GitHub Actions, and after branch protection was enabled on `main` with `Test (Bun latest)` and `DCO` as required checks, a contributor could easily hit one of these rules without understanding what to do about it.

## What's new in the doc

- **"Before opening a PR" checklist** at the top — the one-glance view of everything that has to be true before hitting "Create pull request".
- **"DCO (Developer Certificate of Origin)" section** — the biggest addition:
  - What DCO is and why it matters
  - `git commit -s` walkthrough with an example of the appended `Signed-off-by:` line
  - `git config --global alias.ci "commit -s"` as a set-it-and-forget-it tip
  - **Recovery recipes** for the two common cases:
    - Forgot on the last commit → `git commit --amend --no-edit -s && git push --force-with-lease`
    - Forgot on several commits → `git rebase --signoff HEAD~N && git push --force-with-lease`
- **"Automated tests" section** — points to `bun test`, names the two test files, and includes a minimal `bun:test` example so contributors adding new pure logic have a template to copy.
- **"What happens when you open a PR" section** — a table listing both required checks (`Test (Bun latest)`, `DCO`), what each one verifies, and the "click the check, fix locally, push again" loop for handling failures.
- **"Commit messages" subsection under Code Style** — the conventional prefixes (`feat:` / `fix:` / `chore:` / `docs:` / `refactor:` / `test:` / `ci:`), the English-only rule, and a fully-signed example.
- Existing manual CLI test commands are preserved under a new **"Manual testing"** heading so the two kinds of testing are clearly separated.

## Why this lives in CONTRIBUTING.md

GitHub links `CONTRIBUTING.md` automatically on the "New pull request" and "New issue" screens, so first-time contributors get pointed here before they even start. That makes it the highest-leverage place to document these rules — better than a README section (which is for users, not contributors) or a separate `docs/` file (which nobody discovers).

## Test plan

- [x] `bun test` still passes (docs-only change, no code touched)
- [ ] CI workflow runs green on this PR
- [ ] Markdown renders cleanly on GitHub (tables, code blocks, checklist)
- [ ] All internal references match reality (filenames, script names, check names)