### PR TITLE
fix(plugin): resolve manifest paths + add bun preflight launcher

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
         "name": "1270011"
     },
     "metadata": {
-        "description": "Permanent coding companion for Claude Code",
+        "description": "Permanent coding companion for Claude Code (requires bun: https://bun.sh/install)",
         "version": "0.3.0"
     },
     "plugins": [
         {
             "name": "claude-buddy",
             "source": "./",
-            "description": "Permanent coding companion for Claude Code \u2014 survives any update. MCP-based terminal pet with ASCII art, stats, reactions, and personality.",
+            "description": "Permanent coding companion for Claude Code \u2014 survives any update. MCP-based terminal pet with ASCII art, stats, reactions, and personality. Requires bun runtime (https://bun.sh/install).",
             "version": "0.3.0",
             "author": {
                 "name": "1270011"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,10 +19,8 @@
     "mcpServers": {
         "claude-buddy": {
             "type": "stdio",
-            "command": "bun",
-            "args": [
-                "server/index.ts"
-            ]
+            "command": "${CLAUDE_PLUGIN_ROOT}/server/mcp-launcher.sh",
+            "args": []
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@
 <!-- QUICK START                                                  -->
 <!-- ============================================================ -->
 
+## 📋 Requirements
+
+- **[bun](https://bun.sh/install)** on `PATH` — claude-buddy's MCP server runs on bun. Install once: `curl -fsSL https://bun.sh/install | bash`
+- **Claude Code v2.1.80+**
+- **Linux or macOS** (Windows is experimental)
+
 ## 🚀 Quick Start
 
 ```bash
@@ -83,8 +89,6 @@ bun run install-buddy
 
 Then restart Claude Code and type `/buddy`. That's it.
 
-<sub>💡 Need Bun? → `curl -fsSL https://bun.sh/install | bash`</sub>
-<br>
 <sub>💡 Want a global `claude-buddy` command? → `bun link`</sub>
 <br>
 <sub>💡 Need help? → `bun run help` or `claude-buddy help` (if linked) in terminal · `/buddy help` in Claude Code</sub>

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "./hooks/react.sh"
+                        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/react.sh"
                     }
                 ]
             }
@@ -16,7 +16,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "./hooks/buddy-comment.sh"
+                        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/buddy-comment.sh"
                     }
                 ]
             }
@@ -26,7 +26,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "./hooks/name-react.sh"
+                        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/name-react.sh"
                     }
                 ]
             }

--- a/server/manifest.test.ts
+++ b/server/manifest.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression tests for shipped plugin manifests. These exist because a
+ * single misplaced "./" relative path in hooks.json or plugin.json silently
+ * breaks `claude plugin install` — Claude Code runs those commands from the
+ * user's project cwd, not the plugin cache dir, so every lookup fails. The
+ * tests below pin the invariants that prevent that class of bug from
+ * returning.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync, existsSync, statSync } from "fs";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+
+describe("shipped plugin manifests", () => {
+  test("hooks/hooks.json: every hook command uses ${CLAUDE_PLUGIN_ROOT}", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(REPO_ROOT, "hooks", "hooks.json"), "utf8"),
+    );
+
+    const commands: string[] = [];
+    for (const hookType of Object.keys(manifest.hooks ?? {})) {
+      for (const entry of manifest.hooks[hookType]) {
+        for (const hook of entry.hooks ?? []) {
+          if (hook.type === "command" && hook.command) commands.push(hook.command);
+        }
+      }
+    }
+
+    expect(commands.length).toBeGreaterThan(0);
+    for (const cmd of commands) {
+      expect(cmd).toContain("${CLAUDE_PLUGIN_ROOT}");
+    }
+  });
+
+  test(".claude-plugin/plugin.json: MCP server command resolves plugin-root-absolute", () => {
+    const manifest = JSON.parse(
+      readFileSync(join(REPO_ROOT, ".claude-plugin", "plugin.json"), "utf8"),
+    );
+    const entry = manifest.mcpServers?.["claude-buddy"];
+    expect(entry).toBeDefined();
+
+    // Either the command itself is plugin-root-anchored (the launcher path),
+    // or every positional arg must be — a relative path would break install.
+    const command: string = entry.command;
+    const args: string[] = entry.args ?? [];
+    const isRooted = (p: string) => p.startsWith("${CLAUDE_PLUGIN_ROOT}") || p.startsWith("/");
+
+    if (isRooted(command)) {
+      // Args may be empty or flags — no file-path args expected.
+      return;
+    }
+
+    expect(args.length).toBeGreaterThan(0);
+    for (const arg of args) expect(isRooted(arg)).toBe(true);
+  });
+
+  test("server/mcp-launcher.sh: exists, is executable, and contains the bun preflight", () => {
+    const launcher = join(REPO_ROOT, "server", "mcp-launcher.sh");
+
+    expect(existsSync(launcher)).toBe(true);
+
+    const mode = statSync(launcher).mode;
+    // Owner, group, and other must all have the execute bit.
+    expect(mode & 0o111).toBe(0o111);
+
+    const contents = readFileSync(launcher, "utf8");
+    expect(contents).toContain("command -v bun");
+    expect(contents).toMatch(/exec\s+bun\b/);
+  });
+});

--- a/server/mcp-launcher.sh
+++ b/server/mcp-launcher.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# claude-buddy MCP server launcher — preflight checks bun, then execs the server.
+# Failing here with a clear stderr message is much easier to debug than a silent
+# "MCP tools not available" from Claude Code.
+
+set -eu
+
+if ! command -v bun >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+[claude-buddy] ERROR: 'bun' was not found on PATH.
+
+claude-buddy's MCP server runs on bun. Install it with:
+
+    curl -fsSL https://bun.sh/install | bash
+
+Then open a new shell (so PATH picks up bun) and restart Claude Code.
+EOF
+  exit 127
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec bun "$SCRIPT_DIR/index.ts"


### PR DESCRIPTION
Installing via the plugin marketplace (claude plugin marketplace add + claude plugin install) landed the files correctly but the plugin failed to run, with two symptoms:

  /bin/sh: 1: ./hooks/react.sh: not found
  claude-buddy MCP tools are not available

Root cause: the shipped manifests used cwd-relative paths for the hook and MCP-server entries. Claude Code invokes both from the user's project cwd, not from the plugin install dir, so every lookup failed the moment the user ran `claude` anywhere outside the plugin cache.

Changes:

- hooks/hooks.json: rewrite the three hook commands to ${CLAUDE_PLUGIN_ROOT}/hooks/*.sh so they resolve to the plugin cache regardless of where `claude` was started.

- .claude-plugin/plugin.json: switch the MCP server entry from `bun server/index.ts` (relative) to a small shell launcher at ${CLAUDE_PLUGIN_ROOT}/server/mcp-launcher.sh. The launcher does a preflight check for bun on PATH — if missing, it prints a clear error with the install URL to stderr and exits 127, instead of the silent "MCP tools not available" the user sees today. If bun is present it execs `bun $SCRIPT_DIR/index.ts`, using $0-relative lookup so it also works when invoked manually.

- README.md: add a Requirements section above Quick Start making bun an explicit, named hard dependency. Previously bun was mentioned only as a hint inside the Quick Start block, which is invisible to users who install via the marketplace and never read the git-clone path.

- .claude-plugin/marketplace.json: append the bun requirement to both description fields so it shows up in the marketplace listing itself.

Manually verified end-to-end: fresh state (no plugin, no hooks, no statusline in settings.json, companion data preserved), then
  claude plugin marketplace add <path>
  claude plugin install claude-buddy@claude-buddy
  claude
  /claude-buddy:buddy statusline on
→ MCP tool fires, no hook not-found errors, statusline gets written.

Known follow-up (out of scope here): `claude plugin uninstall` does not clean the statusLine entry that buddy_statusline writes to settings.json. Fix needs to live in a new buddy_uninstall MCP tool, since Claude Code has no plugin-side uninstall hook. Separate PR.

Thanks @grlee for the original plugin.json work that exposed this follow-up.