### PR TITLE
fix: normalize Windows backslash paths to POSIX in config output

### DIFF
--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -15,7 +15,10 @@ import { homedir } from "os";
 
 const PROJECT_ROOT = resolve(dirname(import.meta.dir));
 const HOME = homedir();
-const STATUS_SCRIPT = join(PROJECT_ROOT, "statusline", "buddy-status.sh");
+/** Normalize Windows backslash paths to POSIX forward slashes. */
+const toPosix = (p: string) => p.replace(/\\/g, "/");
+
+const STATUS_SCRIPT = toPosix(join(PROJECT_ROOT, "statusline", "buddy-status.sh"));
 
 const RED = "\x1b[31m";
 const GREEN = "\x1b[32m";

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -10,6 +10,10 @@ import { execSync } from "child_process";
 import { join, resolve, dirname } from "path";
 import { homedir } from "os";
 
+/** Normalize Windows backslash paths to POSIX forward slashes for config files
+ *  (Git Bash eats lone backslashes as escape characters). */
+const toPosix = (p: string) => p.replace(/\\/g, "/");
+
 import { generateBones, renderBuddy, renderFace, RARITY_STARS } from "../server/engine.ts";
 import { loadCompanion, saveCompanion, resolveUserId, writeStatusState } from "../server/state.ts";
 import { generateFallbackName } from "../server/reactions.ts";
@@ -113,8 +117,8 @@ function installMcp() {
 
   claudeJson.mcpServers["claude-buddy"] = {
     command: "bun",
-    args: [serverPath],
-    cwd: PROJECT_ROOT,
+    args: [toPosix(serverPath)],
+    cwd: toPosix(PROJECT_ROOT),
   };
 
   writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
@@ -133,7 +137,7 @@ function installSkill() {
 // ─── Step 3: Configure status line (with animation refresh) ─────────────────
 
 function installStatusLine(settings: Record<string, any>) {
-  const statusScript = `bun ${join(PROJECT_ROOT, "statusline", "buddy-status.ts")}`;
+  const statusScript = `bun ${toPosix(join(PROJECT_ROOT, "statusline", "buddy-status.ts"))}`;
 
   settings.statusLine = {
     type: "command",
@@ -161,7 +165,7 @@ function detectTmux(): boolean {
 }
 
 function installPopupHooks(settings: Record<string, any>) {
-  const popupManager = join(PROJECT_ROOT, "popup", "popup-manager.sh");
+  const popupManager = toPosix(join(PROJECT_ROOT, "popup", "popup-manager.sh"));
 
   if (!settings.hooks) settings.hooks = {};
 
@@ -189,9 +193,9 @@ function installPopupHooks(settings: Record<string, any>) {
 // ─── Step 4: Register hooks ─────────────────────────────────────────────────
 
 function installHooks(settings: Record<string, any>) {
-  const reactHook    = `bun ${join(PROJECT_ROOT, "hooks", "react.ts")}`;
-  const commentHook  = `bun ${join(PROJECT_ROOT, "hooks", "buddy-comment.ts")}`;
-  const nameHook     = `bun ${join(PROJECT_ROOT, "hooks", "name-react.ts")}`;
+  const reactHook    = `bun ${toPosix(join(PROJECT_ROOT, "hooks", "react.ts"))}`;
+  const commentHook  = `bun ${toPosix(join(PROJECT_ROOT, "hooks", "buddy-comment.ts"))}`;
+  const nameHook     = `bun ${toPosix(join(PROJECT_ROOT, "hooks", "name-react.ts"))}`;
 
   if (!settings.hooks) settings.hooks = {};
 


### PR DESCRIPTION
## Summary

- Adds a `toPosix()` helper to `cli/install.ts` and `cli/doctor.ts` that normalizes `\` to `/` in all paths written to config files
- On Windows, `path.join()` produces backslash-separated paths. When Claude Code pipes these through Git Bash, lone backslashes are eaten as escape characters — producing corrupted paths like `C:Userslcjansourcereposforksclaude-buddyhooksbuddy-comment.ts`
- Applied to: MCP server `args` + `cwd`, status line command, popup manager path, all three hook commands (`react.ts`, `buddy-comment.ts`, `name-react.ts`), and `STATUS_SCRIPT` in doctor

## Verified on

- **Machine:** athena-win11-vm (Windows 11 ARM via Parallels)
- **Bun:** 1.3.12
- **Claude Code:** latest

After running `bun cli/install.ts`, all paths in `~/.claude.json` and `~/.claude/settings.json` use forward slashes.

## Test plan

- [x] Run `bun cli/install.ts` on Windows
- [x] Verify `~/.claude.json` MCP server paths use forward slashes
- [x] Verify `~/.claude/settings.json` hook and status line paths use forward slashes
- [ ] Restart Claude Code, verify MCP server connects and hooks fire

---
Host: athena-win11-vm Model: claude-opus-4-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)