### PR TITLE
Plugin marketplace support + togglable status line

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,7 +16,6 @@
         "terminal-pet",
         "tamagotchi"
     ],
-    "hooks": "./hooks/hooks.json",
     "mcpServers": {
         "claude-buddy": {
             "type": "stdio",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
     "hooks": {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "./hooks/statusline-setup.sh"
+                    }
+                ]
+            }
+        ],
         "PostToolUse": [
             {
                 "matcher": "Bash",

--- a/hooks/statusline-setup.sh
+++ b/hooks/statusline-setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# claude-buddy SessionStart hook — configure status line if opted in
+#
+# Reads ~/.claude-buddy/config.json for statusLineEnabled.
+# If true, sets settings.json statusLine to point to buddy-status.sh.
+# If false or missing, does nothing (does NOT remove an existing status line).
+
+set -euo pipefail
+
+CONFIG="$HOME/.claude-buddy/config.json"
+SETTINGS="$HOME/.claude/settings.json"
+
+# Bail if no config or jq not available
+[ -f "$CONFIG" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+ENABLED=$(jq -r '.statusLineEnabled // false' "$CONFIG" 2>/dev/null)
+[ "$ENABLED" = "true" ] || exit 0
+
+# Resolve buddy-status.sh path relative to this hook
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
+STATUS_SCRIPT="$PLUGIN_ROOT/statusline/buddy-status.sh"
+
+[ -f "$STATUS_SCRIPT" ] || exit 0
+[ -f "$SETTINGS" ] || exit 0
+
+# Check if already pointing to buddy status
+CURRENT=$(jq -r '.statusLine.command // ""' "$SETTINGS" 2>/dev/null)
+if echo "$CURRENT" | grep -q "buddy-status.sh"; then
+    exit 0
+fi
+
+# Patch settings.json with buddy status line
+TMP="$SETTINGS.tmp.$$"
+jq --arg cmd "$STATUS_SCRIPT" '.statusLine = {
+    "type": "command",
+    "command": $cmd,
+    "padding": 1,
+    "refreshInterval": 1
+}' "$SETTINGS" > "$TMP" && mv "$TMP" "$SETTINGS"
+
+exit 0

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,25 +11,42 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 import {
-  generateBones, renderFace,
-  SPECIES, RARITIES, STAT_NAMES, RARITY_STARS,
-  type Species, type Rarity, type StatName, type Companion,
+  generateBones,
+  renderFace,
+  SPECIES,
+  RARITIES,
+  STAT_NAMES,
+  RARITY_STARS,
+  type Species,
+  type Rarity,
+  type StatName,
+  type Companion,
 } from "./engine.ts";
 import {
-  loadCompanion, saveCompanion, resolveUserId,
-  loadReaction, saveReaction, writeStatusState,
-  loadConfig, saveConfig,
-  loadActiveSlot, saveActiveSlot, slugify, unusedName,
-  loadCompanionSlot, saveCompanionSlot, deleteCompanionSlot, listCompanionSlots,
+  loadCompanion,
+  saveCompanion,
+  resolveUserId,
+  loadReaction,
+  saveReaction,
+  writeStatusState,
+  loadConfig,
+  saveConfig,
+  loadActiveSlot,
+  saveActiveSlot,
+  slugify,
+  unusedName,
+  loadCompanionSlot,
+  saveCompanionSlot,
+  deleteCompanionSlot,
+  listCompanionSlots,
 } from "./state.ts";
-import {
-  getReaction, generatePersonalityPrompt,
-} from "./reactions.ts";
+import { getReaction, generatePersonalityPrompt } from "./reactions.ts";
 import { renderCompanionCard } from "./art.ts";
 
 function getInstructions(): string {
   const companion = loadCompanion();
-  if (!companion) return "Companion not yet hatched. Use buddy_show to initialize.";
+  if (!companion)
+    return "Companion not yet hatched. Use buddy_show to initialize.";
   const b = companion.bones;
   return [
     `A ${b.rarity} ${b.species} named ${companion.name} watches from the status line.`,
@@ -49,12 +66,15 @@ function getInstructions(): string {
   ].join("\n");
 }
 
-const server = new McpServer({
-  name: "claude-buddy",
-  version: "0.3.0",
-}, {
-  instructions: getInstructions(),
-});
+const server = new McpServer(
+  {
+    name: "claude-buddy",
+    version: "0.3.0",
+  },
+  {
+    instructions: getInstructions(),
+  },
+);
 
 // ─── Helper: ensure companion exists ────────────────────────────────────────
 
@@ -98,7 +118,8 @@ server.tool(
   async () => {
     const companion = ensureCompanion();
     const reaction = loadReaction();
-    const reactionText = reaction?.reaction ?? `*${companion.name} watches your code quietly*`;
+    const reactionText =
+      reaction?.reaction ?? `*${companion.name} watches your code quietly*`;
 
     const card = renderCompanionCard(
       companion.bones,
@@ -121,13 +142,19 @@ server.tool(
   {},
   async () => {
     const companion = ensureCompanion();
-    const reaction = getReaction("pet", companion.bones.species, companion.bones.rarity);
+    const reaction = getReaction(
+      "pet",
+      companion.bones.species,
+      companion.bones.rarity,
+    );
     saveReaction(reaction, "pet");
     writeStatusState(companion, reaction);
 
     const face = renderFace(companion.bones.species, companion.bones.eye);
     return {
-      content: [{ type: "text", text: `${face} ${companion.name}: "${reaction}"` }],
+      content: [
+        { type: "text", text: `${face} ${companion.name}: "${reaction}"` },
+      ],
     };
   },
 );
@@ -145,7 +172,7 @@ server.tool(
     const card = renderCompanionCard(
       companion.bones,
       companion.name,
-      "",  // no personality in stats view
+      "", // no personality in stats view
     );
 
     return { content: [{ type: "text", text: card }] };
@@ -158,8 +185,17 @@ server.tool(
   "buddy_react",
   "Post a buddy comment. Call this at the END of every response with a short in-character comment from the companion about what just happened. The comment should be 1 sentence, in character, and reference something specific from the conversation — a pitfall noticed, a compliment on clean code, a warning about edge cases, etc. Write the comment yourself based on the companion's personality.",
   {
-    comment: z.string().min(1).max(150).describe("The buddy's comment, written in-character (1 short sentence, max 150 chars). Use *asterisks* for actions."),
-    reason: z.enum(["error", "test-fail", "large-diff", "turn"]).optional().describe("What triggered the reaction"),
+    comment: z
+      .string()
+      .min(1)
+      .max(150)
+      .describe(
+        "The buddy's comment, written in-character (1 short sentence, max 150 chars). Use *asterisks* for actions.",
+      ),
+    reason: z
+      .enum(["error", "test-fail", "large-diff", "turn"])
+      .optional()
+      .describe("What triggered the reaction"),
   },
   async ({ comment, reason }) => {
     const companion = ensureCompanion();
@@ -168,7 +204,9 @@ server.tool(
 
     const face = renderFace(companion.bones.species, companion.bones.eye);
     return {
-      content: [{ type: "text", text: `${face} ${companion.name}: "${comment}"` }],
+      content: [
+        { type: "text", text: `${face} ${companion.name}: "${comment}"` },
+      ],
     };
   },
 );
@@ -179,7 +217,11 @@ server.tool(
   "buddy_rename",
   "Rename your coding companion",
   {
-    name: z.string().min(1).max(14).describe("New name for your buddy (1-14 characters)"),
+    name: z
+      .string()
+      .min(1)
+      .max(14)
+      .describe("New name for your buddy (1-14 characters)"),
   },
   async ({ name }) => {
     const companion = ensureCompanion();
@@ -200,7 +242,11 @@ server.tool(
   "buddy_set_personality",
   "Set a custom personality description for your buddy",
   {
-    personality: z.string().min(1).max(500).describe("Personality description (1-500 chars)"),
+    personality: z
+      .string()
+      .min(1)
+      .max(500)
+      .describe("Personality description (1-500 chars)"),
   },
   async ({ personality }) => {
     const companion = ensureCompanion();
@@ -208,7 +254,9 @@ server.tool(
     saveCompanion(companion);
 
     return {
-      content: [{ type: "text", text: `Personality updated for ${companion.name}.` }],
+      content: [
+        { type: "text", text: `Personality updated for ${companion.name}.` },
+      ],
     };
   },
 );
@@ -241,6 +289,7 @@ server.tool(
       "  /buddy style      Show or set bubble style (tmux only)",
       "  /buddy position   Show or set bubble position (tmux only)",
       "  /buddy rarity     Show or hide rarity stars (tmux only)",
+      "  /buddy statusline Enable or disable buddy in the status line",
       "",
       "CLI:",
       "  bun run help            Show full CLI help",
@@ -263,18 +312,36 @@ server.tool(
   "buddy_frequency",
   "Configure how often buddy comments appear in the speech bubble. Returns current settings if called without arguments.",
   {
-    cooldown: z.number().int().min(5).max(300).optional().describe("Minimum seconds between displayed comments (default 30). The buddy always writes comments, but the display only updates this often."),
+    cooldown: z
+      .number()
+      .int()
+      .min(5)
+      .max(300)
+      .optional()
+      .describe(
+        "Minimum seconds between displayed comments (default 30). The buddy always writes comments, but the display only updates this often.",
+      ),
   },
   async ({ cooldown }) => {
     if (cooldown === undefined) {
       const cfg = loadConfig();
       return {
-        content: [{ type: "text", text: `Comment cooldown: ${cfg.commentCooldown}s between displayed comments.\nUse /buddy frequency <seconds> to change.` }],
+        content: [
+          {
+            type: "text",
+            text: `Comment cooldown: ${cfg.commentCooldown}s between displayed comments.\nUse /buddy frequency <seconds> to change.`,
+          },
+        ],
       };
     }
     const cfg = saveConfig({ commentCooldown: cooldown });
     return {
-      content: [{ type: "text", text: `Updated: ${cfg.commentCooldown}s cooldown between displayed comments.` }],
+      content: [
+        {
+          type: "text",
+          text: `Updated: ${cfg.commentCooldown}s cooldown between displayed comments.`,
+        },
+      ],
     };
   },
 );
@@ -283,15 +350,37 @@ server.tool(
   "buddy_style",
   "Configure the popup appearance. Returns current settings if called without arguments.",
   {
-    style: z.enum(["classic", "round"]).optional().describe("Bubble border style: classic (pipes/dashes like status line) or round (parens/tildes)"),
-    position: z.enum(["top", "left"]).optional().describe("Bubble position relative to buddy: top (above) or left (beside)"),
-    showRarity: z.boolean().optional().describe("Show or hide the stars + rarity line in the popup"),
+    style: z
+      .enum(["classic", "round"])
+      .optional()
+      .describe(
+        "Bubble border style: classic (pipes/dashes like status line) or round (parens/tildes)",
+      ),
+    position: z
+      .enum(["top", "left"])
+      .optional()
+      .describe(
+        "Bubble position relative to buddy: top (above) or left (beside)",
+      ),
+    showRarity: z
+      .boolean()
+      .optional()
+      .describe("Show or hide the stars + rarity line in the popup"),
   },
   async ({ style, position, showRarity }) => {
-    if (style === undefined && position === undefined && showRarity === undefined) {
+    if (
+      style === undefined &&
+      position === undefined &&
+      showRarity === undefined
+    ) {
       const cfg = loadConfig();
       return {
-        content: [{ type: "text", text: `Bubble style: ${cfg.bubbleStyle}\nBubble position: ${cfg.bubblePosition}\nShow rarity: ${cfg.showRarity}\nUse /buddy style <classic|round>, /buddy position <top|left>, /buddy rarity <on|off> to change.` }],
+        content: [
+          {
+            type: "text",
+            text: `Bubble style: ${cfg.bubbleStyle}\nBubble position: ${cfg.bubblePosition}\nShow rarity: ${cfg.showRarity}\nUse /buddy style <classic|round>, /buddy position <top|left>, /buddy rarity <on|off> to change.`,
+          },
+        ],
       };
     }
     const updates: Record<string, string | boolean> = {};
@@ -300,7 +389,12 @@ server.tool(
     if (showRarity !== undefined) updates.showRarity = showRarity;
     const cfg = saveConfig(updates);
     return {
-      content: [{ type: "text", text: `Updated: style=${cfg.bubbleStyle}, position=${cfg.bubblePosition}, showRarity=${cfg.showRarity}\nRestart Claude Code for changes to take effect.` }],
+      content: [
+        {
+          type: "text",
+          text: `Updated: style=${cfg.bubbleStyle}, position=${cfg.bubblePosition}, showRarity=${cfg.showRarity}\nRestart Claude Code for changes to take effect.`,
+        },
+      ],
     };
   },
 );
@@ -312,19 +406,109 @@ server.tool(
   async () => {
     const companion = ensureCompanion();
     writeStatusState(companion, "", true);
-    return { content: [{ type: "text", text: `${companion.name} goes quiet. /buddy on to unmute.` }] };
+    return {
+      content: [
+        {
+          type: "text",
+          text: `${companion.name} goes quiet. /buddy on to unmute.`,
+        },
+      ],
+    };
   },
 );
 
+server.tool("buddy_unmute", "Unmute buddy reactions", {}, async () => {
+  const companion = ensureCompanion();
+  writeStatusState(companion, "*stretches* I'm back!", false);
+  saveReaction("*stretches* I'm back!", "pet");
+  return { content: [{ type: "text", text: `${companion.name} is back!` }] };
+});
+
+// ─── Tool: buddy_statusline ─────────────────────────────────────────────────
+
 server.tool(
-  "buddy_unmute",
-  "Unmute buddy reactions",
-  {},
-  async () => {
-    const companion = ensureCompanion();
-    writeStatusState(companion, "*stretches* I'm back!", false);
-    saveReaction("*stretches* I'm back!", "pet");
-    return { content: [{ type: "text", text: `${companion.name} is back!` }] };
+  "buddy_statusline",
+  "Enable or disable the buddy status line. When enabled, a SessionStart hook configures Claude Code's status line to show your buddy with animation and reactions. When disabled, the status line is released for other use. Returns current status if called without arguments.",
+  {
+    enabled: z
+      .boolean()
+      .optional()
+      .describe(
+        "true to enable, false to disable. Omit to show current status.",
+      ),
+  },
+  async ({ enabled }) => {
+    if (enabled === undefined) {
+      const cfg = loadConfig();
+      const state = cfg.statusLineEnabled ? "enabled" : "disabled";
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Status line: ${state}\nUse /buddy statusline on or /buddy statusline off to change.\nRestart Claude Code after enabling for it to take effect.`,
+          },
+        ],
+      };
+    }
+    saveConfig({ statusLineEnabled: enabled });
+
+    if (enabled) {
+      // Immediately patch settings.json so the user doesn't need to restart twice
+      try {
+        const { readFileSync, writeFileSync } = await import("fs");
+        const { join, resolve, dirname } = await import("path");
+        const { homedir } = await import("os");
+
+        const settingsPath = join(homedir(), ".claude", "settings.json");
+        const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+        const pluginRoot = resolve(dirname(import.meta.dir));
+        const statusScript = join(pluginRoot, "statusline", "buddy-status.sh");
+
+        settings.statusLine = {
+          type: "command",
+          command: statusScript,
+          padding: 1,
+          refreshInterval: 1,
+        };
+        writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+      } catch {
+        /* SessionStart hook will handle it on next restart */
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: "Status line enabled! Restart Claude Code to see your buddy in the status line.",
+          },
+        ],
+      };
+    } else {
+      // Remove buddy status line from settings.json
+      try {
+        const { readFileSync, writeFileSync } = await import("fs");
+        const { join } = await import("path");
+        const { homedir } = await import("os");
+
+        const settingsPath = join(homedir(), ".claude", "settings.json");
+        const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+        if (settings.statusLine?.command?.includes("buddy-status.sh")) {
+          delete settings.statusLine;
+          writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+        }
+      } catch {
+        /* best effort */
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: "Status line disabled. Restart Claude Code to apply.",
+          },
+        ],
+      };
+    }
   },
 );
 
@@ -334,9 +518,14 @@ server.tool(
   "buddy_summon",
   "Summon a buddy by slot name. Loads a saved buddy if the slot exists; generates a new deterministic buddy for unknown slot names. Omit slot to pick randomly from all saved buddies. Your current buddy is NOT destroyed — they stay saved in their slot.",
   {
-    slot: z.string().min(1).max(14).optional().describe(
-      "Slot name to summon (e.g. 'fafnir', 'dragon-2'). Omit to pick a random saved buddy.",
-    ),
+    slot: z
+      .string()
+      .min(1)
+      .max(14)
+      .optional()
+      .describe(
+        "Slot name to summon (e.g. 'fafnir', 'dragon-2'). Omit to pick a random saved buddy.",
+      ),
   },
   async ({ slot }) => {
     const userId = resolveUserId();
@@ -348,7 +537,12 @@ server.tool(
       const saved = listCompanionSlots();
       if (saved.length === 0) {
         return {
-          content: [{ type: "text", text: "Your menagerie is empty. Use buddy_summon with a slot name to add one." }],
+          content: [
+            {
+              type: "text",
+              text: "Your menagerie is empty. Use buddy_summon with a slot name to add one.",
+            },
+          ],
         };
       }
       targetSlot = saved[Math.floor(Math.random() * saved.length)].slot;
@@ -360,7 +554,12 @@ server.tool(
     const companion = loadCompanionSlot(targetSlot);
     if (!companion) {
       return {
-        content: [{ type: "text", text: `No buddy found in slot "${targetSlot}". Use /buddy list to see saved buddies.` }],
+        content: [
+          {
+            type: "text",
+            text: `No buddy found in slot "${targetSlot}". Use /buddy list to see saved buddies.`,
+          },
+        ],
       };
     }
 
@@ -383,9 +582,14 @@ server.tool(
   "buddy_save",
   "Save the current buddy to a named slot. Useful for bookmarking before trying a new buddy.",
   {
-    slot: z.string().min(1).max(14).optional().describe(
-      "Slot name (defaults to the buddy's current name, slugified). Overwrites existing slot with same name.",
-    ),
+    slot: z
+      .string()
+      .min(1)
+      .max(14)
+      .optional()
+      .describe(
+        "Slot name (defaults to the buddy's current name, slugified). Overwrites existing slot with same name.",
+      ),
   },
   async ({ slot }) => {
     const companion = ensureCompanion();
@@ -393,7 +597,12 @@ server.tool(
     saveCompanionSlot(companion, targetSlot);
     saveActiveSlot(targetSlot);
     return {
-      content: [{ type: "text", text: `${companion.name} saved to slot "${targetSlot}".` }],
+      content: [
+        {
+          type: "text",
+          text: `${companion.name} saved to slot "${targetSlot}".`,
+        },
+      ],
     };
   },
 );
@@ -409,7 +618,14 @@ server.tool(
     const activeSlot = loadActiveSlot();
 
     if (saved.length === 0) {
-      return { content: [{ type: "text", text: "Your menagerie is empty. Use buddy_summon <slot> to add one." }] };
+      return {
+        content: [
+          {
+            type: "text",
+            text: "Your menagerie is empty. Use buddy_summon <slot> to add one.",
+          },
+        ],
+      };
     }
 
     const lines = saved.map(({ slot, companion }) => {
@@ -437,20 +653,32 @@ server.tool(
 
     if (targetSlot === activeSlot) {
       return {
-        content: [{ type: "text", text: `Cannot dismiss the active buddy. Use buddy_summon to switch first, then buddy_dismiss "${targetSlot}".` }],
+        content: [
+          {
+            type: "text",
+            text: `Cannot dismiss the active buddy. Use buddy_summon to switch first, then buddy_dismiss "${targetSlot}".`,
+          },
+        ],
       };
     }
 
     const companion = loadCompanionSlot(targetSlot);
     if (!companion) {
       return {
-        content: [{ type: "text", text: `No buddy found in slot "${targetSlot}". Use buddy_list to see saved buddies.` }],
+        content: [
+          {
+            type: "text",
+            text: `No buddy found in slot "${targetSlot}". Use buddy_list to see saved buddies.`,
+          },
+        ],
       };
     }
 
     deleteCompanionSlot(targetSlot);
     return {
-      content: [{ type: "text", text: `${companion.name} [${targetSlot}] dismissed.` }],
+      content: [
+        { type: "text", text: `${companion.name} [${targetSlot}] dismissed.` },
+      ],
     };
   },
 );
@@ -464,11 +692,13 @@ server.resource(
   async () => {
     const companion = ensureCompanion();
     return {
-      contents: [{
-        uri: "buddy://companion",
-        mimeType: "application/json",
-        text: JSON.stringify(companion, null, 2),
-      }],
+      contents: [
+        {
+          uri: "buddy://companion",
+          mimeType: "application/json",
+          text: JSON.stringify(companion, null, 2),
+        },
+      ],
     };
   },
 );
@@ -517,11 +747,13 @@ server.resource(
     ].join("\n");
 
     return {
-      contents: [{
-        uri: "buddy://prompt",
-        mimeType: "text/plain",
-        text: prompt,
-      }],
+      contents: [
+        {
+          uri: "buddy://prompt",
+          mimeType: "text/plain",
+          text: prompt,
+        },
+      ],
     };
   },
 );

--- a/server/state.ts
+++ b/server/state.ts
@@ -17,15 +17,20 @@
  */
 
 import {
-  readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, renameSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+  renameSync,
 } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import type { Companion } from "./engine.ts";
 
-const STATE_DIR      = join(homedir(), ".claude-buddy");
-const MANIFEST_FILE  = join(STATE_DIR, "menagerie.json");
-const CONFIG_FILE    = join(STATE_DIR, "config.json");
+const STATE_DIR = join(homedir(), ".claude-buddy");
+const MANIFEST_FILE = join(STATE_DIR, "menagerie.json");
+const CONFIG_FILE = join(STATE_DIR, "config.json");
 
 // ─── Session ID (PR #6: tmux session isolation) ─────────────────────────────
 
@@ -67,19 +72,21 @@ function saveManifest(m: Manifest): void {
   mkdirSync(STATE_DIR, { recursive: true });
   const tmp = MANIFEST_FILE + ".tmp";
   writeFileSync(tmp, JSON.stringify(m, null, 2));
-  renameSync(tmp, MANIFEST_FILE);  // atomic on same filesystem
+  renameSync(tmp, MANIFEST_FILE); // atomic on same filesystem
 }
 
 // ─── Slot helpers ────────────────────────────────────────────────────────────
 
 /** Normalise a string to a safe slot key (a-z0-9-, max 14 chars). */
 export function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "")
-    .slice(0, 14) || "buddy";
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 14) || "buddy"
+  );
 }
 
 /**
@@ -147,9 +154,13 @@ export function deleteCompanionSlot(slot: string): void {
   saveManifest(m);
 }
 
-export function listCompanionSlots(): Array<{ slot: string; companion: Companion }> {
+export function listCompanionSlots(): Array<{
+  slot: string;
+  companion: Companion;
+}> {
   return Object.entries(loadManifest().companions).map(([slot, companion]) => ({
-    slot, companion,
+    slot,
+    companion,
   }));
 }
 
@@ -183,15 +194,21 @@ function migrateIfNeeded(): void {
   const menagerieDir = join(STATE_DIR, "menagerie");
   if (existsSync(menagerieDir)) {
     try {
-      for (const f of readdirSync(menagerieDir).filter((f) => f.endsWith(".json"))) {
+      for (const f of readdirSync(menagerieDir).filter((f) =>
+        f.endsWith(".json"),
+      )) {
         const slot = f.slice(0, -5);
         try {
           companions[slot] = JSON.parse(
             readFileSync(join(menagerieDir, f), "utf8"),
           );
-        } catch { /* skip malformed */ }
+        } catch {
+          /* skip malformed */
+        }
       }
-    } catch { /* noop */ }
+    } catch {
+      /* noop */
+    }
   }
 
   // Absorb legacy companion.json
@@ -202,7 +219,9 @@ function migrateIfNeeded(): void {
       const slot = slugify(c.name);
       companions[slot] = c;
       active = slot;
-    } catch { /* noop */ }
+    } catch {
+      /* noop */
+    }
   }
 
   // Read active pointer if it exists
@@ -211,7 +230,9 @@ function migrateIfNeeded(): void {
     try {
       const a = readFileSync(activeFile, "utf8").trim();
       if (a && companions[a]) active = a;
-    } catch { /* noop */ }
+    } catch {
+      /* noop */
+    }
   }
 
   if (Object.keys(companions).length > 0) {
@@ -231,7 +252,9 @@ export interface ReactionState {
 
 export function loadReaction(): ReactionState | null {
   try {
-    const data: ReactionState = JSON.parse(readFileSync(reactionFile(), "utf8"));
+    const data: ReactionState = JSON.parse(
+      readFileSync(reactionFile(), "utf8"),
+    );
     // Reactions expire after 20 seconds (matches shell display TTL)
     if (Date.now() - data.timestamp > 20_000) return null;
     return data;
@@ -266,6 +289,7 @@ export interface BuddyConfig {
   bubbleStyle: "classic" | "round";
   bubblePosition: "top" | "left";
   showRarity: boolean;
+  statusLineEnabled: boolean;
 }
 
 const DEFAULT_CONFIG: BuddyConfig = {
@@ -273,6 +297,7 @@ const DEFAULT_CONFIG: BuddyConfig = {
   bubbleStyle: "classic",
   bubblePosition: "top",
   showRarity: true,
+  statusLineEnabled: false,
 };
 
 export function loadConfig(): BuddyConfig {
@@ -308,22 +333,24 @@ export interface StatusState {
 }
 
 export function writeStatusState(
-  companion: Companion, reaction?: string, muted?: boolean,
+  companion: Companion,
+  reaction?: string,
+  muted?: boolean,
 ): void {
   mkdirSync(STATE_DIR, { recursive: true });
   const { renderFace, RARITY_STARS } =
     require("./engine.ts") as typeof import("./engine.ts");
   const state: StatusState = {
-    name:     companion.name,
-    species:  companion.bones.species,
-    rarity:   companion.bones.rarity,
-    stars:    RARITY_STARS[companion.bones.rarity],
-    face:     renderFace(companion.bones.species, companion.bones.eye),
-    eye:      companion.bones.eye,
-    shiny:    companion.bones.shiny,
-    hat:      companion.bones.hat,
+    name: companion.name,
+    species: companion.bones.species,
+    rarity: companion.bones.rarity,
+    stars: RARITY_STARS[companion.bones.rarity],
+    face: renderFace(companion.bones.species, companion.bones.eye),
+    eye: companion.bones.eye,
+    shiny: companion.bones.shiny,
+    hat: companion.bones.hat,
     reaction: reaction ?? "",
-    muted:    muted ?? false,
+    muted: muted ?? false,
   };
   writeFileSync(join(STATE_DIR, "status.json"), JSON.stringify(state));
 }

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buddy
 description: "Show, pet, or manage your coding companion. Use when the user types /buddy or mentions their companion by name."
-argument-hint: "[show|pet|stats|help|off|on|rename <name>|personality <text>|summon [slot]|save [slot]|list|dismiss <slot>|pick|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]]"
+argument-hint: "[show|pet|stats|help|off|on|rename <name>|personality <text>|summon [slot]|save [slot]|list|dismiss <slot>|pick|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]|statusline [on|off]]"
 allowed-tools: mcp__claude_buddy__*
 ---
 
@@ -13,36 +13,40 @@ Handle the user's `/buddy` command using the claude-buddy MCP tools.
 
 Based on `$ARGUMENTS`:
 
-| Input | Action |
-|-------|--------|
-| *(empty)* or `show` | Call `buddy_show` |
-| `help` | Call `buddy_help` |
-| `pet` | Call `buddy_pet` |
-| `stats` | Call `buddy_stats` |
-| `off` | Call `buddy_mute` |
-| `on` | Call `buddy_unmute` |
-| `rename <name>` | Call `buddy_rename` with the given name |
-| `personality <text>` | Call `buddy_set_personality` with the given text |
-| `summon` | Call `buddy_summon` with no args — picks a random saved buddy |
-| `summon <slot>` | Call `buddy_summon` with the given slot name |
-| `save [slot]` | Call `buddy_save` with optional slot name |
-| `list` | Call `buddy_list` |
-| `dismiss <slot>` | Call `buddy_dismiss` with the slot name |
-| `pick` | Tell user to run `! bun run pick` from the claude-buddy directory (launches interactive TUI) |
-| `frequency` | Call `buddy_frequency` with no args (show current) |
-| `frequency <seconds>` | Call `buddy_frequency` with cooldown=seconds |
-| `style` | Call `buddy_style` with no args (show current) |
-| `style <classic\|round>` | Call `buddy_style` with style arg |
-| `position` | Call `buddy_style` with no args (show current) |
-| `position <top\|left>` | Call `buddy_style` with position arg |
-| `rarity on` | Call `buddy_style` with showRarity=true |
-| `rarity off` | Call `buddy_style` with showRarity=false |
+| Input                    | Action                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| _(empty)_ or `show`      | Call `buddy_show`                                                                            |
+| `help`                   | Call `buddy_help`                                                                            |
+| `pet`                    | Call `buddy_pet`                                                                             |
+| `stats`                  | Call `buddy_stats`                                                                           |
+| `off`                    | Call `buddy_mute`                                                                            |
+| `on`                     | Call `buddy_unmute`                                                                          |
+| `rename <name>`          | Call `buddy_rename` with the given name                                                      |
+| `personality <text>`     | Call `buddy_set_personality` with the given text                                             |
+| `summon`                 | Call `buddy_summon` with no args — picks a random saved buddy                                |
+| `summon <slot>`          | Call `buddy_summon` with the given slot name                                                 |
+| `save [slot]`            | Call `buddy_save` with optional slot name                                                    |
+| `list`                   | Call `buddy_list`                                                                            |
+| `dismiss <slot>`         | Call `buddy_dismiss` with the slot name                                                      |
+| `pick`                   | Tell user to run `! bun run pick` from the claude-buddy directory (launches interactive TUI) |
+| `frequency`              | Call `buddy_frequency` with no args (show current)                                           |
+| `frequency <seconds>`    | Call `buddy_frequency` with cooldown=seconds                                                 |
+| `style`                  | Call `buddy_style` with no args (show current)                                               |
+| `style <classic\|round>` | Call `buddy_style` with style arg                                                            |
+| `position`               | Call `buddy_style` with no args (show current)                                               |
+| `position <top\|left>`   | Call `buddy_style` with position arg                                                         |
+| `rarity on`              | Call `buddy_style` with showRarity=true                                                      |
+| `rarity off`             | Call `buddy_style` with showRarity=false                                                     |
+| `statusline`             | Call `buddy_statusline` with no args (show current)                                          |
+| `statusline on`          | Call `buddy_statusline` with enabled=true                                                    |
+| `statusline off`         | Call `buddy_statusline` with enabled=false                                                   |
 
 ## CRITICAL OUTPUT RULES
 
 The MCP tools return pre-formatted ASCII art with ANSI colors, box-drawing characters, stat bars, and species art. This is the companion's visual identity.
 
 **You MUST output the tool result text EXACTLY as returned — character for character, line for line.** Do NOT:
+
 - Summarize or paraphrase the ASCII art
 - Describe what the companion looks like in prose
 - Add commentary before or after the card


### PR DESCRIPTION
## Summary

Closes two gaps from the previous plugin-marketplace PR discussion so that `claude plugin install` gives users the full experience without needing `bun run install-buddy`.

- **Fix plugin load failure**: `plugin.json` declared `"hooks": "./hooks/hooks.json"`, but the plugin system auto-loads that file by convention. The duplicate registration caused `Hook load failed: Duplicate hooks file detected` and prevented the plugin from loading at all. Removing the line fixes it.
- **Add togglable status line**: status line isn't part of the plugin spec (`settings.json` only), so plugin-installed users had no way to enable it. Added a `buddy_statusline` MCP tool and a `SessionStart` hook that keeps the preference applied across restarts.

## What this answers from the previous PR

> Can plugins auto-register MCP servers, status lines, and hooks through the manifest alone?

- **MCP servers**: Yes — auto-registered via `plugin.json` `mcpServers`, no `~/.claude.json` needed
- **Hooks**: Yes — auto-loaded from `hooks/hooks.json` **by convention**, no `settings.json` entry needed (this was the bug)
- **Skills**: Yes — auto-loaded from `skills/` directory
- **Status line**: No — not part of the plugin spec, needs user opt-in (this PR adds that)

No post-install step needed anymore.

## New user commands

```
/buddy statusline          # show current state
/buddy statusline on       # enable (patches settings.json immediately + on every SessionStart)
/buddy statusline off      # disable (removes from settings.json)
```

Preference is stored in `~/.claude-buddy/config.json` (`statusLineEnabled: boolean`, default `false`) alongside the existing `commentCooldown`, `bubbleStyle`, etc. A new `hooks/statusline-setup.sh` SessionStart hook reads that flag and patches `~/.claude/settings.json` — same pattern leefully-toolkit uses for its own status line.

## Files changed

- \`.claude-plugin/plugin.json\` — remove duplicate \`hooks\` declaration (1 line)
- \`hooks/hooks.json\` — register new SessionStart hook
- \`hooks/statusline-setup.sh\` — new: reads config.json, patches settings.json
- \`server/state.ts\` — add \`statusLineEnabled\` to \`BuddyConfig\`
- \`server/index.ts\` — new \`buddy_statusline\` MCP tool + help text update
- \`skills/buddy/SKILL.md\` — add \`statusline\` to command routing table

## Test plan

- [x] \`claude plugin validate .\` passes
- [x] \`claude plugin install claude-buddy\` loads cleanly (previously failed with duplicate hooks error)
- [x] \`/buddy statusline on\` writes config.json + patches settings.json
- [x] After restart, buddy appears in status line
- [x] \`/buddy statusline off\` removes the statusLine entry
- [x] SessionStart hook re-applies on subsequent launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)