### PR TITLE
Add  command

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -8,6 +8,7 @@
  *   npx claude-buddy show         Show current buddy
  *   npx claude-buddy pick         Interactive two-pane buddy picker (saved + search)
  *   npx claude-buddy hunt         Search for a specific buddy (non-interactive)
+ *   npx claude-buddy upgrade     Pull latest + reinstall
  *   npx claude-buddy uninstall    Remove all integrations
  *   npx claude-buddy verify       Verify what buddy your ID produces
  */
@@ -49,6 +50,9 @@ switch (command) {
   case "disable":
     await import("./disable.ts");
     break;
+  case "upgrade":
+    await import("./upgrade.ts");
+    break;
   case "enable":
     await import("./install.ts");
     break;
@@ -69,6 +73,7 @@ claude-buddy — permanent coding companion for Claude Code
 
 Setup:
   install-buddy     Set up MCP server, skill, hooks, and status line
+  upgrade           Pull latest version and reinstall integrations
   enable            Same as install-buddy (re-enable after disable)
   disable           Temporarily deactivate buddy (data preserved)
   uninstall         Remove all claude-buddy integrations
@@ -78,6 +83,8 @@ Buddy:
   pick              Interactive two-pane buddy picker (browse saved + search)
   hunt              Search for a specific buddy (non-interactive)
   verify            Verify what buddy your current ID produces
+
+  upgrade           Pull latest version + reinstall (add --check to just check)
 
 Settings:
   settings          Show current settings

--- a/cli/upgrade.ts
+++ b/cli/upgrade.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+
+import { readFileSync } from "fs";
+import { execSync } from "child_process";
+import { join, resolve, dirname } from "path";
+import { homedir } from "os";
+
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const NC = "\x1b[0m";
+
+const PROJECT_ROOT = resolve(dirname(import.meta.dir));
+
+function ok(msg: string) { console.log(`${GREEN}✓${NC}  ${msg}`); }
+function info(msg: string) { console.log(`${CYAN}→${NC}  ${msg}`); }
+function warn(msg: string) { console.log(`${YELLOW}⚠${NC}  ${msg}`); }
+function err(msg: string) { console.log(`${RED}✗${NC}  ${msg}`); }
+
+function tryExec(cmd: string, fallback = ""): string {
+  try {
+    return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+function getCurrentVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, "package.json"), "utf8"));
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function banner() {
+  console.log(`
+${CYAN}╔══════════════════════════════════════════════════════════╗${NC}
+${CYAN}║${NC}  ${BOLD}claude-buddy upgrade${NC}                                    ${CYAN}║${NC}
+${CYAN}╚══════════════════════════════════════════════════════════╝${NC}
+`);
+}
+
+function checkGitRepo(): boolean {
+  const isRepo = tryExec("git rev-parse --is-inside-work-tree 2>/dev/null");
+  if (isRepo !== "true") {
+    err("Not inside a git repository. Upgrade requires a git clone of claude-buddy.");
+    return false;
+  }
+  return true;
+}
+
+function getRemoteBranch(): string {
+  const branch = tryExec("git rev-parse --abbrev-ref HEAD 2>/dev/null", "main");
+  return branch === "HEAD" ? "main" : branch;
+}
+
+function checkForUpdates(branch: string): { hasUpdate: boolean; local: string; remote: string; commits: string[] } {
+  info("Fetching latest from remote...\n");
+  try {
+    execSync("git fetch --quiet 2>/dev/null", { cwd: PROJECT_ROOT, stdio: "ignore" });
+  } catch {
+    warn("git fetch failed — proceeding with cached remote state");
+  }
+
+  const local = tryExec("git rev-parse HEAD 2>/dev/null");
+  const upstream = tryExec(`git rev-parse '@{upstream}' 2>/dev/null`);
+  const remote = upstream || tryExec(`git rev-parse origin/${branch} 2>/dev/null`);
+
+  if (!local || !remote) {
+    warn("Could not determine remote HEAD — no tracking branch configured");
+    info(`To set one: git branch --set-upstream-to=origin/${branch} ${branch}`);
+    return { hasUpdate: false, local, remote, commits: [] };
+  }
+
+  if (local === remote) {
+    return { hasUpdate: false, local, remote, commits: [] };
+  }
+
+  const commits = tryExec(
+    `git log --oneline ${local}..origin/${branch} 2>/dev/null`,
+  ).split("\n").filter(Boolean);
+
+  return { hasUpdate: true, local, remote, commits };
+}
+
+function pullLatest(branch: string): boolean {
+  info(`Pulling latest from origin/${branch}...`);
+  try {
+    const output = execSync(`git pull --ff-only origin ${branch} 2>&1`, {
+      cwd: PROJECT_ROOT,
+      encoding: "utf8",
+    });
+    ok("Git pull successful");
+    return true;
+  } catch (e: any) {
+    err("git pull failed — you may have local changes that conflict");
+    err(e.message?.split("\n")[0] || "unknown error");
+    info("Stash or commit your local changes, then re-run upgrade");
+    return false;
+  }
+}
+
+function installDeps(): boolean {
+  info("Installing dependencies...");
+  try {
+    execSync("bun install 2>&1", { cwd: PROJECT_ROOT, stdio: "ignore" });
+    ok("Dependencies installed");
+    return true;
+  } catch {
+    err("bun install failed");
+    return false;
+  }
+}
+
+function reinstallBuddy(): boolean {
+  info("Re-running install-buddy to update integrations...\n");
+  try {
+    execSync("bun run install-buddy 2>&1", { cwd: PROJECT_ROOT, stdio: "inherit" });
+    return true;
+  } catch {
+    err("install-buddy failed");
+    return false;
+  }
+}
+
+function printSummary(oldVersion: string, commits: string[]) {
+  const newVersion = getCurrentVersion();
+
+  console.log("");
+  console.log(`${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}`);
+  console.log(`${GREEN}  Upgrade complete!${NC}`);
+  console.log(`${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}`);
+  console.log("");
+  console.log(`  ${BOLD}Version:${NC}  ${oldVersion} → ${BOLD}${newVersion}${NC}`);
+
+  if (commits.length > 0) {
+    console.log(`  ${BOLD}Changes:${NC}`);
+    const display = commits.slice(0, 15);
+    for (const c of display) {
+      console.log(`    ${DIM}${c}${NC}`);
+    }
+    if (commits.length > 15) {
+      console.log(`    ${DIM}... and ${commits.length - 15} more${NC}`);
+    }
+  }
+
+  console.log("");
+  console.log(`${DIM}  Restart Claude Code for changes to take effect.${NC}`);
+  console.log("");
+}
+
+const args = process.argv.slice(2);
+const checkOnly = args.includes("--check");
+
+banner();
+
+const oldVersion = getCurrentVersion();
+info(`Current version: ${oldVersion}\n`);
+
+if (!checkGitRepo()) {
+  process.exit(1);
+}
+
+const branch = getRemoteBranch();
+const { hasUpdate, commits } = checkForUpdates(branch);
+
+if (!hasUpdate) {
+  ok(`Already up to date (v${oldVersion})`);
+  console.log("");
+  process.exit(0);
+}
+
+if (checkOnly) {
+  warn(`Update available! ${commits.length} new commit${commits.length === 1 ? "" : "s"}:`);
+  for (const c of commits.slice(0, 10)) {
+    console.log(`  ${DIM}${c}${NC}`);
+  }
+  if (commits.length > 10) {
+    console.log(`  ${DIM}... and ${commits.length - 10} more${NC}`);
+  }
+  console.log("");
+  info("Run without --check to apply the update");
+  console.log("");
+  process.exit(0);
+}
+
+info(`${commits.length} new commit${commits.length === 1 ? "" : ""} available:`);
+for (const c of commits.slice(0, 10)) {
+  console.log(`  ${DIM}${c}${NC}`);
+}
+if (commits.length > 10) {
+  console.log(`  ${DIM}... and ${commits.length - 10} more${NC}`);
+}
+console.log("");
+
+if (!pullLatest(branch)) {
+  process.exit(1);
+}
+
+if (!installDeps()) {
+  process.exit(1);
+}
+
+if (!reinstallBuddy()) {
+  process.exit(1);
+}
+
+printSummary(oldVersion, commits);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "settings": "bun run cli/settings.ts",
         "disable": "bun run cli/disable.ts",
         "enable": "bun run cli/install.ts",
+        "upgrade": "bun run cli/upgrade.ts",
         "uninstall": "bun run cli/uninstall.ts",
         "help": "bun run cli/index.ts help",
         "test": "bun test",


### PR DESCRIPTION
## What

Adds a single-command upgrade path so users don't have to manually run 4 separate commands every time there's a new version.

Closes #33

## How it works

`bun run upgrade` does the following:

1. `git fetch` and compares local HEAD vs remote
2. Shows what changed — lists new commits since last upgrade
3. `git pull --ff-only` — safe, won't create merge commits
4. `bun install` — picks up any dependency changes
5. Re-runs `install-buddy` — idempotent, updates MCP/hooks/skill/statusline in place
6. Prints a summary: old version → new version, what was updated

There's also a `--check` flag that just tells you if an update is available without applying it.

## Files changed

- `cli/upgrade.ts` — new command
- `cli/index.ts` — registered the `upgrade` route + help text
- `package.json` — added `upgrade` script

## Testing

```bash
bun run upgrade --check   # dry run
bun run upgrade           # full upgrade
claude-buddy upgrade      # also works via the CLI router
```

Tested on macOS with bun 1.2.x. The `--ff-only` flag means it'll fail safely if someone has local diverging changes instead of creating a messy merge.