### PR TITLE
feat(uninstall): /buddy uninstall + buddy_uninstall MCP tool

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import {
   listCompanionSlots,
   setBuddyStatusLine,
   unsetBuddyStatusLine,
+  cleanupPluginState,
 } from "./state.ts";
 import {
   getReaction, generatePersonalityPrompt,
@@ -489,7 +490,10 @@ server.tool(
         content: [
           {
             type: "text",
-            text: "Status line enabled! Restart Claude Code to see your buddy in the status line.",
+            text:
+              "Status line enabled! Restart Claude Code to see your buddy in the status line.\n\n" +
+              "Note: this writes an entry to ~/.claude/settings.json that `claude plugin uninstall` does not remove. " +
+              "Run `/buddy uninstall` before uninstalling the plugin to clean it up.",
           },
         ],
       };
@@ -504,6 +508,47 @@ server.tool(
         ],
       };
     }
+  },
+);
+
+// ─── Tool: buddy_uninstall ───────────────────────────────────────────────────
+
+server.tool(
+  "buddy_uninstall",
+  "Clean up claude-buddy's writes to ~/.claude/settings.json and transient session files in ~/.claude-buddy/, in preparation for `claude plugin uninstall`. Companion data (menagerie, status, config) is intentionally preserved so reinstalling restores the buddy. The tool only cleans the plugin's own settings — it never removes a foreign statusLine.",
+  {},
+  async () => {
+    const result = cleanupPluginState();
+
+    const lines: string[] = [];
+    lines.push("claude-buddy: settings.json cleanup complete.");
+    lines.push("");
+    lines.push(
+      result.statusLineRemoved
+        ? "  \u2713 statusLine entry removed from ~/.claude/settings.json"
+        : "  \u2014 no buddy statusLine was present (nothing to remove)",
+    );
+    if (result.foreignStatusLineKept) {
+      lines.push(
+        "  \u2713 a non-buddy statusLine was detected and left untouched",
+      );
+    }
+    lines.push(
+      `  \u2713 ${result.transientFilesRemoved} transient session file(s) removed from ~/.claude-buddy/`,
+    );
+    lines.push("  \u2014 companion data at ~/.claude-buddy/ preserved");
+    lines.push("");
+    lines.push("Now run these commands via the Bash tool, in order:");
+    lines.push("");
+    lines.push("  claude plugin uninstall claude-buddy@claude-buddy");
+    lines.push("  claude plugin marketplace remove claude-buddy");
+    lines.push("  rm -rf ~/.claude/plugins/cache/claude-buddy");
+    lines.push("");
+    lines.push(
+      "After those three commands the plugin is fully removed. Restart Claude Code to apply.",
+    );
+
+    return { content: [{ type: "text", text: lines.join("\n") }] };
   },
 );
 

--- a/server/state.ts
+++ b/server/state.ts
@@ -23,12 +23,13 @@ import {
   existsSync,
   readdirSync,
   renameSync,
+  rmSync,
 } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import type { Companion } from "./engine.ts";
 
-const STATE_DIR = join(homedir(), ".claude-buddy");
+export const STATE_DIR = join(homedir(), ".claude-buddy");
 const MANIFEST_FILE = join(STATE_DIR, "menagerie.json");
 const CONFIG_FILE = join(STATE_DIR, "config.json");
 
@@ -406,4 +407,65 @@ export function unsetBuddyStatusLine(
   } catch {
     return false;
   }
+}
+
+// ─── Plugin uninstall cleanup ───────────────────────────────────────────────
+
+export interface CleanupResult {
+  statusLineRemoved: boolean;
+  foreignStatusLineKept: boolean;
+  transientFilesRemoved: number;
+}
+
+const TRANSIENT_PREFIXES = [
+  "popup-stop.",
+  "popup-resize.",
+  "popup-env.",
+  "popup-scroll.",
+  "popup-reopen-pid.",
+  "reaction.",
+  ".last_reaction.",
+  ".last_comment.",
+];
+
+/**
+ * Clean up plugin-owned writes to the user's global state so that
+ * `claude plugin uninstall` leaves no orphaned entries behind. Specifically:
+ *   - remove settings.statusLine if it points to buddy-status.sh
+ *   - delete session-scoped transient files under ~/.claude-buddy/
+ *
+ * Companion data (menagerie.json, status.json, config.json) is intentionally
+ * kept — users reinstalling get their buddy back. Call-sites that want a full
+ * wipe should delete STATE_DIR themselves after calling this.
+ */
+export function cleanupPluginState(
+  settingsPath: string = CLAUDE_SETTINGS_PATH,
+  stateDir: string = STATE_DIR,
+): CleanupResult {
+  const statusLineRemoved = unsetBuddyStatusLine(settingsPath);
+
+  let foreignStatusLineKept = false;
+  try {
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    const cmd = settings.statusLine?.command;
+    if (cmd && !cmd.includes("buddy-status.sh")) foreignStatusLineKept = true;
+  } catch {
+    /* missing settings.json is fine */
+  }
+
+  let transientFilesRemoved = 0;
+  try {
+    if (existsSync(stateDir)) {
+      for (const f of readdirSync(stateDir)) {
+        if (TRANSIENT_PREFIXES.some(p => f.startsWith(p))) {
+          rmSync(join(stateDir, f), { force: true });
+          transientFilesRemoved++;
+        }
+      }
+    }
+  } catch {
+    /* state dir unreadable is fine */
+  }
+
+  return { statusLineRemoved, foreignStatusLineKept, transientFilesRemoved };
 }

--- a/server/uninstall.test.ts
+++ b/server/uninstall.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for cleanupPluginState — the helper behind the buddy_uninstall MCP
+ * tool. Uses a temp dir per test so no real user state is touched.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { cleanupPluginState } from "./state.ts";
+
+describe("cleanupPluginState", () => {
+  let settingsPath: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    const root = mkdtempSync(join(tmpdir(), "buddy-uninstall-test-"));
+    settingsPath = join(root, "settings.json");
+    stateDir = join(root, ".claude-buddy");
+    mkdirSync(stateDir, { recursive: true });
+  });
+
+  test("removes buddy statusLine and reports it", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        statusLine: { type: "command", command: "/opt/buddy/statusline/buddy-status.sh" },
+        other: "keep",
+      }),
+    );
+
+    const result = cleanupPluginState(settingsPath, stateDir);
+
+    expect(result.statusLineRemoved).toBe(true);
+    expect(result.foreignStatusLineKept).toBe(false);
+    const after = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(after.statusLine).toBeUndefined();
+    expect(after.other).toBe("keep");
+  });
+
+  test("never removes a foreign statusLine and reports it was kept", () => {
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        statusLine: { type: "command", command: "/usr/local/bin/my-status.sh" },
+      }),
+    );
+
+    const result = cleanupPluginState(settingsPath, stateDir);
+
+    expect(result.statusLineRemoved).toBe(false);
+    expect(result.foreignStatusLineKept).toBe(true);
+    const after = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(after.statusLine.command).toBe("/usr/local/bin/my-status.sh");
+  });
+
+  test("wipes session-scoped transient files but keeps companion data", () => {
+    writeFileSync(join(stateDir, "reaction.pane-1.json"), "{}");
+    writeFileSync(join(stateDir, "reaction.default.json"), "{}");
+    writeFileSync(join(stateDir, ".last_reaction.pane-1"), "0");
+    writeFileSync(join(stateDir, ".last_comment.default"), "0");
+    writeFileSync(join(stateDir, "popup-stop.42"), "");
+    writeFileSync(join(stateDir, "popup-reopen-pid.42"), "99999");
+    writeFileSync(join(stateDir, "popup-env.42"), "");
+    writeFileSync(join(stateDir, "popup-resize.42"), "");
+    writeFileSync(join(stateDir, "popup-scroll.42"), "");
+    writeFileSync(join(stateDir, "menagerie.json"), "{}");
+    writeFileSync(join(stateDir, "status.json"), "{}");
+    writeFileSync(join(stateDir, "config.json"), "{}");
+
+    const result = cleanupPluginState(settingsPath, stateDir);
+
+    expect(result.transientFilesRemoved).toBe(9);
+    const remaining = readdirSync(stateDir).sort();
+    expect(remaining).toEqual(["config.json", "menagerie.json", "status.json"]);
+  });
+
+  test("is a no-op when settings.json and state dir are both absent", () => {
+    const missingSettings = join(tmpdir(), `nonexistent-${Date.now()}.json`);
+    const missingState = join(tmpdir(), `nonexistent-state-${Date.now()}`);
+
+    const result = cleanupPluginState(missingSettings, missingState);
+
+    expect(result.statusLineRemoved).toBe(false);
+    expect(result.foreignStatusLineKept).toBe(false);
+    expect(result.transientFilesRemoved).toBe(0);
+    expect(existsSync(missingSettings)).toBe(false);
+    expect(existsSync(missingState)).toBe(false);
+  });
+
+  test("handles empty state dir without error", () => {
+    writeFileSync(settingsPath, JSON.stringify({ other: "keep" }));
+
+    const result = cleanupPluginState(settingsPath, stateDir);
+
+    expect(result.transientFilesRemoved).toBe(0);
+    expect(result.statusLineRemoved).toBe(false);
+  });
+});

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buddy
 description: "Show, pet, or manage your coding companion. Use when the user types /buddy or mentions their companion by name."
-argument-hint: "[show|pet|stats|help|off|on|rename <name>|personality <text>|achievements|summon [slot]|save [slot]|list|dismiss <slot>|pick|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]|statusline [on|off]]"
+argument-hint: "[show|pet|stats|help|off|on|rename <name>|personality <text>|achievements|summon [slot]|save [slot]|list|dismiss <slot>|pick|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]|statusline [on|off]|uninstall]"
 allowed-tools: mcp__claude_buddy__*
 ---
 
@@ -41,6 +41,7 @@ Based on `$ARGUMENTS`:
 | `statusline`             | Call `buddy_statusline` with no args (show current)                                          |
 | `statusline on`          | Call `buddy_statusline` with enabled=true                                                    |
 | `statusline off`         | Call `buddy_statusline` with enabled=false                                                   |
+| `uninstall`              | Run the uninstall sequence (see **Uninstall Orchestration** below)                           |
 
 ## CRITICAL OUTPUT RULES
 
@@ -57,3 +58,17 @@ The MCP tools return pre-formatted ASCII art with ANSI colors, box-drawing chara
 **Just output the raw text content from the tool result. Nothing else.** The ASCII art IS the response.
 
 If the user mentions the buddy's name in normal conversation, call `buddy_react` with reason "turn" and display the result verbatim.
+
+## Uninstall Orchestration
+
+When the user invokes `/buddy uninstall`, run this sequence **in order** — do not skip steps, do not ask for confirmation between steps:
+
+1. Call the MCP tool `buddy_uninstall`. Display its output verbatim.
+2. Run via Bash tool: `claude plugin uninstall claude-buddy@claude-buddy`
+3. Run via Bash tool: `claude plugin marketplace remove claude-buddy`
+4. Run via Bash tool: `rm -rf ~/.claude/plugins/cache/claude-buddy`
+5. Tell the user: uninstall is complete; companion data is kept at `~/.claude-buddy/`; restart Claude Code to release the plugin.
+
+If any Bash step fails (non-zero exit), report the error but continue with the remaining steps — each step is independent and always-safe to run.
+
+Do not call `buddy_uninstall` for any other command than `/buddy uninstall`. Never call it proactively.


### PR DESCRIPTION
## Problem

`buddy_statusline on` writes a `statusLine` entry to `~/.claude/settings.json` pointing at the plugin cache. `claude plugin uninstall` removes the plugin cache dir but does **not** remove this entry — so every uninstall leaks an orphaned config entry pointing at a path that no longer exists. On the next Claude Code start the status-line command fails silently, and the user is left with stale global config they didn't know was there.

## Why this can't be fixed in the plugin manifest

Plugin manifest has **no** `statusLine` field and **no** "on uninstall" hook mechanism I know of (If somebody do, point me into it pls). Confirmed against [plugins-reference.md](https://code.claude.com/docs/en/plugins-reference.md). So the cleanest workaround is a plugin-side teardown that the user triggers once, before `claude plugin uninstall`, while the MCP server is still running.

## Design — why Claude orchestrates, not the MCP server

Naive approach: the MCP tool spawns `claude plugin uninstall` internally. Problem: that command removes the plugin cache dir containing the MCP server process, causing a self-termination race. The response might not flush before the parent Claude Code kills the subprocess.

Chosen approach: the MCP tool does only the deterministic, fast work (patch `settings.json`, wipe transient files), then returns text telling Claude to run the three remaining CLI steps via the Bash tool. The skill prompt repeats the instruction (belt + suspenders). The user runs one slash command; everything else is automatic.

```
User: /buddy uninstall

Claude (skill-driven sequence):
1. buddy_uninstall MCP tool    → cleans settings.json, removes transient files
2. Bash: claude plugin uninstall claude-buddy@claude-buddy
3. Bash: claude plugin marketplace remove claude-buddy
4. Bash: rm -rf ~/.claude/plugins/cache/claude-buddy
5. Summary to user
```

Companion data at `~/.claude-buddy/` is intentionally preserved so reinstalling restores the buddy — matches the policy already set in `cli/uninstall.ts:105`.

## Changes

- **`server/state.ts`** — new `cleanupPluginState(settingsPath?, stateDir?)` helper. Removes buddy statusLine (reusing the existing "never touch foreign statusLine" invariant), wipes session-scoped transient files (`popup-*`, `reaction.*`, `.last_reaction.*`, `.last_comment.*`). Paths injectable for tests. Exports `STATE_DIR` for composition.
- **`server/index.ts`** — new `buddy_uninstall` MCP tool calling the helper and returning a response with the three follow-up Bash commands. Plus a short notice added to the `buddy_statusline on` response telling users about the leak and how to clean it.
- **`skills/buddy/SKILL.md`** — route `/buddy uninstall` + new "Uninstall Orchestration" section that pins the exact 4-step sequence. No confirmation prompts between steps — each step is always-safe to run independently.
- **`server/uninstall.test.ts`** — 5 tests:
  - removes buddy statusLine and preserves other keys
  - **never** removes a foreign statusLine (safety invariant)
  - wipes transient files but keeps companion data (menagerie / status / config)
  - no-op when settings.json + state dir both absent
  - no-op when state dir is empty

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 106 pass / 0 fail (was 101; +5 uninstall tests)
- [ ] Manual E2E: install → `/buddy statusline on` → `/buddy uninstall` → verify `settings.json` has no `statusLine`, cache dir gone, companion data intact, `~/.claude/plugins/installed_plugins.json` empty.

## Known limitations

- If the user skips `/buddy uninstall` and goes straight to `claude plugin uninstall`, the statusLine entry still leaks. Nothing we can do without upstream support.
- The skill prompt is a prompt, not a program. If Claude decides not to follow the orchestration prompt in some edge case, the MCP step still runs (deterministic) — worst case is the user has to run the three Bash commands manually, which are printed in the MCP tool's response.

## Stacking

This PR is based on `main`, independent of `fix/plugin-root-paths`. Both can land in either order. Together they give: marketplace install that works cleanly + marketplace uninstall that leaves no orphans.