### PR TITLE
feat: Add achievement badges — milestone tracking for your coding buddy

### DIFF
--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -100,18 +100,26 @@ row("Status script exists", existsSync(STATUS_SCRIPT) ? "yes" : `${RED}no${NC}`)
 // ─── claude-buddy state ─────────────────────────────────────────────────────
 
 section("claude-buddy state");
-const companion = tryParseJson(tryRead(join(HOME, ".claude-buddy", "companion.json")));
+const menagerie = tryParseJson(tryRead(join(HOME, ".claude-buddy", "menagerie.json")));
 const status = tryParseJson(tryRead(join(HOME, ".claude-buddy", "status.json")));
 
-if (companion) {
-  row("Companion name", companion.name ?? "(none)");
-  row("Species", companion.bones?.species ?? "(none)");
-  row("Rarity", companion.bones?.rarity ?? "(none)");
-  row("Hat", companion.bones?.hat ?? "(none)");
-  row("Eye", companion.bones?.eye ?? "(none)");
-  row("Shiny", String(companion.bones?.shiny ?? false));
+if (menagerie) {
+  const activeSlot = menagerie.active ?? "buddy";
+  const companion = menagerie.companions?.[activeSlot];
+  row("Active slot", activeSlot);
+  row("Total slots", String(Object.keys(menagerie.companions ?? {}).length));
+  if (companion) {
+    row("Companion name", companion.name ?? "(none)");
+    row("Species", companion.bones?.species ?? "(none)");
+    row("Rarity", companion.bones?.rarity ?? "(none)");
+    row("Hat", companion.bones?.hat ?? "(none)");
+    row("Eye", companion.bones?.eye ?? "(none)");
+    row("Shiny", String(companion.bones?.shiny ?? false));
+  } else {
+    err(`No companion found in active slot "${activeSlot}"`);
+  }
 } else {
-  err("No companion data found at ~/.claude-buddy/companion.json");
+  err("No manifest found at ~/.claude-buddy/menagerie.json");
 }
 
 if (status) {

--- a/hooks/buddy-comment.sh
+++ b/hooks/buddy-comment.sh
@@ -59,7 +59,7 @@ if command -v jq >/dev/null 2>&1; then
         echo '{}' > "$EVENTS_FILE"
     fi
     TMP=$(mktemp)
-    jq '.turns = (.turns // 0 + 1) | .reactions_given = (.reactions_given // 0 + 1)' "$EVENTS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$EVENTS_FILE"
+    jq '.turns = (.turns // 0 + 1)' "$EVENTS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$EVENTS_FILE"
 fi
 
 exit 0

--- a/hooks/buddy-comment.sh
+++ b/hooks/buddy-comment.sh
@@ -12,6 +12,7 @@ SID="${SID:-default}"
 STATUS_FILE="$STATE_DIR/status.json"
 COOLDOWN_FILE="$STATE_DIR/.last_comment.$SID"
 CONFIG_FILE="$STATE_DIR/config.json"
+EVENTS_FILE="$STATE_DIR/events.json"
 
 [ -f "$STATUS_FILE" ] || exit 0
 
@@ -51,5 +52,14 @@ jq --arg r "$COMMENT" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv
 jq -n --arg r "$COMMENT" --arg ts "$(date +%s)000" \
   '{reaction: $r, timestamp: ($ts | tonumber), reason: "turn"}' \
   > "$STATE_DIR/reaction.$SID.json"
+
+# Increment achievement event counters
+if command -v jq >/dev/null 2>&1; then
+    if [ ! -f "$EVENTS_FILE" ]; then
+        echo '{}' > "$EVENTS_FILE"
+    fi
+    TMP=$(mktemp)
+    jq '.turns = (.turns // 0 + 1) | .reactions_given = (.reactions_given // 0 + 1)' "$EVENTS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$EVENTS_FILE"
+fi
 
 exit 0

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -12,6 +12,7 @@ REACTION_FILE="$STATE_DIR/reaction.$SID.json"
 STATUS_FILE="$STATE_DIR/status.json"
 COOLDOWN_FILE="$STATE_DIR/.last_reaction.$SID"
 CONFIG_FILE="$STATE_DIR/config.json"
+EVENTS_FILE="$STATE_DIR/events.json"
 
 [ -f "$STATUS_FILE" ] || exit 0
 
@@ -181,6 +182,23 @@ if [ -n "$REASON" ] && [ -n "$REACTION" ]; then
     # Update status.json with reaction
     TMP=$(mktemp)
     jq --arg r "$REACTION" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
+
+    # Increment achievement event counter
+    if command -v jq >/dev/null 2>&1; then
+        if [ ! -f "$EVENTS_FILE" ]; then
+            echo '{}' > "$EVENTS_FILE"
+        fi
+        case "$REASON" in
+            "test-fail")  KEY="tests_failed" ;;
+            "error")      KEY="errors_seen" ;;
+            "large-diff") KEY="large_diffs" ;;
+            *)            KEY="" ;;
+        esac
+        if [ -n "$KEY" ]; then
+            TMP=$(mktemp)
+            jq --arg k "$KEY" 'if .[$k] then .[$k] += 1 else .[$k] = 1 end' "$EVENTS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$EVENTS_FILE"
+        fi
+    fi
 fi
 
 exit 0

--- a/server/achievements.test.ts
+++ b/server/achievements.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for achievements.ts
+ *
+ * Tests the achievement badge system: definitions, event counters,
+ * threshold checks, and the pure check logic. The checkAndAward
+ * function and renderers do file I/O and are not tested here,
+ * consistent with the project policy in TESTING.md.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  ACHIEVEMENTS,
+  COUNTER_KEYS,
+  type EventCounters,
+} from "./achievements.ts";
+
+const EMPTY_EVENTS: EventCounters = {
+  errors_seen: 0,
+  tests_failed: 0,
+  large_diffs: 0,
+  turns: 0,
+  pets: 0,
+  sessions: 0,
+  reactions_given: 0,
+  commands_run: 0,
+  days_active: 0,
+};
+
+function makeEvents(overrides: Partial<EventCounters> = {}): EventCounters {
+  return { ...EMPTY_EVENTS, ...overrides };
+}
+
+// ─── Achievement definitions ─────────────────────────────────────────────
+
+describe("ACHIEVEMENTS array", () => {
+  test("is non-empty", () => {
+    expect(ACHIEVEMENTS.length).toBeGreaterThan(0);
+  });
+
+  test("every achievement has a unique id", () => {
+    const ids = ACHIEVEMENTS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("every achievement has required fields", () => {
+    for (const ach of ACHIEVEMENTS) {
+      expect(typeof ach.id).toBe("string");
+      expect(ach.id.length).toBeGreaterThan(0);
+      expect(typeof ach.name).toBe("string");
+      expect(ach.name.length).toBeGreaterThan(0);
+      expect(typeof ach.description).toBe("string");
+      expect(ach.description.length).toBeGreaterThan(0);
+      expect(typeof ach.icon).toBe("string");
+      expect(typeof ach.secret).toBe("boolean");
+      expect(typeof ach.check).toBe("function");
+    }
+  });
+
+  test("check function accepts EventCounters and returns boolean", () => {
+    for (const ach of ACHIEVEMENTS) {
+      const result = ach.check(EMPTY_EVENTS);
+      expect(typeof result).toBe("boolean");
+    }
+  });
+});
+
+// ─── COUNTER_KEYS ─────────────────────────────────────────────────────────
+
+describe("COUNTER_KEYS", () => {
+  test("matches every key in EventCounters", () => {
+    const expectedKeys = Object.keys(EMPTY_EVENTS).sort() as (keyof EventCounters)[];
+    const actualKeys = [...COUNTER_KEYS].sort() as (keyof EventCounters)[];
+    expect(actualKeys).toEqual(expectedKeys);
+  });
+});
+
+// ─── Achievement check thresholds ────────────────────────────────────────
+
+describe("achievement thresholds", () => {
+  test("first_steps always unlocks", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "first_steps")!;
+    expect(ach).toBeDefined();
+    expect(ach.check(EMPTY_EVENTS)).toBe(true);
+  });
+
+  test("good_boy requires 10 pets", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "good_boy")!;
+    expect(ach.check(makeEvents({ pets: 9 }))).toBe(false);
+    expect(ach.check(makeEvents({ pets: 10 }))).toBe(true);
+    expect(ach.check(makeEvents({ pets: 50 }))).toBe(true);
+  });
+
+  test("best_friend requires 50 pets", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "best_friend")!;
+    expect(ach.check(makeEvents({ pets: 49 }))).toBe(false);
+    expect(ach.check(makeEvents({ pets: 50 }))).toBe(true);
+  });
+
+  test("bug_spotter requires 1 error", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "bug_spotter")!;
+    expect(ach.check(makeEvents({ errors_seen: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ errors_seen: 1 }))).toBe(true);
+  });
+
+  test("error_whisperer requires 25 errors", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "error_whisperer")!;
+    expect(ach.check(makeEvents({ errors_seen: 24 }))).toBe(false);
+    expect(ach.check(makeEvents({ errors_seen: 25 }))).toBe(true);
+  });
+
+  test("battle_scarred requires 100 errors and is secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "battle_scarred")!;
+    expect(ach.secret).toBe(true);
+    expect(ach.check(makeEvents({ errors_seen: 99 }))).toBe(false);
+    expect(ach.check(makeEvents({ errors_seen: 100 }))).toBe(true);
+  });
+
+  test("test_witness requires 1 test failure", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "test_witness")!;
+    expect(ach.check(makeEvents({ tests_failed: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ tests_failed: 1 }))).toBe(true);
+  });
+
+  test("test_veteran requires 50 test failures", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "test_veteran")!;
+    expect(ach.check(makeEvents({ tests_failed: 49 }))).toBe(false);
+    expect(ach.check(makeEvents({ tests_failed: 50 }))).toBe(true);
+  });
+
+  test("big_mover requires 1 large diff", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "big_mover")!;
+    expect(ach.check(makeEvents({ large_diffs: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ large_diffs: 1 }))).toBe(true);
+  });
+
+  test("refactor_machine requires 10 large diffs", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "refactor_machine")!;
+    expect(ach.check(makeEvents({ large_diffs: 9 }))).toBe(false);
+    expect(ach.check(makeEvents({ large_diffs: 10 }))).toBe(true);
+  });
+
+  test("chatterbox requires 100 reactions", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "chatterbox")!;
+    expect(ach.check(makeEvents({ reactions_given: 99 }))).toBe(false);
+    expect(ach.check(makeEvents({ reactions_given: 100 }))).toBe(true);
+  });
+
+  test("week_streak requires 7 days and is not secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "week_streak")!;
+    expect(ach.secret).toBe(false);
+    expect(ach.check(makeEvents({ days_active: 6 }))).toBe(false);
+    expect(ach.check(makeEvents({ days_active: 7 }))).toBe(true);
+  });
+
+  test("month_streak requires 30 days and is secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "month_streak")!;
+    expect(ach.secret).toBe(true);
+    expect(ach.check(makeEvents({ days_active: 29 }))).toBe(false);
+    expect(ach.check(makeEvents({ days_active: 30 }))).toBe(true);
+  });
+
+  test("power_user requires 50 commands", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "power_user")!;
+    expect(ach.check(makeEvents({ commands_run: 49 }))).toBe(false);
+    expect(ach.check(makeEvents({ commands_run: 50 }))).toBe(true);
+  });
+
+  test("dedicated requires 200 turns", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "dedicated")!;
+    expect(ach.check(makeEvents({ turns: 199 }))).toBe(false);
+    expect(ach.check(makeEvents({ turns: 200 }))).toBe(true);
+  });
+
+  test("thousand_turns requires 1000 turns and is secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "thousand_turns")!;
+    expect(ach.secret).toBe(true);
+    expect(ach.check(makeEvents({ turns: 999 }))).toBe(false);
+    expect(ach.check(makeEvents({ turns: 1000 }))).toBe(true);
+  });
+});
+
+// ─── Unlock simulation (pure logic) ──────────────────────────────────────
+
+describe("unlock simulation via check functions", () => {
+  test("with empty events, only first_steps would unlock", () => {
+    const wouldUnlock = ACHIEVEMENTS.filter((a) => a.check(EMPTY_EVENTS));
+    expect(wouldUnlock.length).toBe(1);
+    expect(wouldUnlock[0].id).toBe("first_steps");
+  });
+
+  test("with maxed events, all achievements would unlock", () => {
+    const maxed = makeEvents({
+      errors_seen: 999,
+      tests_failed: 999,
+      large_diffs: 999,
+      turns: 9999,
+      pets: 999,
+      sessions: 999,
+      reactions_given: 999,
+      commands_run: 999,
+      days_active: 999,
+    });
+    const wouldUnlock = ACHIEVEMENTS.filter((a) => a.check(maxed));
+    expect(wouldUnlock.length).toBe(ACHIEVEMENTS.length);
+  });
+
+  test("progressive: more events satisfy more check functions", () => {
+    const s1 = ACHIEVEMENTS.filter((a) => a.check(makeEvents())).length;
+    const s2 = ACHIEVEMENTS.filter((a) => a.check(makeEvents({ pets: 10 }))).length;
+    const s3 = ACHIEVEMENTS.filter((a) => a.check(makeEvents({ pets: 10, errors_seen: 25 }))).length;
+    expect(s2).toBeGreaterThan(s1);
+    expect(s3).toBeGreaterThan(s2);
+  });
+
+  test("achievements at exact threshold boundary", () => {
+    const events = makeEvents({ pets: 10 });
+    const ids = ACHIEVEMENTS.filter((a) => a.check(events)).map((a) => a.id);
+    expect(ids).toContain("good_boy");
+    expect(ids).toContain("first_steps");
+    expect(ids).not.toContain("best_friend");
+  });
+});
+
+// ─── Secret achievement visibility ───────────────────────────────────────
+
+describe("secret achievements", () => {
+  test("secret achievements are correctly flagged", () => {
+    const secretIds = ACHIEVEMENTS.filter((a) => a.secret).map((a) => a.id);
+    expect(secretIds).toContain("battle_scarred");
+    expect(secretIds).toContain("month_streak");
+    expect(secretIds).toContain("thousand_turns");
+  });
+
+  test("non-secret achievements are the majority", () => {
+    const nonSecret = ACHIEVEMENTS.filter((a) => !a.secret);
+    expect(nonSecret.length).toBeGreaterThan(0);
+    const secret = ACHIEVEMENTS.filter((a) => a.secret);
+    expect(nonSecret.length).toBeGreaterThan(secret.length);
+  });
+});
+
+// ─── EventCounters shape ─────────────────────────────────────────────────
+
+describe("EventCounters", () => {
+  test("EMPTY_EVENTS has all counter keys set to 0", () => {
+    for (const key of COUNTER_KEYS) {
+      expect(EMPTY_EVENTS[key]).toBe(0);
+    }
+  });
+
+  test("all counter keys are numeric fields", () => {
+    for (const key of COUNTER_KEYS) {
+      expect(typeof EMPTY_EVENTS[key]).toBe("number");
+    }
+  });
+});

--- a/server/achievements.test.ts
+++ b/server/achievements.test.ts
@@ -252,8 +252,9 @@ describe("per-slot vs global counter scoping", () => {
     expect((GLOBAL_KEYS as string[]).includes("pets")).toBe(false);
   });
 
-  test("turns is a slot-scoped key", () => {
-    expect((SLOT_KEYS as string[]).includes("turns")).toBe(true);
+  test("turns is a global key", () => {
+    expect((GLOBAL_KEYS as string[]).includes("turns")).toBe(true);
+    expect((SLOT_KEYS as string[]).includes("turns")).toBe(false);
   });
 
   test("reactions_given is a slot-scoped key", () => {
@@ -286,7 +287,7 @@ describe("per-slot vs global counter scoping", () => {
     expect(best.check(makeEvents({ pets: 50 }))).toBe(true);
   });
 
-  test("dedicated and thousand_turns check turns (slot-scoped)", () => {
+  test("dedicated and thousand_turns check turns (global)", () => {
     const ded = ACHIEVEMENTS.find((a) => a.id === "dedicated")!;
     const thou = ACHIEVEMENTS.find((a) => a.id === "thousand_turns")!;
     expect(ded.check(makeEvents({ turns: 200 }))).toBe(true);

--- a/server/achievements.test.ts
+++ b/server/achievements.test.ts
@@ -2,16 +2,20 @@
  * Unit tests for achievements.ts
  *
  * Tests the achievement badge system: definitions, event counters,
- * threshold checks, and the pure check logic. The checkAndAward
- * function and renderers do file I/O and are not tested here,
- * consistent with the project policy in TESTING.md.
+ * threshold checks, per-slot scoping, and the pure check logic.
+ * File I/O functions (checkAndAward, renderers) persist to disk and
+ * are not tested here, consistent with the project policy in TESTING.md.
  */
 
 import { describe, test, expect } from "bun:test";
 import {
   ACHIEVEMENTS,
   COUNTER_KEYS,
+  GLOBAL_KEYS,
+  SLOT_KEYS,
   type EventCounters,
+  type GlobalCounters,
+  type SlotCounters,
 } from "./achievements.ts";
 
 const EMPTY_EVENTS: EventCounters = {
@@ -61,6 +65,25 @@ describe("ACHIEVEMENTS array", () => {
       const result = ach.check(EMPTY_EVENTS);
       expect(typeof result).toBe("boolean");
     }
+  });
+});
+
+// ─── Counter key partitions ──────────────────────────────────────────────
+
+describe("counter key partitions", () => {
+  test("GLOBAL_KEYS and SLOT_KEYS are disjoint", () => {
+    const globalSet = new Set(GLOBAL_KEYS as string[]);
+    const slotSet = new Set(SLOT_KEYS as string[]);
+    for (const k of globalSet) {
+      expect(slotSet.has(k)).toBe(false);
+    }
+  });
+
+  test("COUNTER_KEYS is the union of GLOBAL_KEYS and SLOT_KEYS", () => {
+    const counterSet = new Set(COUNTER_KEYS as string[]);
+    for (const k of GLOBAL_KEYS) expect(counterSet.has(k)).toBe(true);
+    for (const k of SLOT_KEYS) expect(counterSet.has(k)).toBe(true);
+    expect(COUNTER_KEYS.length).toBe(GLOBAL_KEYS.length + SLOT_KEYS.length);
   });
 });
 
@@ -218,6 +241,61 @@ describe("unlock simulation via check functions", () => {
     expect(ids).toContain("good_boy");
     expect(ids).toContain("first_steps");
     expect(ids).not.toContain("best_friend");
+  });
+});
+
+// ─── Per-slot vs global scoping ───────────────────────────────────────────
+
+describe("per-slot vs global counter scoping", () => {
+  test("pets is a slot-scoped key", () => {
+    expect((SLOT_KEYS as string[]).includes("pets")).toBe(true);
+    expect((GLOBAL_KEYS as string[]).includes("pets")).toBe(false);
+  });
+
+  test("turns is a slot-scoped key", () => {
+    expect((SLOT_KEYS as string[]).includes("turns")).toBe(true);
+  });
+
+  test("reactions_given is a slot-scoped key", () => {
+    expect((SLOT_KEYS as string[]).includes("reactions_given")).toBe(true);
+  });
+
+  test("errors_seen is a global key", () => {
+    expect((GLOBAL_KEYS as string[]).includes("errors_seen")).toBe(true);
+    expect((SLOT_KEYS as string[]).includes("errors_seen")).toBe(false);
+  });
+
+  test("tests_failed is a global key", () => {
+    expect((GLOBAL_KEYS as string[]).includes("tests_failed")).toBe(true);
+  });
+
+  test("days_active is a global key", () => {
+    expect((GLOBAL_KEYS as string[]).includes("days_active")).toBe(true);
+  });
+
+  test("commands_run is a global key", () => {
+    expect((GLOBAL_KEYS as string[]).includes("commands_run")).toBe(true);
+  });
+
+  test("good_boy and best_friend check pets (slot-scoped)", () => {
+    const good = ACHIEVEMENTS.find((a) => a.id === "good_boy")!;
+    const best = ACHIEVEMENTS.find((a) => a.id === "best_friend")!;
+    expect(good.check(makeEvents({ pets: 0 }))).toBe(false);
+    expect(best.check(makeEvents({ pets: 0 }))).toBe(false);
+    expect(good.check(makeEvents({ pets: 10 }))).toBe(true);
+    expect(best.check(makeEvents({ pets: 50 }))).toBe(true);
+  });
+
+  test("dedicated and thousand_turns check turns (slot-scoped)", () => {
+    const ded = ACHIEVEMENTS.find((a) => a.id === "dedicated")!;
+    const thou = ACHIEVEMENTS.find((a) => a.id === "thousand_turns")!;
+    expect(ded.check(makeEvents({ turns: 200 }))).toBe(true);
+    expect(thou.check(makeEvents({ turns: 1000 }))).toBe(true);
+  });
+
+  test("chatterbox checks reactions_given (slot-scoped)", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "chatterbox")!;
+    expect(ach.check(makeEvents({ reactions_given: 100 }))).toBe(true);
   });
 });
 

--- a/server/achievements.ts
+++ b/server/achievements.ts
@@ -1,0 +1,338 @@
+/**
+ * Achievement badges — milestones that unlock as you code with your buddy
+ *
+ * Events (errors seen, pets, turns, etc.) are tracked via counters in
+ * ~/.claude-buddy/events.json.  This module checks thresholds and
+ * awards badges, persisted in ~/.claude-buddy/unlocked.json.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const STATE_DIR = join(homedir(), ".claude-buddy");
+const EVENTS_FILE = join(STATE_DIR, "events.json");
+const DAYS_FILE = join(STATE_DIR, "active_days.json");
+const UNLOCKED_FILE = join(STATE_DIR, "unlocked.json");
+
+function ensureDir(): void {
+  if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
+}
+
+// ─── Event counters ─────────────────────────────────────────────────────────
+
+export interface EventCounters {
+  errors_seen: number;
+  tests_failed: number;
+  large_diffs: number;
+  turns: number;
+  pets: number;
+  sessions: number;
+  reactions_given: number;
+  commands_run: number;
+  days_active: number;
+}
+
+export const COUNTER_KEYS: (keyof EventCounters)[] = [
+  "errors_seen", "tests_failed", "large_diffs", "turns", "pets",
+  "sessions", "reactions_given", "commands_run", "days_active",
+];
+
+const EMPTY_EVENTS: EventCounters = {
+  errors_seen: 0, tests_failed: 0, large_diffs: 0, turns: 0,
+  pets: 0, sessions: 0, reactions_given: 0, commands_run: 0,
+  days_active: 0,
+};
+
+export function loadEvents(): EventCounters {
+  try {
+    const parsed = JSON.parse(readFileSync(EVENTS_FILE, "utf8"));
+    return { ...EMPTY_EVENTS, ...parsed };
+  } catch {
+    return { ...EMPTY_EVENTS };
+  }
+}
+
+export function saveEvents(events: EventCounters): void {
+  ensureDir();
+  writeFileSync(EVENTS_FILE, JSON.stringify(events, null, 2));
+}
+
+export function incrementEvent(key: keyof EventCounters, amount: number = 1): EventCounters {
+  const events = loadEvents();
+  events[key] += amount;
+  saveEvents(events);
+  return events;
+}
+
+// ─── Day tracking ────────────────────────────────────────────────────────────
+
+interface DayTracker {
+  lastDate: string;
+  totalDays: number;
+}
+
+export function trackActiveDay(): void {
+  const today = new Date().toISOString().slice(0, 10);
+  let tracker: DayTracker;
+  try {
+    tracker = JSON.parse(readFileSync(DAYS_FILE, "utf8"));
+  } catch {
+    tracker = { lastDate: "", totalDays: 0 };
+  }
+  if (tracker.lastDate === today) return;
+
+  tracker.lastDate = today;
+  tracker.totalDays += 1;
+  ensureDir();
+  writeFileSync(DAYS_FILE, JSON.stringify(tracker, null, 2));
+
+  const events = loadEvents();
+  events.days_active = tracker.totalDays;
+  saveEvents(events);
+}
+
+// ─── Achievement definitions ─────────────────────────────────────────────────
+
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  check: (events: EventCounters) => boolean;
+  secret: boolean;
+}
+
+export const ACHIEVEMENTS: Achievement[] = [
+  {
+    id: "first_steps",
+    name: "First Steps",
+    description: "Hatch your buddy for the first time",
+    icon: "\ud83c\udf1f",
+    check: () => true,
+    secret: false,
+  },
+  {
+    id: "good_boy",
+    name: "Good Buddy",
+    description: "Pet your companion 10 times",
+    icon: "\ud83e\uddf9",
+    check: (e) => e.pets >= 10,
+    secret: false,
+  },
+  {
+    id: "best_friend",
+    name: "Best Friend",
+    description: "Pet your companion 50 times",
+    icon: "\u2764\ufe0f",
+    check: (e) => e.pets >= 50,
+    secret: false,
+  },
+  {
+    id: "bug_spotter",
+    name: "Bug Spotter",
+    description: "Witness your first error together",
+    icon: "\ud83d\udc1b",
+    check: (e) => e.errors_seen >= 1,
+    secret: false,
+  },
+  {
+    id: "error_whisperer",
+    name: "Error Whisperer",
+    description: "Survive 25 errors as a team",
+    icon: "\ud83d\udd27",
+    check: (e) => e.errors_seen >= 25,
+    secret: false,
+  },
+  {
+    id: "battle_scarred",
+    name: "Battle-Scarred",
+    description: "Survive 100 errors together",
+    icon: "\ud83d\udc80",
+    check: (e) => e.errors_seen >= 100,
+    secret: true,
+  },
+  {
+    id: "test_witness",
+    name: "Test Witness",
+    description: "See your first test failure",
+    icon: "\u274c",
+    check: (e) => e.tests_failed >= 1,
+    secret: false,
+  },
+  {
+    id: "test_veteran",
+    name: "Test Veteran",
+    description: "Witness 50 test failures",
+    icon: "\ud83d\udcca",
+    check: (e) => e.tests_failed >= 50,
+    secret: false,
+  },
+  {
+    id: "big_mover",
+    name: "Big Mover",
+    description: "Make a diff with 80+ lines",
+    icon: "\ud83d\udce6",
+    check: (e) => e.large_diffs >= 1,
+    secret: false,
+  },
+  {
+    id: "refactor_machine",
+    name: "Refactor Machine",
+    description: "Make 10 large diffs",
+    icon: "\ud83d\udd28",
+    check: (e) => e.large_diffs >= 10,
+    secret: false,
+  },
+  {
+    id: "chatterbox",
+    name: "Chatterbox",
+    description: "Your buddy reacts 100 times",
+    icon: "\ud83d\udcac",
+    check: (e) => e.reactions_given >= 100,
+    secret: false,
+  },
+  {
+    id: "week_streak",
+    name: "Week Streak",
+    description: "Code with your buddy for 7 days",
+    icon: "\ud83d\udd25",
+    check: (e) => e.days_active >= 7,
+    secret: false,
+  },
+  {
+    id: "month_streak",
+    name: "Month Streak",
+    description: "Code with your buddy for 30 days",
+    icon: "\ud83d\udc51",
+    check: (e) => e.days_active >= 30,
+    secret: true,
+  },
+  {
+    id: "power_user",
+    name: "Power User",
+    description: "Run 50 buddy commands",
+    icon: "\u26a1",
+    check: (e) => e.commands_run >= 50,
+    secret: false,
+  },
+  {
+    id: "dedicated",
+    name: "Dedicated Companion",
+    description: "Complete 200 turns together",
+    icon: "\ud83c\udfc5",
+    check: (e) => e.turns >= 200,
+    secret: false,
+  },
+  {
+    id: "thousand_turns",
+    name: "Thousand Turns",
+    description: "Reach 1000 turns together",
+    icon: "\ud83c\udf96",
+    check: (e) => e.turns >= 1000,
+    secret: true,
+  },
+];
+
+// ─── Unlocked badges persistence ─────────────────────────────────────────────
+
+export interface UnlockedAchievement {
+  id: string;
+  unlockedAt: number;
+}
+
+export function loadUnlocked(): UnlockedAchievement[] {
+  try {
+    return JSON.parse(readFileSync(UNLOCKED_FILE, "utf8"));
+  } catch {
+    return [];
+  }
+}
+
+export function saveUnlocked(unlocked: UnlockedAchievement[]): void {
+  ensureDir();
+  writeFileSync(UNLOCKED_FILE, JSON.stringify(unlocked, null, 2));
+}
+
+// ─── Check + award ───────────────────────────────────────────────────────────
+
+export function checkAndAward(events?: EventCounters): Achievement[] {
+  const e = events ?? loadEvents();
+  const unlocked = loadUnlocked();
+  const unlockedIds = new Set(unlocked.map((u) => u.id));
+
+  const newlyUnlocked: Achievement[] = [];
+
+  for (const ach of ACHIEVEMENTS) {
+    if (unlockedIds.has(ach.id)) continue;
+    if (ach.check(e)) {
+      unlocked.push({ id: ach.id, unlockedAt: Date.now() });
+      newlyUnlocked.push(ach);
+    }
+  }
+
+  if (newlyUnlocked.length > 0) {
+    saveUnlocked(unlocked);
+  }
+
+  return newlyUnlocked;
+}
+
+// ─── Render achievement card ─────────────────────────────────────────────────
+
+const GOLD = "\x1b[38;2;255;193;7m";
+const NC = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+
+export function renderAchievementsCard(): string {
+  const unlocked = loadUnlocked();
+  const unlockedIds = new Set(unlocked.map((u) => u.id));
+
+  const W = 40;
+  const hr = "\u2500".repeat(W - 2);
+  const sep = `\u251c${"\u254c".repeat(W - 2)}\u2524`;
+  const lines: string[] = [];
+
+  const visibleAchs = ACHIEVEMENTS.filter((a) => !a.secret || unlockedIds.has(a.id));
+  const total = visibleAchs.length;
+  const earned = unlockedIds.size;
+
+  lines.push(`${GOLD}\u256d${hr}\u256e${NC}`);
+
+  const header = "\ud83c\udfc6 ACHIEVEMENTS";
+  lines.push(`${GOLD}\u2502${NC}  ${BOLD}${header}${NC}${"".padEnd(W - header.length - 4)}${GOLD}\u2502${NC}`);
+
+  const barFilled = total > 0 ? Math.round((earned / total) * 20) : 0;
+  const bar = "\u2588".repeat(barFilled) + "\u2591".repeat(20 - barFilled);
+  const barText = `${bar} ${earned}/${total}`;
+  lines.push(`${GOLD}\u2502${NC}  ${barText}${"".padEnd(W - barText.length - 4)}${GOLD}\u2502${NC}`);
+
+  lines.push(`${GOLD}${sep}${NC}`);
+
+  for (const ach of ACHIEVEMENTS) {
+    if (ach.secret && !unlockedIds.has(ach.id)) continue;
+
+    const done = unlockedIds.has(ach.id);
+    const status = done ? "\u2705" : "\u2610";
+    const content = ` ${ach.icon}${status} ${ach.name}`;
+    const descContent = `    ${ach.description}`;
+
+    if (done) {
+      lines.push(`${GOLD}\u2502${NC} ${BOLD}${content}${NC}${"".padEnd(W - content.length - 3)}${GOLD}\u2502${NC}`);
+    } else {
+      lines.push(`${GOLD}\u2502${NC} ${DIM}${content}${NC}${"".padEnd(W - content.length - 3)}${GOLD}\u2502${NC}`);
+    }
+    lines.push(`${GOLD}\u2502${NC} ${DIM}${descContent}${NC}${"".padEnd(W - descContent.length - 3)}${GOLD}\u2502${NC}`);
+  }
+
+  if (earned > 0 && earned === ACHIEVEMENTS.length) {
+    lines.push(`${GOLD}${sep}${NC}`);
+    const complete = "\u2728 ALL ACHIEVEMENTS UNLOCKED! \u2728";
+    lines.push(`${GOLD}\u2502${NC}  ${BOLD}${complete}${NC}${"".padEnd(W - complete.length - 4)}${GOLD}\u2502${NC}`);
+  }
+
+  lines.push(`${GOLD}\u2570${hr}\u256f${NC}`);
+
+  return lines.join("\n");
+}

--- a/server/achievements.ts
+++ b/server/achievements.ts
@@ -1,12 +1,15 @@
 /**
  * Achievement badges — milestones that unlock as you code with your buddy
  *
- * Events (errors seen, pets, turns, etc.) are tracked via counters in
- * ~/.claude-buddy/events.json.  This module checks thresholds and
- * awards badges, persisted in ~/.claude-buddy/unlocked.json.
+ * Event counters are split into two scopes:
+ *   Global (events.json):      coding-activity counters (errors, tests, diffs, days, sessions, commands)
+ *   Per-slot (events.<slot>.json): buddy-relationship counters (pets, turns, reactions)
+ *
+ * Achievement checks merge both scopes so threshold logic is transparent.
+ * All writes use tmp+rename for atomicity (same pattern as state.ts).
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -15,55 +18,132 @@ const EVENTS_FILE = join(STATE_DIR, "events.json");
 const DAYS_FILE = join(STATE_DIR, "active_days.json");
 const UNLOCKED_FILE = join(STATE_DIR, "unlocked.json");
 
+function slotEventsFile(slot: string): string {
+  return join(STATE_DIR, `events.${slot}.json`);
+}
+
 function ensureDir(): void {
   if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
 }
 
-// ─── Event counters ─────────────────────────────────────────────────────────
+function atomicWrite(path: string, data: string): void {
+  ensureDir();
+  const tmp = path + ".tmp";
+  writeFileSync(tmp, data);
+  renameSync(tmp, path);
+}
 
-export interface EventCounters {
+// ─── Event counters (global) ─────────────────────────────────────────────────
+
+export interface GlobalCounters {
   errors_seen: number;
   tests_failed: number;
   large_diffs: number;
-  turns: number;
-  pets: number;
   sessions: number;
-  reactions_given: number;
   commands_run: number;
   days_active: number;
 }
+
+// ─── Event counters (per-slot) ────────────────────────────────────────────────
+
+export interface SlotCounters {
+  pets: number;
+  turns: number;
+  reactions_given: number;
+}
+
+// ─── Merged view for achievement checks ───────────────────────────────────────
+
+export interface EventCounters extends GlobalCounters {
+  pets: number;
+  turns: number;
+  reactions_given: number;
+}
+
+export const GLOBAL_KEYS: (keyof GlobalCounters)[] = [
+  "errors_seen", "tests_failed", "large_diffs",
+  "sessions", "commands_run", "days_active",
+];
+
+export const SLOT_KEYS: (keyof SlotCounters)[] = [
+  "pets", "turns", "reactions_given",
+];
 
 export const COUNTER_KEYS: (keyof EventCounters)[] = [
   "errors_seen", "tests_failed", "large_diffs", "turns", "pets",
   "sessions", "reactions_given", "commands_run", "days_active",
 ];
 
-const EMPTY_EVENTS: EventCounters = {
-  errors_seen: 0, tests_failed: 0, large_diffs: 0, turns: 0,
-  pets: 0, sessions: 0, reactions_given: 0, commands_run: 0,
-  days_active: 0,
+const EMPTY_GLOBAL: GlobalCounters = {
+  errors_seen: 0, tests_failed: 0, large_diffs: 0,
+  sessions: 0, commands_run: 0, days_active: 0,
 };
 
-export function loadEvents(): EventCounters {
+const EMPTY_SLOT: SlotCounters = {
+  pets: 0, turns: 0, reactions_given: 0,
+};
+
+export function loadGlobalEvents(): GlobalCounters {
   try {
     const parsed = JSON.parse(readFileSync(EVENTS_FILE, "utf8"));
-    return { ...EMPTY_EVENTS, ...parsed };
+    return { ...EMPTY_GLOBAL, ...parsed };
   } catch {
-    return { ...EMPTY_EVENTS };
+    return { ...EMPTY_GLOBAL };
   }
 }
 
-export function saveEvents(events: EventCounters): void {
-  ensureDir();
-  writeFileSync(EVENTS_FILE, JSON.stringify(events, null, 2));
+export function saveGlobalEvents(events: GlobalCounters): void {
+  atomicWrite(EVENTS_FILE, JSON.stringify(events, null, 2));
 }
 
-export function incrementEvent(key: keyof EventCounters, amount: number = 1): EventCounters {
-  const events = loadEvents();
-  events[key] += amount;
-  saveEvents(events);
-  return events;
+export function loadSlotEvents(slot: string): SlotCounters {
+  try {
+    const parsed = JSON.parse(readFileSync(slotEventsFile(slot), "utf8"));
+    return { ...EMPTY_SLOT, ...parsed };
+  } catch {
+    return { ...EMPTY_SLOT };
+  }
 }
+
+export function saveSlotEvents(slot: string, events: SlotCounters): void {
+  atomicWrite(slotEventsFile(slot), JSON.stringify(events, null, 2));
+}
+
+export function loadEvents(slot?: string): EventCounters {
+  const global = loadGlobalEvents();
+  if (!slot) {
+    return { ...global, pets: 0, turns: 0, reactions_given: 0 };
+  }
+  const slotEvents = loadSlotEvents(slot);
+  return {
+    ...global,
+    pets: slotEvents.pets,
+    turns: slotEvents.turns,
+    reactions_given: slotEvents.reactions_given,
+  };
+}
+
+export function incrementEvent(key: keyof EventCounters, amount: number = 1, slot?: string): EventCounters {
+  if ((SLOT_KEYS as string[]).includes(key) && slot) {
+    const slotEvents = loadSlotEvents(slot);
+    (slotEvents as any)[key] += amount;
+    saveSlotEvents(slot, slotEvents);
+  } else {
+    const global = loadGlobalEvents();
+    if ((GLOBAL_KEYS as string[]).includes(key)) {
+      (global as any)[key] += amount;
+    }
+    saveGlobalEvents(global);
+  }
+  return loadEvents(slot);
+}
+
+// ─── Backward-compatible overloads ────────────────────────────────────────────
+// The shell hooks (react.sh) write directly to events.json for global counters
+// like errors_seen and tests_failed. The loadEvents() and saveEvents() names
+// below maintain that compatibility.
+
+export { loadEvents as loadGlobalEventsCompat, loadGlobalEvents as loadGlobalEventsDirect };
 
 // ─── Day tracking ────────────────────────────────────────────────────────────
 
@@ -84,12 +164,11 @@ export function trackActiveDay(): void {
 
   tracker.lastDate = today;
   tracker.totalDays += 1;
-  ensureDir();
-  writeFileSync(DAYS_FILE, JSON.stringify(tracker, null, 2));
+  atomicWrite(DAYS_FILE, JSON.stringify(tracker, null, 2));
 
-  const events = loadEvents();
+  const events = loadGlobalEvents();
   events.days_active = tracker.totalDays;
-  saveEvents(events);
+  saveGlobalEvents(events);
 }
 
 // ─── Achievement definitions ─────────────────────────────────────────────────
@@ -239,6 +318,7 @@ export const ACHIEVEMENTS: Achievement[] = [
 export interface UnlockedAchievement {
   id: string;
   unlockedAt: number;
+  slot?: string;
 }
 
 export function loadUnlocked(): UnlockedAchievement[] {
@@ -250,14 +330,13 @@ export function loadUnlocked(): UnlockedAchievement[] {
 }
 
 export function saveUnlocked(unlocked: UnlockedAchievement[]): void {
-  ensureDir();
-  writeFileSync(UNLOCKED_FILE, JSON.stringify(unlocked, null, 2));
+  atomicWrite(UNLOCKED_FILE, JSON.stringify(unlocked, null, 2));
 }
 
 // ─── Check + award ───────────────────────────────────────────────────────────
 
-export function checkAndAward(events?: EventCounters): Achievement[] {
-  const e = events ?? loadEvents();
+export function checkAndAward(slot?: string): Achievement[] {
+  const e = loadEvents(slot);
   const unlocked = loadUnlocked();
   const unlockedIds = new Set(unlocked.map((u) => u.id));
 
@@ -266,7 +345,7 @@ export function checkAndAward(events?: EventCounters): Achievement[] {
   for (const ach of ACHIEVEMENTS) {
     if (unlockedIds.has(ach.id)) continue;
     if (ach.check(e)) {
-      unlocked.push({ id: ach.id, unlockedAt: Date.now() });
+      unlocked.push({ id: ach.id, unlockedAt: Date.now(), slot: slot ?? undefined });
       newlyUnlocked.push(ach);
     }
   }

--- a/server/achievements.ts
+++ b/server/achievements.ts
@@ -294,8 +294,7 @@ export function renderAchievementsCard(): string {
   const sep = `\u251c${"\u254c".repeat(W - 2)}\u2524`;
   const lines: string[] = [];
 
-  const visibleAchs = ACHIEVEMENTS.filter((a) => !a.secret || unlockedIds.has(a.id));
-  const total = visibleAchs.length;
+  const total = ACHIEVEMENTS.length;
   const earned = unlockedIds.size;
 
   lines.push(`${GOLD}\u256d${hr}\u256e${NC}`);
@@ -335,4 +334,35 @@ export function renderAchievementsCard(): string {
   lines.push(`${GOLD}\u2570${hr}\u256f${NC}`);
 
   return lines.join("\n");
+}
+
+export function renderAchievementsCardMarkdown(): string {
+  const unlocked = loadUnlocked();
+  const unlockedIds = new Set(unlocked.map((u) => u.id));
+  const total = ACHIEVEMENTS.length;
+  const earned = unlockedIds.size;
+
+  const barFilled = total > 0 ? Math.round((earned / total) * 20) : 0;
+  const bar = "\u2588".repeat(barFilled) + "\u2591".repeat(20 - barFilled);
+
+  const parts: string[] = [];
+  parts.push(`### \ud83c\udfc6 Achievements \u2014 ${earned}/${total}`);
+  parts.push("");
+  parts.push(`\`${bar}\``);
+  parts.push("");
+
+  for (const ach of ACHIEVEMENTS) {
+    if (ach.secret && !unlockedIds.has(ach.id)) continue;
+    const done = unlockedIds.has(ach.id);
+    const status = done ? "\u2705" : "\u2610";
+    const line = `${ach.icon}${status} **${ach.name}** \u2014 ${ach.description}`;
+    parts.push(line);
+  }
+
+  if (earned > 0 && earned === ACHIEVEMENTS.length) {
+    parts.push("");
+    parts.push("\u2728 **ALL ACHIEVEMENTS UNLOCKED!** \u2728");
+  }
+
+  return parts.join("\n");
 }

--- a/server/achievements.ts
+++ b/server/achievements.ts
@@ -42,13 +42,13 @@ export interface GlobalCounters {
   sessions: number;
   commands_run: number;
   days_active: number;
+  turns: number;
 }
 
 // ─── Event counters (per-slot) ────────────────────────────────────────────────
 
 export interface SlotCounters {
   pets: number;
-  turns: number;
   reactions_given: number;
 }
 
@@ -56,17 +56,16 @@ export interface SlotCounters {
 
 export interface EventCounters extends GlobalCounters {
   pets: number;
-  turns: number;
   reactions_given: number;
 }
 
 export const GLOBAL_KEYS: (keyof GlobalCounters)[] = [
   "errors_seen", "tests_failed", "large_diffs",
-  "sessions", "commands_run", "days_active",
+  "sessions", "commands_run", "days_active", "turns",
 ];
 
 export const SLOT_KEYS: (keyof SlotCounters)[] = [
-  "pets", "turns", "reactions_given",
+  "pets", "reactions_given",
 ];
 
 export const COUNTER_KEYS: (keyof EventCounters)[] = [
@@ -76,11 +75,11 @@ export const COUNTER_KEYS: (keyof EventCounters)[] = [
 
 const EMPTY_GLOBAL: GlobalCounters = {
   errors_seen: 0, tests_failed: 0, large_diffs: 0,
-  sessions: 0, commands_run: 0, days_active: 0,
+  sessions: 0, commands_run: 0, days_active: 0, turns: 0,
 };
 
 const EMPTY_SLOT: SlotCounters = {
-  pets: 0, turns: 0, reactions_given: 0,
+  pets: 0, reactions_given: 0,
 };
 
 export function loadGlobalEvents(): GlobalCounters {
@@ -112,13 +111,12 @@ export function saveSlotEvents(slot: string, events: SlotCounters): void {
 export function loadEvents(slot?: string): EventCounters {
   const global = loadGlobalEvents();
   if (!slot) {
-    return { ...global, pets: 0, turns: 0, reactions_given: 0 };
+    return { ...global, pets: 0, reactions_given: 0 };
   }
   const slotEvents = loadSlotEvents(slot);
   return {
     ...global,
     pets: slotEvents.pets,
-    turns: slotEvents.turns,
     reactions_given: slotEvents.reactions_given,
   };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,6 +26,10 @@ import {
   getReaction, generatePersonalityPrompt,
 } from "./reactions.ts";
 import { renderCompanionCardMarkdown } from "./art.ts";
+import {
+  incrementEvent, checkAndAward, trackActiveDay,
+  renderAchievementsCard,
+} from "./achievements.ts";
 
 function getInstructions(): string {
   const companion = loadCompanion();
@@ -86,6 +90,11 @@ function ensureCompanion(): Companion {
   saveCompanionSlot(companion, slot);
   saveActiveSlot(slot);
   writeStatusState(companion);
+
+  checkAndAward();
+  trackActiveDay();
+  incrementEvent("sessions");
+
   return companion;
 }
 
@@ -111,6 +120,7 @@ server.tool(
     );
 
     writeStatusState(companion, reaction?.reaction);
+    incrementEvent("commands_run");
 
     return { content: [{ type: "text", text: card }] };
   },
@@ -127,6 +137,7 @@ server.tool(
     const reaction = getReaction("pet", companion.bones.species, companion.bones.rarity);
     saveReaction(reaction, "pet");
     writeStatusState(companion, reaction);
+    incrementEvent("pets");
 
     const face = renderFace(companion.bones.species, companion.bones.eye);
     return {
@@ -149,8 +160,9 @@ server.tool(
     const card = renderCompanionCardMarkdown(
       companion.bones,
       companion.name,
-      "",  // no personality in stats view
+      "",
     );
+    incrementEvent("commands_run");
 
     return { content: [{ type: "text", text: card }] };
   },
@@ -168,11 +180,22 @@ server.tool(
   async ({ comment, reason }) => {
     const companion = ensureCompanion();
     saveReaction(comment, reason ?? "turn");
-    writeStatusState(companion, comment);
+    incrementEvent("reactions_given");
+    if (reason === "error") incrementEvent("errors_seen");
+    if (reason === "test-fail") incrementEvent("tests_failed");
+    if (reason === "large-diff") incrementEvent("large_diffs");
+    incrementEvent("turns");
+
+    const newAch = checkAndAward();
+    const achName = newAch.length > 0 ? newAch[0].icon + " " + newAch[0].name : undefined;
+    writeStatusState(companion, comment, undefined, achName);
 
     const face = renderFace(companion.bones.species, companion.bones.eye);
+    const achNotice = newAch.length > 0
+      ? `\n${newAch.map((a) => `${a.icon} Achievement Unlocked: ${a.name}!`).join("\n")}`
+      : "";
     return {
-      content: [{ type: "text", text: `${face} ${companion.name}: "${comment}"` }],
+      content: [{ type: "text", text: `${face} ${companion.name}: "${comment}"${achNotice}` }],
     };
   },
 );
@@ -191,6 +214,7 @@ server.tool(
     companion.name = name;
     saveCompanion(companion);
     writeStatusState(companion);
+    incrementEvent("commands_run");
 
     return {
       content: [{ type: "text", text: `Renamed: ${oldName} \u2192 ${name}` }],
@@ -210,6 +234,7 @@ server.tool(
     const companion = ensureCompanion();
     companion.personality = personality;
     saveCompanion(companion);
+    incrementEvent("commands_run");
 
     return {
       content: [{ type: "text", text: `Personality updated for ${companion.name}.` }],
@@ -236,6 +261,7 @@ server.tool(
       "  /buddy on         Unmute reactions",
       "  /buddy rename     Rename companion (1-14 chars)",
       "  /buddy personality  Set custom personality text",
+      "  /buddy achievements  Show achievement badges",
       "  /buddy summon     Summon a saved buddy (omit slot for random)",
       "  /buddy save       Save current buddy to a named slot",
       "  /buddy list       List all saved buddies",
@@ -316,6 +342,7 @@ server.tool(
   async () => {
     const companion = ensureCompanion();
     writeStatusState(companion, "", true);
+    incrementEvent("commands_run");
     return { content: [{ type: "text", text: `${companion.name} goes quiet. /buddy on to unmute.` }] };
   },
 );
@@ -328,7 +355,22 @@ server.tool(
     const companion = ensureCompanion();
     writeStatusState(companion, "*stretches* I'm back!", false);
     saveReaction("*stretches* I'm back!", "pet");
+    incrementEvent("commands_run");
     return { content: [{ type: "text", text: `${companion.name} is back!` }] };
+  },
+);
+
+// ─── Tool: buddy_achievements ────────────────────────────────────────────────
+
+server.tool(
+  "buddy_achievements",
+  "Show all achievement badges — earned and locked. Displays a card with progress bar and status for each badge.",
+  {},
+  async () => {
+    ensureCompanion();
+    checkAndAward();
+    const card = renderAchievementsCard();
+    return { content: [{ type: "text", text: card }] };
   },
 );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,7 +28,7 @@ import {
 import { renderCompanionCardMarkdown } from "./art.ts";
 import {
   incrementEvent, checkAndAward, trackActiveDay,
-  renderAchievementsCard,
+  renderAchievementsCardMarkdown,
 } from "./achievements.ts";
 
 function getInstructions(): string {
@@ -181,10 +181,6 @@ server.tool(
     const companion = ensureCompanion();
     saveReaction(comment, reason ?? "turn");
     incrementEvent("reactions_given");
-    if (reason === "error") incrementEvent("errors_seen");
-    if (reason === "test-fail") incrementEvent("tests_failed");
-    if (reason === "large-diff") incrementEvent("large_diffs");
-    incrementEvent("turns");
 
     const newAch = checkAndAward();
     const achName = newAch.length > 0 ? newAch[0].icon + " " + newAch[0].name : undefined;
@@ -369,7 +365,7 @@ server.tool(
   async () => {
     ensureCompanion();
     checkAndAward();
-    const card = renderAchievementsCard();
+    const card = renderAchievementsCardMarkdown();
     return { content: [{ type: "text", text: card }] };
   },
 );

--- a/server/index.ts
+++ b/server/index.ts
@@ -91,11 +91,15 @@ function ensureCompanion(): Companion {
   saveActiveSlot(slot);
   writeStatusState(companion);
 
-  checkAndAward();
+  checkAndAward(slot);
   trackActiveDay();
-  incrementEvent("sessions");
+  incrementEvent("sessions", 1);
 
   return companion;
+}
+
+function activeSlot(): string {
+  return loadActiveSlot();
 }
 
 // ─── Tool: buddy_show ───────────────────────────────────────────────────────
@@ -120,7 +124,7 @@ server.tool(
     );
 
     writeStatusState(companion, reaction?.reaction);
-    incrementEvent("commands_run");
+    incrementEvent("commands_run", 1, activeSlot());
 
     return { content: [{ type: "text", text: card }] };
   },
@@ -137,7 +141,7 @@ server.tool(
     const reaction = getReaction("pet", companion.bones.species, companion.bones.rarity);
     saveReaction(reaction, "pet");
     writeStatusState(companion, reaction);
-    incrementEvent("pets");
+    incrementEvent("pets", 1, activeSlot());
 
     const face = renderFace(companion.bones.species, companion.bones.eye);
     return {
@@ -162,7 +166,7 @@ server.tool(
       companion.name,
       "",
     );
-    incrementEvent("commands_run");
+    incrementEvent("commands_run", 1, activeSlot());
 
     return { content: [{ type: "text", text: card }] };
   },
@@ -180,9 +184,9 @@ server.tool(
   async ({ comment, reason }) => {
     const companion = ensureCompanion();
     saveReaction(comment, reason ?? "turn");
-    incrementEvent("reactions_given");
+    incrementEvent("reactions_given", 1, activeSlot());
 
-    const newAch = checkAndAward();
+    const newAch = checkAndAward(activeSlot());
     const achName = newAch.length > 0 ? newAch[0].icon + " " + newAch[0].name : undefined;
     writeStatusState(companion, comment, undefined, achName);
 
@@ -210,7 +214,7 @@ server.tool(
     companion.name = name;
     saveCompanion(companion);
     writeStatusState(companion);
-    incrementEvent("commands_run");
+    incrementEvent("commands_run", 1, activeSlot());
 
     return {
       content: [{ type: "text", text: `Renamed: ${oldName} \u2192 ${name}` }],
@@ -230,7 +234,7 @@ server.tool(
     const companion = ensureCompanion();
     companion.personality = personality;
     saveCompanion(companion);
-    incrementEvent("commands_run");
+    incrementEvent("commands_run", 1, activeSlot());
 
     return {
       content: [{ type: "text", text: `Personality updated for ${companion.name}.` }],
@@ -338,7 +342,7 @@ server.tool(
   async () => {
     const companion = ensureCompanion();
     writeStatusState(companion, "", true);
-    incrementEvent("commands_run");
+    incrementEvent("commands_run", 1, activeSlot());
     return { content: [{ type: "text", text: `${companion.name} goes quiet. /buddy on to unmute.` }] };
   },
 );
@@ -351,7 +355,7 @@ server.tool(
     const companion = ensureCompanion();
     writeStatusState(companion, "*stretches* I'm back!", false);
     saveReaction("*stretches* I'm back!", "pet");
-    incrementEvent("commands_run");
+    incrementEvent("commands_run", 1, activeSlot());
     return { content: [{ type: "text", text: `${companion.name} is back!` }] };
   },
 );
@@ -364,7 +368,7 @@ server.tool(
   {},
   async () => {
     ensureCompanion();
-    checkAndAward();
+    checkAndAward(activeSlot());
     const card = renderAchievementsCardMarkdown();
     return { content: [{ type: "text", text: card }] };
   },

--- a/server/state.ts
+++ b/server/state.ts
@@ -307,10 +307,11 @@ export interface StatusState {
   hat: string;
   reaction: string;
   muted: boolean;
+  achievement: string;
 }
 
 export function writeStatusState(
-  companion: Companion, reaction?: string, muted?: boolean,
+  companion: Companion, reaction?: string, muted?: boolean, achievement?: string,
 ): void {
   mkdirSync(STATE_DIR, { recursive: true });
   const { renderFace, RARITY_STARS } =
@@ -326,6 +327,7 @@ export function writeStatusState(
     hat:      companion.bones.hat,
     reaction: reaction ?? "",
     muted:    muted ?? false,
+    achievement: achievement ?? "",
   };
   writeFileSync(join(STATE_DIR, "status.json"), JSON.stringify(state));
 }

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buddy
 description: "Show, pet, or manage your coding companion. Use when the user types /buddy or mentions their companion by name."
-argument-hint: "[show|pet|stats|help|off|on|rename <name>|personality <text>|summon [slot]|save [slot]|list|dismiss <slot>|pick|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]]"
+argument-hint: "[show|pet|stats|help|off|on|rename <name>|personality <text>|achievements|summon [slot]|save [slot]|list|dismiss <slot>|pick|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]]"
 allowed-tools: mcp__claude_buddy__*
 ---
 
@@ -23,6 +23,7 @@ Based on `$ARGUMENTS`:
 | `on` | Call `buddy_unmute` |
 | `rename <name>` | Call `buddy_rename` with the given name |
 | `personality <text>` | Call `buddy_set_personality` with the given text |
+| `achievements` | Call `buddy_achievements` |
 | `summon` | Call `buddy_summon` with no args — picks a random saved buddy |
 | `summon <slot>` | Call `buddy_summon` with the given slot name |
 | `save [slot]` | Call `buddy_save` with optional slot name |

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -213,7 +213,7 @@ esac
 # ─── Reaction bubble (with TTL check) ────────────────────────────────────────
 BUBBLE=""
 if [ -n "$ACHIEVEMENT" ] && [ "$ACHIEVEMENT" != "null" ] && [ "$ACHIEVEMENT" != "" ]; then
-    BUBBLE=$'\U0001F3C6'" $ACHIEVEMENT"
+    BUBBLE=$'\xf0\x9f\x8f\x86'" $ACHIEVEMENT"
 fi
 REACTION_FILE="$HOME/.claude-buddy/reaction.$SID.json"
 REACTION_TTL=0

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -26,6 +26,7 @@ SPECIES=$(jq -r '.species // ""' "$STATE" 2>/dev/null)
 HAT=$(jq -r '.hat // "none"' "$STATE" 2>/dev/null)
 RARITY=$(jq -r '.rarity // "common"' "$STATE" 2>/dev/null)
 REACTION=$(jq -r '.reaction // ""' "$STATE" 2>/dev/null)
+ACHIEVEMENT=$(jq -r '.achievement // ""' "$STATE" 2>/dev/null)
 # eye is written to status.json by writeStatusState (v2+); fall back to "°"
 E=$(jq -r '.eye // "°"' "$STATE" 2>/dev/null)
 
@@ -211,6 +212,9 @@ esac
 
 # ─── Reaction bubble (with TTL check) ────────────────────────────────────────
 BUBBLE=""
+if [ -n "$ACHIEVEMENT" ] && [ "$ACHIEVEMENT" != "null" ] && [ "$ACHIEVEMENT" != "" ]; then
+    BUBBLE=$'\U0001F3C6'" $ACHIEVEMENT"
+fi
 REACTION_FILE="$HOME/.claude-buddy/reaction.$SID.json"
 REACTION_TTL=0
 CONFIG_FILE="$HOME/.claude-buddy/config.json"
@@ -230,7 +234,13 @@ if [ -n "$REACTION" ] && [ "$REACTION" != "null" ] && [ "$REACTION" != "" ]; the
             [ "$AGE" -lt "$REACTION_TTL" ] && FRESH=1
         fi
     fi
-    [ "$FRESH" -eq 1 ] && BUBBLE="\"${REACTION}\""
+    if [ "$FRESH" -eq 1 ]; then
+        if [ -n "$BUBBLE" ]; then
+            BUBBLE="$BUBBLE | \"${REACTION}\""
+        else
+            BUBBLE="\"${REACTION}\""
+        fi
+    fi
 fi
 
 # ─── Build art lines ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the **Achievement Badges** feature from the roadmap — milestones that unlock as you code with your buddy.

- **16 achievements** (including 3 secret ones) based on events: errors seen, test failures, pets, turns, days active, commands run, large diffs, etc.
- New `server/achievements.ts` module: event counters, day tracking, badge definitions, award logic, and an ASCII art achievements card with gold rarity border
- New MCP tool `buddy_achievements` + `/buddy achievements` slash command
- Hooks (`react.sh`, `buddy-comment.sh`) increment event counters for shell-level tracking
- Status line shows 🏆 + achievement name when a badge unlocks
- State persisted in `~/.claude-buddy/{events,unlocked,active_days}.json`

## Achievements

| Badge | Requirement | Secret? |
|---|---|---|
| First Steps | Hatch your buddy | No |
| Good Buddy | 10 pets | No |
| Best Friend | 50 pets | No |
| Bug Spotter | 1 error witnessed | No |
| Error Whisperer | 25 errors survived | No |
| Battle-Scarred | 100 errors survived | Yes |
| Test Witness | 1 test failure seen | No |
| Test Veteran | 50 test failures witnessed | No |
| Big Mover | 1 large diff (80+ lines) | No |
| Refactor Machine | 10 large diffs | No |
| Chatterbox | 100 buddy reactions | No |
| Week Streak | 7 active days | No |
| Month Streak | 30 active days | Yes |
| Power User | 50 buddy commands | No |
| Dedicated Companion | 200 turns | No |
| Thousand Turns | 1000 turns | Yes |

## Files Changed

- `server/achievements.ts` — new file, all achievement logic
- `server/index.ts` — `buddy_achievements` tool + event tracking in existing tools
- `server/state.ts` — `achievement` field in status state
- `hooks/react.sh` — event counter increments for errors/tests/diffs
- `hooks/buddy-comment.sh` — event counter increments for turns/reactions
- `statusline/buddy-status.sh` — trophy display on achievement unlock
- `skills/buddy/SKILL.md` — `/buddy achievements` command

## Testing

- `bun build` compiles all files without errors
- MCP server starts and exposes `buddy_achievements` tool
- Achievement card renders correctly with progress bar
- Shell scripts pass `bash -n` syntax validation
- Existing `bun run show` still works