### PR TITLE
ci: bump actions/checkout from v4 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         bun-version: [latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` from `v4` to `v5` in `.github/workflows/ci.yml`. One-line change.

## Why

The post-merge CI run for PR #44 on `main` succeeded, but surfaced a deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

This is about the **internal Node.js runtime** that JavaScript-based GitHub Actions (like `actions/checkout`) run on inside the worker — **not** the Node/Bun our code uses. Our `bun test` and `tsc --noEmit` steps are entirely unaffected. But the action itself will stop working on June 2nd unless we bump it to a version compiled against Node 24.

`actions/checkout@v5` was released specifically to add that Node 24 compatibility, with no breaking changes to the checkout behavior itself. `v6` also exists (released Nov 2025, latest `v6.0.2` from Jan 2026) but carries additional changes we don't need for this fix — can be done as a separate PR later if wanted.

## What about setup-bun?

`oven-sh/setup-bun@v2` is not affected because we use the **floating `v2` tag**, which already resolves to `v2.2.0` (March 2026) — Node 24 support landed there before this warning showed up. No change needed.

## Test plan

- [ ] CI is green on this PR
- [ ] The Node.js 20 deprecation warning no longer appears in the CI run
- [ ] After merge: the post-merge run on `main` is also clean