### PR TITLE
patch(windows): cross-compatibility with Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ The popup is modal. To scroll:
 |---|---|
 | **[Bun](https://bun.sh)** | `curl -fsSL https://bun.sh/install \| bash` |
 | **Claude Code** v2.1.80+ | Any version with MCP support |
-| **jq** | `apt install jq` / `brew install jq` |
+| **jq** | `apt install jq` / `brew install jq` / [`windows: download and add 'jq.exe' from jqlang/jq to path`](https://github.com/jqlang/jq/releases/latest)|
 
 > **Will I get the same buddy I had?** Yes. claude-buddy uses the exact same algorithm as the original (`wyhash + mulberry32`, same salt, same identity resolution). If your `~/.claude.json` still has your `accountUuid`, you'll get the identical species, rarity, stats, and cosmetics.
 

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -11,6 +11,7 @@ import { join, resolve, dirname } from "path";
 import { homedir } from "os";
 
 import { generateBones, renderBuddy, renderFace, RARITY_STARS } from "../server/engine.ts";
+import { toUnixPath } from "../server/path.ts";
 import { loadCompanion, saveCompanion, resolveUserId, writeStatusState } from "../server/state.ts";
 import { generateFallbackName } from "../server/reactions.ts";
 
@@ -88,15 +89,6 @@ function preflight(): boolean {
   }
 
   return pass;
-}
-
-// Path normalization (Windows compat)
-// Node's path.join() produces backslash paths on Windows, which bash treats as
-// escape sequences, stripping them entirely (e.g. C:\Users -> C:Users).
-// Use forward slashes in all paths written to config files.
-
-function toUnixPath(p: string): string {
-  return p.replace(/\\/g, "/");
 }
 
 // ─── Load / update settings.json ────────────────────────────────────────────

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -90,6 +90,15 @@ function preflight(): boolean {
   return pass;
 }
 
+// Path normalization (Windows compat)
+// Node's path.join() produces backslash paths on Windows, which bash treats as
+// escape sequences, stripping them entirely (e.g. C:\Users -> C:Users).
+// Use forward slashes in all paths written to config files.
+
+function toUnixPath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
 // ─── Load / update settings.json ────────────────────────────────────────────
 
 function loadSettings(): Record<string, any> {
@@ -120,8 +129,8 @@ function installMcp() {
 
   claudeJson.mcpServers["claude-buddy"] = {
     command: "bun",
-    args: [serverPath],
-    cwd: PROJECT_ROOT,
+    args: [toUnixPath(serverPath)],
+    cwd: toUnixPath(PROJECT_ROOT),
   };
 
   writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
@@ -144,7 +153,7 @@ function installStatusLine(settings: Record<string, any>) {
 
   settings.statusLine = {
     type: "command",
-    command: statusScript,
+    command: toUnixPath(statusScript),
     padding: 1,
     refreshInterval: 1,  // 1 second — drives the buddy animation
   };
@@ -178,7 +187,7 @@ function installPopupHooks(settings: Record<string, any>) {
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
   );
   settings.hooks.SessionStart.push({
-    hooks: [{ type: "command", command: `${popupManager} start` }],
+    hooks: [{ type: "command", command: `${toUnixPath(popupManager)} start` }],
   });
 
   // SessionEnd: close popup
@@ -187,7 +196,7 @@ function installPopupHooks(settings: Record<string, any>) {
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
   );
   settings.hooks.SessionEnd.push({
-    hooks: [{ type: "command", command: `${popupManager} stop` }],
+    hooks: [{ type: "command", command: `${toUnixPath(popupManager)} stop` }],
   });
 
   ok("Popup hooks registered: SessionStart + SessionEnd");
@@ -209,7 +218,7 @@ function installHooks(settings: Record<string, any>) {
   );
   settings.hooks.PostToolUse.push({
     matcher: "Bash",
-    hooks: [{ type: "command", command: reactHook }],
+    hooks: [{ type: "command", command: toUnixPath(reactHook) }],
   });
 
   // Stop: extract <!-- buddy: --> comment from Claude's response
@@ -218,7 +227,7 @@ function installHooks(settings: Record<string, any>) {
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
   );
   settings.hooks.Stop.push({
-    hooks: [{ type: "command", command: commentHook }],
+    hooks: [{ type: "command", command: toUnixPath(commentHook) }],
   });
 
   // UserPromptSubmit: detect buddy's name in user message → instant status line reaction
@@ -227,7 +236,7 @@ function installHooks(settings: Record<string, any>) {
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
   );
   settings.hooks.UserPromptSubmit.push({
-    hooks: [{ type: "command", command: nameHook }],
+    hooks: [{ type: "command", command: toUnixPath(nameHook) }],
   });
 
   ok("Hooks registered: PostToolUse + Stop + UserPromptSubmit");

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -65,7 +65,7 @@ function preflight(): boolean {
       execSync("sudo apt-get install -y jq 2>/dev/null || brew install jq 2>/dev/null", { stdio: "ignore" });
       ok("jq installed");
     } catch {
-      err("Could not install jq. Install manually: apt install jq / brew install jq");
+      err("Could not install jq. Install manually: apt install jq / brew install jq / windows: install from https://github.com/jqlang/jq/releases/latest and add to PATH");
       pass = false;
     }
   }

--- a/server/path.ts
+++ b/server/path.ts
@@ -1,0 +1,16 @@
+// Path utilities and helpers
+
+// Path normalization (Windows compat)
+// Node's path.join() produces backslash paths on Windows, which bash treats as
+// escape sequences, stripping them entirely (e.g. C:\Users -> C:Users).
+// Use forward slashes in all paths written to config files.
+
+/**
+ * Converts all backslashes in a file path to forward slashes, producing a Unix-style path.
+ *
+ * @param p - The file path to convert.
+ * @returns The converted path with forward slashes.
+ */
+export function toUnixPath(p: string): string {
+  return p.replace(/\\/g, "/");
+}

--- a/server/state.ts
+++ b/server/state.ts
@@ -28,6 +28,7 @@ import {
 import { join } from "path";
 import { homedir } from "os";
 import type { Companion } from "./engine.ts";
+import { toUnixPath } from "./path.ts";
 
 export const STATE_DIR = join(homedir(), ".claude-buddy");
 const MANIFEST_FILE = join(STATE_DIR, "menagerie.json");
@@ -388,7 +389,7 @@ export function setBuddyStatusLine(
     const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
     settings.statusLine = {
       type: "command",
-      command: statusScript,
+      command: toUnixPath(statusScript),
       padding: 1,
       refreshInterval: 1,
     };

--- a/server/statusline.test.ts
+++ b/server/statusline.test.ts
@@ -69,4 +69,18 @@ describe("buddy statusline settings patch", () => {
     const ok = setBuddyStatusLine("/opt/buddy/statusline/buddy-status.sh", missing);
     expect(ok).toBe(false);
   });
+
+  test("backslash path is normalized to forward slashes in persisted command", () => {
+    writeFileSync(settingsPath, JSON.stringify({}));
+
+    // Simulate a Windows-style path with backslashes (e.g. from path.join on Windows).
+    // The persisted command must contain only forward slashes so bash can execute it.
+    const backslashPath = "C:\\Users\\user\\.claude\\statusline\\buddy-status.sh";
+    const ok = setBuddyStatusLine(backslashPath, settingsPath);
+
+    expect(ok).toBe(true);
+    const result = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(result.statusLine.command).not.toContain("\\");
+    expect(result.statusLine.command).toContain("/");
+  });
 });


### PR DESCRIPTION
Fixes #7

## Problem

On Windows, `claude-buddy`'s hooks and MCP server silently fail to start. The root cause is that Node's `path.join()` produces Windows-style backslash paths (like: `C:\Users\igarcia\...`), which get written directly into `~/.claude/settings.json` and `~/.claude.json`.

Since Claude Code uses Git Bash for execution, bash treats each `\` as an escape character - stripping them entirely:

So for example:
`C:\Users\igarcia\source\repos\claude-buddy\hooks\react.sh` becomes --> `C:Usersigarciasourcereposclaude-buddyhooksreact.sh` = **Failed command**

This breaks all three hooks (`UserPromptSubmit`, `PostToolUse`, `Stop`) and prevents the MCP server from connecting, so `/buddy` fails with **"Failed to reconnect to claude-buddy."**

## The Fix

Added a small `toUnixPath()` helper in `cli/install.ts` that converts backslashes to forward slashes before any path is written to a config file:

```javascript
  function toUnixPath(p: string): string {
    return p.replace(/\\/g, "/");
  }
```

Applied to all paths written by the installer: 

* MCP server args/cwd
* Status line command
* Hook commands
* Popup hook commands.

Git Bash on Windows handles `C:/Users/...` paths correctly while maintaining compatibility with Linux/MacOS, so this is safe cross-platform.

## Also worth noting

**This fix does not require any port-over from bash to TypeScript or PowerShell - as Git Bash handles the scripts just fine**

The MCP server requires `jq` to be on the PATH. If `jq` was downloaded via [jqlang/jq](https://github.com/jqlang/jq/releases/latest) but not added to PATH, Claude Code can't find it when spawning the server process. 

The installer's `jq` error message was also updated to include Windows install instructions.

## Screenshots

Tested on Windows 11 with Git Bash. Hooks fire correctly and `/buddy show` works after a fresh install.

<img width="1187" height="788" alt="image" src="https://github.com/user-attachments/assets/0bc1c428-0435-4017-b285-a6c26f7581c0" />


<img width="1227" height="218" alt="image" src="https://github.com/user-attachments/assets/53973adf-8a67-45b2-bcf0-ae5cb4c7e84c" />
