### PR TITLE
feat: respect CLAUDE_CONFIG_DIR for multi-profile Claude Code setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ Then restart Claude Code and type `/buddy`. That's it.
 <br>
 <sub>💡 Need help? → `bun run help` or `claude-buddy help` (if linked) in terminal · `/buddy help` in Claude Code</sub>
 
+### Multiple Claude profiles?
+
+If you run Claude Code with `CLAUDE_CONFIG_DIR` set (e.g. separate work and personal accounts), pass the same env var to install so buddy lands in the active profile and gets its own menagerie:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.claude-personal bun run install-buddy
+CLAUDE_CONFIG_DIR=~/.claude-personal bun run uninstall
+```
+
+The installer prints `Target profile: <path>` at the top so you can see at a glance which profile you're targeting. Each profile gets its own MCP entry, skill, hooks, status line, and `$CLAUDE_CONFIG_DIR/buddy-state/` menagerie — installs in one profile don't touch another. With `CLAUDE_CONFIG_DIR` unset, behaviour is identical to single-profile (`~/.claude/`, `~/.claude-buddy/`).
+
 <br>
 
 ---

--- a/cli/backup.ts
+++ b/cli/backup.ts
@@ -10,30 +10,37 @@
  *   bun run backup restore <ts>    Restore a specific backup
  *   bun run backup delete <ts>     Delete a specific backup
  *
- * Backups are stored in ~/.claude-buddy/backups/YYYY-MM-DD-HHMMSS/
+ * Backups are stored in <state-dir>/backups/YYYY-MM-DD-HHMMSS/, where
+ * <state-dir> resolves via server/paths.ts ($CLAUDE_CONFIG_DIR/buddy-state
+ * when that env var is set, else ~/.claude-buddy).
  *
  * What gets backed up:
- *   - ~/.claude/settings.json (full file)
- *   - ~/.claude.json mcpServers["claude-buddy"] block (only our entry)
- *   - ~/.claude/skills/buddy/SKILL.md
- *   - ~/.claude-buddy/companion.json
- *   - ~/.claude-buddy/status.json
- *   - ~/.claude-buddy/reaction.json
+ *   - settings.json (full file)
+ *   - .claude.json mcpServers["claude-buddy"] block (only our entry)
+ *   - skills/buddy/SKILL.md
+ *   - <state-dir>/companion.json
+ *   - <state-dir>/status.json
+ *   - <state-dir>/reaction.json
  */
 
 import {
   readFileSync, writeFileSync, mkdirSync, existsSync,
   readdirSync, statSync, rmSync, copyFileSync,
 } from "fs";
-import { join } from "path";
-import { homedir } from "os";
+import { dirname, join } from "path";
+import {
+  buddyStateDir,
+  claudeSettingsPath,
+  claudeSkillDir,
+  claudeUserConfigPath,
+} from "../server/path.ts";
 
-const HOME = homedir();
-const BACKUPS_DIR = join(HOME, ".claude-buddy", "backups");
-const SETTINGS = join(HOME, ".claude", "settings.json");
-const CLAUDE_JSON = join(HOME, ".claude.json");
-const SKILL = join(HOME, ".claude", "skills", "buddy", "SKILL.md");
-const STATE_DIR = join(HOME, ".claude-buddy");
+const SETTINGS = claudeSettingsPath();
+const CLAUDE_JSON = claudeUserConfigPath();
+const SKILL_DIR = claudeSkillDir("buddy");
+const SKILL = join(SKILL_DIR, "SKILL.md");
+const STATE_DIR = buddyStateDir();
+const BACKUPS_DIR = join(STATE_DIR, "backups");
 
 const RED = "\x1b[31m";
 const GREEN = "\x1b[32m";
@@ -80,9 +87,9 @@ function createBackup(): string {
   if (settings) {
     writeFileSync(join(dir, "settings.json"), settings);
     manifest.files.push("settings.json");
-    ok(`Backed up: ~/.claude/settings.json`);
+    ok(`Backed up: ${SETTINGS}`);
   } else {
-    warn(`Skipped: ~/.claude/settings.json (not found)`);
+    warn(`Skipped: ${SETTINGS} (not found)`);
   }
 
   // 2. claude.json mcpServers["claude-buddy"]
@@ -94,12 +101,12 @@ function createBackup(): string {
       if (ourMcp) {
         writeFileSync(join(dir, "mcpserver.json"), JSON.stringify(ourMcp, null, 2));
         manifest.files.push("mcpserver.json");
-        ok(`Backed up: ~/.claude.json → mcpServers["claude-buddy"]`);
+        ok(`Backed up: ${CLAUDE_JSON} → mcpServers["claude-buddy"]`);
       } else {
-        warn(`Skipped: ~/.claude.json mcpServers["claude-buddy"] (not registered)`);
+        warn(`Skipped: ${CLAUDE_JSON} mcpServers["claude-buddy"] (not registered)`);
       }
     } catch {
-      err(`Failed to parse ~/.claude.json`);
+      err(`Failed to parse ${CLAUDE_JSON}`);
     }
   }
 
@@ -108,9 +115,9 @@ function createBackup(): string {
   if (skill) {
     writeFileSync(join(dir, "SKILL.md"), skill);
     manifest.files.push("SKILL.md");
-    ok(`Backed up: ~/.claude/skills/buddy/SKILL.md`);
+    ok(`Backed up: ${SKILL}`);
   } else {
-    warn(`Skipped: ~/.claude/skills/buddy/SKILL.md (not found)`);
+    warn(`Skipped: ${SKILL} (not found)`);
   }
 
   // 4-6. ~/.claude-buddy/ state files (don't back up the backups dir itself)
@@ -122,7 +129,7 @@ function createBackup(): string {
     if (existsSync(src)) {
       copyFileSync(src, join(stateDestDir, f));
       manifest.files.push(`claude-buddy/${f}`);
-      ok(`Backed up: ~/.claude-buddy/${f}`);
+      ok(`Backed up: ${join(STATE_DIR, f)}`);
     }
   }
 
@@ -193,9 +200,9 @@ function restoreBackup(ts: string) {
   // 1. settings.json — overwrite
   const settingsBak = join(dir, "settings.json");
   if (existsSync(settingsBak)) {
-    mkdirSync(join(HOME, ".claude"), { recursive: true });
+    mkdirSync(dirname(SETTINGS), { recursive: true });
     copyFileSync(settingsBak, SETTINGS);
-    ok("Restored: ~/.claude/settings.json");
+    ok(`Restored: ${SETTINGS}`);
   }
 
   // 2. claude.json mcpServers — merge our entry back in
@@ -208,16 +215,19 @@ function restoreBackup(ts: string) {
     } catch { /* empty */ }
     if (!claudeJson.mcpServers) claudeJson.mcpServers = {};
     claudeJson.mcpServers["claude-buddy"] = ourMcp;
+    // Under CLAUDE_CONFIG_DIR the parent dir is not guaranteed to exist
+    // if settings.json wasn't in this backup (and so step 1 was skipped).
+    mkdirSync(dirname(CLAUDE_JSON), { recursive: true });
     writeFileSync(CLAUDE_JSON, JSON.stringify(claudeJson, null, 2));
-    ok("Restored: ~/.claude.json → mcpServers[\"claude-buddy\"]");
+    ok(`Restored: ${CLAUDE_JSON} → mcpServers["claude-buddy"]`);
   }
 
   // 3. SKILL.md
   const skillBak = join(dir, "SKILL.md");
   if (existsSync(skillBak)) {
-    mkdirSync(join(HOME, ".claude", "skills", "buddy"), { recursive: true });
+    mkdirSync(SKILL_DIR, { recursive: true });
     copyFileSync(skillBak, SKILL);
-    ok("Restored: ~/.claude/skills/buddy/SKILL.md");
+    ok(`Restored: ${SKILL}`);
   }
 
   // 4. ~/.claude-buddy/ state files
@@ -226,7 +236,7 @@ function restoreBackup(ts: string) {
     mkdirSync(STATE_DIR, { recursive: true });
     for (const f of readdirSync(stateDir)) {
       copyFileSync(join(stateDir, f), join(STATE_DIR, f));
-      ok(`Restored: ~/.claude-buddy/${f}`);
+      ok(`Restored: ${join(STATE_DIR, f)}`);
     }
   }
 
@@ -317,12 +327,12 @@ ${BOLD}Commands:${NC}
   bun run backup delete <ts>     Delete a specific backup
 
 ${BOLD}What gets backed up:${NC}
-  - ~/.claude/settings.json (full)
-  - ~/.claude.json mcpServers["claude-buddy"] (only our entry)
-  - ~/.claude/skills/buddy/SKILL.md
-  - ~/.claude-buddy/companion.json
-  - ~/.claude-buddy/status.json
-  - ~/.claude-buddy/reaction.json
+  - ${SETTINGS}
+  - ${CLAUDE_JSON} mcpServers["claude-buddy"] (only our entry)
+  - ${SKILL}
+  - ${STATE_DIR}/companion.json
+  - ${STATE_DIR}/status.json
+  - ${STATE_DIR}/reaction.json
 
 ${BOLD}Backup location:${NC}
   ${BACKUPS_DIR}/<timestamp>/

--- a/cli/buddy-shell.ts
+++ b/cli/buddy-shell.ts
@@ -34,8 +34,9 @@ if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") {
 import { execSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+
+import { buddyStateDir } from "../server/path.ts";
 import { getArtFrame, HAT_ART } from "../server/art.ts";
 import type { Species, Eye, Hat } from "../server/engine.ts";
 import { getBiome, listBiomes } from "./biomes.ts";
@@ -95,7 +96,7 @@ const RARITY_CLR: Record<string, string> = {
   epic: MAGENTA, legendary: YELLOW,
 };
 
-const STATE_DIR = join(homedir(), ".claude-buddy");
+const STATE_DIR = buddyStateDir();
 
 // ─── xterm cell → ANSI renderer ─────────────────────────────────────────────
 //

--- a/cli/disable.ts
+++ b/cli/disable.ts
@@ -9,8 +9,11 @@
  */
 
 import { readFileSync, writeFileSync, existsSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
+import {
+  buddyStateDir,
+  claudeSettingsPath,
+  claudeUserConfigPath,
+} from "../server/path.ts";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -21,9 +24,9 @@ const NC = "\x1b[0m";
 function ok(msg: string) { console.log(`${GREEN}✓${NC}  ${msg}`); }
 function warn(msg: string) { console.log(`${YELLOW}⚠${NC}  ${msg}`); }
 
-const HOME = homedir();
-const CLAUDE_JSON = join(HOME, ".claude.json");
-const SETTINGS = join(HOME, ".claude", "settings.json");
+const CLAUDE_JSON = claudeUserConfigPath();
+const SETTINGS = claudeSettingsPath();
+const STATE_DIR = buddyStateDir();
 
 console.log(`\n${BOLD}Disabling claude-buddy...${NC}\n`);
 
@@ -34,12 +37,12 @@ try {
     delete claudeJson.mcpServers["claude-buddy"];
     if (Object.keys(claudeJson.mcpServers).length === 0) delete claudeJson.mcpServers;
     writeFileSync(CLAUDE_JSON, JSON.stringify(claudeJson, null, 2));
-    ok("MCP server removed from ~/.claude.json");
+    ok(`MCP server removed from ${CLAUDE_JSON}`);
   } else {
     warn("MCP server was not registered");
   }
 } catch {
-  warn("Could not update ~/.claude.json");
+  warn(`Could not update ${CLAUDE_JSON}`);
 }
 
 // 2. Remove status line + hooks from settings.json
@@ -86,7 +89,7 @@ try {
 console.log(`
 ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
 ${GREEN}  Buddy disabled.${NC}
-${GREEN}  Companion data is preserved at ~/.claude-buddy/${NC}
+${GREEN}  Companion data is preserved at ${STATE_DIR}${NC}
 ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}
 
 ${DIM}  Restart Claude Code for changes to take effect.

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -11,10 +11,20 @@
 import { readFileSync, existsSync, statSync } from "fs";
 import { execSync } from "child_process";
 import { join, resolve, dirname } from "path";
-import { homedir } from "os";
+import {
+  buddyStateDir,
+  claudeConfigDir,
+  claudeSettingsPath,
+  claudeSkillDir,
+  claudeUserConfigPath,
+} from "../server/path.ts";
 
 const PROJECT_ROOT = resolve(dirname(import.meta.dir));
-const HOME = homedir();
+const CLAUDE_DIR = claudeConfigDir();
+const CLAUDE_JSON = claudeUserConfigPath();
+const STATE_DIR = buddyStateDir();
+const SETTINGS = claudeSettingsPath();
+const SKILL_DIR = claudeSkillDir("buddy");
 const STATUS_SCRIPT = join(PROJECT_ROOT, "statusline", "buddy-status.sh");
 
 const RED = "\x1b[31m";
@@ -91,17 +101,18 @@ row("tput cols", tryExec("tput cols 2>/dev/null", "(failed)"));
 section("Filesystem");
 const procExists = existsSync("/proc");
 row("/proc exists", procExists ? `${GREEN}yes${NC} (Linux)` : `${RED}no${NC} (macOS/BSD)`);
-row("~/.claude/ exists", existsSync(join(HOME, ".claude")) ? "yes" : "no");
-row("~/.claude.json exists", existsSync(join(HOME, ".claude.json")) ? "yes" : "no");
-row("~/.claude-buddy/ exists", existsSync(join(HOME, ".claude-buddy")) ? "yes" : "no");
+row("CLAUDE_CONFIG_DIR", process.env.CLAUDE_CONFIG_DIR ?? "(unset)");
+row(`${CLAUDE_DIR} exists`, existsSync(CLAUDE_DIR) ? "yes" : "no");
+row(`${CLAUDE_JSON} exists`, existsSync(CLAUDE_JSON) ? "yes" : "no");
+row(`${STATE_DIR} exists`, existsSync(STATE_DIR) ? "yes" : "no");
 row("Project root", PROJECT_ROOT);
 row("Status script exists", existsSync(STATUS_SCRIPT) ? "yes" : `${RED}no${NC}`);
 
 // ─── claude-buddy state ─────────────────────────────────────────────────────
 
 section("claude-buddy state");
-const menagerie = tryParseJson(tryRead(join(HOME, ".claude-buddy", "menagerie.json")));
-const status = tryParseJson(tryRead(join(HOME, ".claude-buddy", "status.json")));
+const menagerie = tryParseJson(tryRead(join(STATE_DIR, "menagerie.json")));
+const status = tryParseJson(tryRead(join(STATE_DIR, "status.json")));
 
 if (menagerie) {
   const activeSlot = menagerie.active ?? "buddy";
@@ -119,27 +130,27 @@ if (menagerie) {
     err(`No companion found in active slot "${activeSlot}"`);
   }
 } else {
-  err("No manifest found at ~/.claude-buddy/menagerie.json");
+  err(`No manifest found at ${join(STATE_DIR, "menagerie.json")}`);
 }
 
 if (status) {
   row("Status muted", String(status.muted ?? false));
   row("Current reaction", status.reaction || "(none)");
 } else {
-  warn("No status state at ~/.claude-buddy/status.json");
+  warn(`No status state at ${join(STATE_DIR, "status.json")}`);
 }
 
 // ─── settings.json ──────────────────────────────────────────────────────────
 
 section("Claude Code config");
-const settings = tryParseJson(tryRead(join(HOME, ".claude", "settings.json")));
-const claudeJson = tryParseJson(tryRead(join(HOME, ".claude.json")));
+const settings = tryParseJson(tryRead(SETTINGS));
+const claudeJson = tryParseJson(tryRead(CLAUDE_JSON));
 
 if (settings?.statusLine) {
   console.log(`  ${DIM}statusLine:${NC}`);
   console.log(`    ${JSON.stringify(settings.statusLine, null, 2).split("\n").join("\n    ")}`);
 } else {
-  warn("No statusLine in ~/.claude/settings.json");
+  warn(`No statusLine in ${SETTINGS}`);
 }
 
 if (settings?.hooks) {
@@ -153,13 +164,13 @@ if (settings?.hooks) {
 }
 
 if (claudeJson?.mcpServers?.["claude-buddy"]) {
-  ok("MCP server registered in ~/.claude.json");
+  ok(`MCP server registered in ${CLAUDE_JSON}`);
   console.log(`    ${JSON.stringify(claudeJson.mcpServers["claude-buddy"], null, 2).split("\n").join("\n    ")}`);
 } else {
-  err("MCP server NOT registered in ~/.claude.json");
+  err(`MCP server NOT registered in ${CLAUDE_JSON}`);
 }
 
-const skillPath = join(HOME, ".claude", "skills", "buddy", "SKILL.md");
+const skillPath = join(SKILL_DIR, "SKILL.md");
 if (existsSync(skillPath)) {
   ok(`Skill installed: ${skillPath}`);
 } else {

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -1,17 +1,24 @@
 /**
  * claude-buddy installer
  *
- * Registers: MCP server (in ~/.claude.json), skill, hooks, status line (in settings.json)
- * Checks: bun, jq, ~/.claude/ directory
+ * Registers: MCP server (in Claude's user config), skill, hooks, status line
+ * (in settings.json). All paths resolve via server/paths.ts, so the installer
+ * targets the active Claude profile ($CLAUDE_CONFIG_DIR) or the default
+ * ~/.claude/ layout when the env var is unset.
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, cpSync } from "fs";
 import { execSync } from "child_process";
-import { join, resolve, dirname } from "path";
-import { homedir } from "os";
+import { resolve, dirname, join } from "path";
 
 import { generateBones, renderBuddy, renderFace, RARITY_STARS } from "../server/engine.ts";
-import { toUnixPath } from "../server/path.ts";
+import {
+  claudeConfigDir,
+  claudeSettingsPath,
+  claudeSkillDir,
+  claudeUserConfigPath,
+  toUnixPath,
+} from "../server/path.ts";
 import { loadCompanion, saveCompanion, resolveUserId, writeStatusState } from "../server/state.ts";
 import { generateFallbackName } from "../server/reactions.ts";
 
@@ -23,9 +30,10 @@ const BOLD = "\x1b[1m";
 const DIM = "\x1b[2m";
 const NC = "\x1b[0m";
 
-const CLAUDE_DIR = join(homedir(), ".claude");
-const SETTINGS_FILE = join(CLAUDE_DIR, "settings.json");
-const BUDDY_DIR = join(CLAUDE_DIR, "skills", "buddy");
+const CLAUDE_DIR = claudeConfigDir();
+const SETTINGS_FILE = claudeSettingsPath();
+const BUDDY_DIR = claudeSkillDir("buddy");
+const CLAUDE_JSON_PATH = claudeUserConfigPath();
 const PROJECT_ROOT = resolve(dirname(import.meta.dir));
 
 function banner() {
@@ -71,21 +79,20 @@ function preflight(): boolean {
     }
   }
 
-  // Check ~/.claude/ exists
+  // Check Claude config dir exists
   if (!existsSync(CLAUDE_DIR)) {
-    err("~/.claude/ not found. Start Claude Code once first, then re-run.");
+    err(`${CLAUDE_DIR} not found. Start Claude Code once first, then re-run.`);
     pass = false;
   } else {
-    ok("~/.claude/ found");
+    ok(`${CLAUDE_DIR} found`);
   }
 
-  // Check ~/.claude.json exists
-  const claudeJson = join(homedir(), ".claude.json");
-  if (!existsSync(claudeJson)) {
-    err("~/.claude.json not found. Start Claude Code once first, then re-run.");
+  // Check Claude user config (.claude.json) exists
+  if (!existsSync(CLAUDE_JSON_PATH)) {
+    err(`${CLAUDE_JSON_PATH} not found. Start Claude Code once first, then re-run.`);
     pass = false;
   } else {
-    ok("~/.claude.json found");
+    ok(`${CLAUDE_JSON_PATH} found`);
   }
 
   return pass;
@@ -110,11 +117,10 @@ function saveSettings(settings: Record<string, any>) {
 
 function installMcp() {
   const serverPath = join(PROJECT_ROOT, "server", "index.ts");
-  const claudeJsonPath = join(homedir(), ".claude.json");
 
   let claudeJson: Record<string, any> = {};
   try {
-    claudeJson = JSON.parse(readFileSync(claudeJsonPath, "utf8"));
+    claudeJson = JSON.parse(readFileSync(CLAUDE_JSON_PATH, "utf8"));
   } catch { /* fresh config */ }
 
   if (!claudeJson.mcpServers) claudeJson.mcpServers = {};
@@ -125,8 +131,8 @@ function installMcp() {
     cwd: toUnixPath(PROJECT_ROOT),
   };
 
-  writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
-  ok("MCP server registered in ~/.claude.json");
+  writeFileSync(CLAUDE_JSON_PATH, JSON.stringify(claudeJson, null, 2));
+  ok(`MCP server registered in ${CLAUDE_JSON_PATH}`);
 }
 
 // ─── Step 2: Install skill ──────────────────────────────────────────────────
@@ -135,7 +141,7 @@ function installSkill() {
   const srcSkill = join(PROJECT_ROOT, "skills", "buddy", "SKILL.md");
   mkdirSync(BUDDY_DIR, { recursive: true });
   cpSync(srcSkill, join(BUDDY_DIR, "SKILL.md"), { force: true });
-  ok("Skill installed: ~/.claude/skills/buddy/SKILL.md");
+  ok(`Skill installed: ${join(BUDDY_DIR, "SKILL.md")}`);
 }
 
 // ─── Step 3: Configure status line (with animation refresh) ─────────────────
@@ -258,6 +264,11 @@ function initCompanion() {
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 banner();
+
+const profileSource = process.env.CLAUDE_CONFIG_DIR
+  ? "from CLAUDE_CONFIG_DIR"
+  : "CLAUDE_CONFIG_DIR unset — single-profile default";
+info(`Target profile: ${CLAUDE_DIR}  ${DIM}(${profileSource})${NC}\n`);
 
 info("Checking requirements...\n");
 if (!preflight()) {

--- a/cli/test-statusline.ts
+++ b/cli/test-statusline.ts
@@ -8,17 +8,18 @@
  * The test status line outputs multiple padding strategies side-by-side
  * so you can see in actual Claude Code which one renders correctly.
  *
- * Your original statusLine config is backed up to ~/.claude-buddy/statusline.bak
+ * Your original statusLine config is backed up to <state-dir>/statusline.bak
+ * (state dir resolves via server/paths.ts).
  */
 
 import { readFileSync, writeFileSync, existsSync, copyFileSync, chmodSync, mkdirSync } from "fs";
 import { join, dirname, resolve } from "path";
-import { homedir } from "os";
+import { buddyStateDir, claudeSettingsPath } from "../server/path.ts";
 
-const HOME = homedir();
-const SETTINGS = join(HOME, ".claude", "settings.json");
-const BACKUP = join(HOME, ".claude-buddy", "statusline.bak");
-const TEST_SCRIPT = join(HOME, ".claude-buddy", "test-statusline.sh");
+const SETTINGS = claudeSettingsPath();
+const STATE_DIR = buddyStateDir();
+const BACKUP = join(STATE_DIR, "statusline.bak");
+const TEST_SCRIPT = join(STATE_DIR, "test-statusline.sh");
 const SOURCE_SCRIPT = resolve(import.meta.dir, "test-statusline.sh");
 
 const RED = "\x1b[31m";
@@ -41,7 +42,7 @@ if (action === "install") {
   console.log(`\n${BOLD}claude-buddy test status line installer${NC}\n`);
 
   if (!existsSync(SETTINGS)) {
-    err("~/.claude/settings.json not found");
+    err(`${SETTINGS} not found`);
     process.exit(1);
   }
   if (!existsSync(SOURCE_SCRIPT)) {

--- a/cli/tui.tsx
+++ b/cli/tui.tsx
@@ -17,7 +17,13 @@ import {
 } from "node:fs";
 import { execSync } from "node:child_process";
 import { join, resolve, dirname } from "node:path";
-import { homedir } from "node:os";
+import {
+  buddyStateDir,
+  claudeConfigDir,
+  claudeSettingsPath,
+  claudeSkillDir,
+  claudeUserConfigPath,
+} from "../server/path.ts";
 import {
   listCompanionSlots, loadActiveSlot, saveActiveSlot,
   loadConfig, saveConfig, writeStatusState, loadReaction,
@@ -48,7 +54,11 @@ const RARITY_COLOR: Record<string, string> = {
 };
 
 
-const HOME = homedir();
+const CLAUDE_DIR = claudeConfigDir();
+const CLAUDE_JSON = claudeUserConfigPath();
+const STATE_DIR = buddyStateDir();
+const SETTINGS_PATH = claudeSettingsPath();
+const SKILL_PATH = join(claudeSkillDir("buddy"), "SKILL.md");
 const PROJECT_ROOT = resolve(dirname(import.meta.dir));
 
 // ─── Sidebar ────────────────────────────────────────────────────────────────
@@ -133,7 +143,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
       "skill, menagerie, status, and config.",
       "",
       "Restore is currently manual (copy from",
-      "~/.claude-buddy/backups/<ts>/ folders).",
+      `${STATE_DIR}/backups/<ts>/ folders).`,
     ],
   },
   {
@@ -441,9 +451,9 @@ function runDiagnostics(): DiagCategory[] {
   // Filesystem
   const fs: DiagCheck[] = [];
   const dirs: [string, string][] = [
-    ["~/.claude/", join(HOME, ".claude")],
-    ["~/.claude.json", join(HOME, ".claude.json")],
-    ["~/.claude-buddy/", join(HOME, ".claude-buddy")],
+    [CLAUDE_DIR, CLAUDE_DIR],
+    [CLAUDE_JSON, CLAUDE_JSON],
+    [STATE_DIR, STATE_DIR],
     ["Status script", join(PROJECT_ROOT, "statusline", "buddy-status.sh")],
   ];
   for (const [label, path] of dirs) {
@@ -455,28 +465,28 @@ function runDiagnostics(): DiagCategory[] {
   // MCP & Hooks
   const mcp: DiagCheck[] = [];
   try {
-    const claudeJson = JSON.parse(readFileSync(join(HOME, ".claude.json"), "utf8"));
+    const claudeJson = JSON.parse(readFileSync(CLAUDE_JSON, "utf8"));
     const registered = !!claudeJson?.mcpServers?.["claude-buddy"];
     mcp.push({ label: "MCP server", value: registered ? "registered" : "NOT registered", status: registered ? "ok" : "err" });
   } catch {
     mcp.push({ label: "MCP server", value: "cannot read config", status: "err" });
   }
   try {
-    const settings = JSON.parse(readFileSync(join(HOME, ".claude", "settings.json"), "utf8"));
+    const settings = JSON.parse(readFileSync(SETTINGS_PATH, "utf8"));
     const hookCount = Object.keys(settings.hooks ?? {}).reduce((n: number, k: string) => n + (settings.hooks[k]?.length ?? 0), 0);
     mcp.push({ label: "Hooks", value: `${hookCount} entries`, status: hookCount > 0 ? "ok" : "warn" });
     mcp.push({ label: "Status line", value: settings.statusLine ? "configured" : "not set", status: settings.statusLine ? "ok" : "warn" });
   } catch {
     mcp.push({ label: "Settings", value: "cannot read", status: "err" });
   }
-  const skillPath = join(HOME, ".claude", "skills", "buddy", "SKILL.md");
+  const skillPath = SKILL_PATH;
   mcp.push({ label: "Skill", value: existsSync(skillPath) ? "installed" : "MISSING", status: existsSync(skillPath) ? "ok" : "err" });
   categories.push({ name: "Integration", icon: "🔌", checks: mcp });
 
   // Buddy state
   const state: DiagCheck[] = [];
   try {
-    const menagerie = JSON.parse(readFileSync(join(HOME, ".claude-buddy", "menagerie.json"), "utf8"));
+    const menagerie = JSON.parse(readFileSync(join(STATE_DIR, "menagerie.json"), "utf8"));
     const slots = Object.keys(menagerie.companions ?? {});
     state.push({ label: "Menagerie", value: `${slots.length} buddy(s)`, status: slots.length > 0 ? "ok" : "warn" });
     state.push({ label: "Active slot", value: menagerie.active ?? "(none)", status: menagerie.active ? "ok" : "warn" });
@@ -487,7 +497,7 @@ function runDiagnostics(): DiagCategory[] {
   } catch {
     state.push({ label: "Menagerie", value: "not found", status: "warn" });
   }
-  const statusJson = join(HOME, ".claude-buddy", "status.json");
+  const statusJson = join(STATE_DIR, "status.json");
   if (existsSync(statusJson)) {
     try {
       const s = JSON.parse(readFileSync(statusJson, "utf8"));
@@ -557,7 +567,7 @@ function DoctorDetailPane({ category }: { category: DiagCategory }) {
 
 // ─── Backup: data ───────────────────────────────────────────────────────────
 
-const BACKUPS_DIR = join(HOME, ".claude-buddy", "backups");
+const BACKUPS_DIR = join(STATE_DIR, "backups");
 
 interface BackupEntry { ts: string; fileCount: number }
 
@@ -588,10 +598,10 @@ function createBackup(): string {
   const manifest: { timestamp: string; files: string[] } = { timestamp: ts, files: [] };
   const tryRead = (p: string) => { try { return readFileSync(p, "utf8"); } catch { return null; } };
 
-  const settingsPath = join(HOME, ".claude", "settings.json");
+  const settingsPath = SETTINGS_PATH;
   if (existsSync(settingsPath)) { writeFileSync(join(dir, "settings.json"), readFileSync(settingsPath)); manifest.files.push("settings.json"); }
 
-  const claudeJsonRaw = tryRead(join(HOME, ".claude.json"));
+  const claudeJsonRaw = tryRead(CLAUDE_JSON);
   if (claudeJsonRaw) {
     try {
       const mcp = JSON.parse(claudeJsonRaw).mcpServers?.["claude-buddy"];
@@ -599,13 +609,13 @@ function createBackup(): string {
     } catch {}
   }
 
-  const skillPath = join(HOME, ".claude", "skills", "buddy", "SKILL.md");
+  const skillPath = SKILL_PATH;
   if (existsSync(skillPath)) { copyFileSync(skillPath, join(dir, "SKILL.md")); manifest.files.push("SKILL.md"); }
 
   const stateDir = join(dir, "claude-buddy");
   mkdirSync(stateDir, { recursive: true });
   for (const f of ["menagerie.json", "status.json", "config.json"]) {
-    const src = join(HOME, ".claude-buddy", f);
+    const src = join(STATE_DIR, f);
     if (existsSync(src)) { copyFileSync(src, join(stateDir, f)); manifest.files.push(`claude-buddy/${f}`); }
   }
 
@@ -793,7 +803,7 @@ function runUninstall(keepState: boolean): InstallResult {
   }
   if (!keepState) {
     try {
-      const stateDir = join(HOME, ".claude-buddy");
+      const stateDir = STATE_DIR;
       if (existsSync(stateDir)) {
         rmSync(stateDir, { recursive: true, force: true });
         ok.push("State directory deleted");
@@ -802,7 +812,7 @@ function runUninstall(keepState: boolean): InstallResult {
       warn.push(`state cleanup: ${e?.message ?? "failed"}`);
     }
   } else {
-    ok.push("State preserved at ~/.claude-buddy/");
+    ok.push(`State preserved at ${STATE_DIR}`);
   }
   return { ok, warn };
 }
@@ -850,7 +860,7 @@ function EnableDetailPane({ result, running }: {
       <Text bold color="green">🔄 Re-Enable claude-buddy</Text>
       <Text>{""}</Text>
       <Text dimColor>This will register:</Text>
-      <Text>{"  "}• MCP server in ~/.claude.json</Text>
+      <Text>{"  "}• MCP server in {CLAUDE_JSON}</Text>
       <Text>{"  "}• Hooks in settings.json</Text>
       <Text>{"  "}• Status line</Text>
       <Text>{"  "}• Skill files</Text>
@@ -909,7 +919,7 @@ function UninstallDetailPane({ stage, typed, result, keepState }: {
       <Text>{"  "}• MCP server registration</Text>
       <Text>{"  "}• Hooks & status line</Text>
       <Text>{"  "}• Skill files</Text>
-      <Text>{"  "}• Optional: ~/.claude-buddy/ (all buddies + backups!)</Text>
+      <Text>{"  "}• Optional: {STATE_DIR} (all buddies + backups!)</Text>
       <Text>{""}</Text>
       <Text dimColor>An auto-backup will be created before uninstall.</Text>
       <Text>{""}</Text>
@@ -936,7 +946,7 @@ function DisableConfirmPane({ result, confirming }: {
         {result.warn.map((m, i) => <Text key={i} color="yellow">{" ⚠ "}{m}</Text>)}
         <Text>{""}</Text>
         <Text dimColor>Companion data preserved at</Text>
-        <Text dimColor>~/.claude-buddy/</Text>
+        <Text dimColor>{STATE_DIR}</Text>
         <Text>{""}</Text>
         <Text dimColor>Restart Claude Code to apply.</Text>
         <Text dimColor>Re-enable: bun run install-buddy</Text>
@@ -949,7 +959,7 @@ function DisableConfirmPane({ result, confirming }: {
       <Text bold color="red">☠ Disable claude-buddy</Text>
       <Text>{""}</Text>
       <Text dimColor>This will remove:</Text>
-      <Text>{"  "}• MCP server from ~/.claude.json</Text>
+      <Text>{"  "}• MCP server from {CLAUDE_JSON}</Text>
       <Text>{"  "}• Hooks from settings.json</Text>
       <Text>{"  "}• Status line configuration</Text>
       <Text>{""}</Text>
@@ -971,8 +981,8 @@ function DisableConfirmPane({ result, confirming }: {
 
 // ─── Disable helpers ────────────────────────────────────────────────────────
 
-const CLAUDE_JSON_PATH = join(HOME, ".claude.json");
-const CLAUDE_SETTINGS_PATH = join(HOME, ".claude", "settings.json");
+const CLAUDE_JSON_PATH = CLAUDE_JSON;
+const CLAUDE_SETTINGS_PATH = SETTINGS_PATH;
 
 interface DisableResult { ok: string[]; warn: string[] }
 
@@ -991,7 +1001,7 @@ function disableBuddy(): DisableResult {
       warn.push("MCP was not registered");
     }
   } catch {
-    warn.push("Could not update ~/.claude.json");
+    warn.push(`Could not update ${CLAUDE_JSON}`);
   }
 
   try {

--- a/cli/uninstall.ts
+++ b/cli/uninstall.ts
@@ -4,7 +4,12 @@
 
 import { readFileSync, writeFileSync, existsSync, rmSync, readdirSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import {
+  buddyStateDir,
+  claudeSettingsPath,
+  claudeSkillDir,
+  claudeUserConfigPath,
+} from "../server/path.ts";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -13,10 +18,10 @@ const NC = "\x1b[0m";
 function ok(msg: string) { console.log(`${GREEN}✓${NC}  ${msg}`); }
 function warn(msg: string) { console.log(`${YELLOW}⚠${NC}  ${msg}`); }
 
-const CLAUDE_DIR = join(homedir(), ".claude");
-const SETTINGS_FILE = join(CLAUDE_DIR, "settings.json");
-const SKILL_DIR = join(CLAUDE_DIR, "skills", "buddy");
-const STATE_DIR = join(homedir(), ".claude-buddy");
+const SETTINGS_FILE = claudeSettingsPath();
+const SKILL_DIR = claudeSkillDir("buddy");
+const STATE_DIR = buddyStateDir();
+const CLAUDE_JSON_PATH = claudeUserConfigPath();
 
 console.log("\nclaude-buddy uninstall\n");
 
@@ -47,18 +52,17 @@ try {
   ok("Popup stopped");
 } catch { /* not in tmux or no popup */ }
 
-// Remove MCP server from ~/.claude.json
+// Remove MCP server from Claude's user config
 try {
-  const claudeJsonPath = join(homedir(), ".claude.json");
-  const claudeJson = JSON.parse(readFileSync(claudeJsonPath, "utf8"));
+  const claudeJson = JSON.parse(readFileSync(CLAUDE_JSON_PATH, "utf8"));
   if (claudeJson.mcpServers?.["claude-buddy"]) {
     delete claudeJson.mcpServers["claude-buddy"];
     if (Object.keys(claudeJson.mcpServers).length === 0) delete claudeJson.mcpServers;
-    writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
-    ok("MCP server removed from ~/.claude.json");
+    writeFileSync(CLAUDE_JSON_PATH, JSON.stringify(claudeJson, null, 2));
+    ok(`MCP server removed from ${CLAUDE_JSON_PATH}`);
   }
 } catch {
-  warn("Could not update ~/.claude.json");
+  warn(`Could not update ${CLAUDE_JSON_PATH}`);
 }
 
 // Remove hooks and statusline from settings.json
@@ -102,7 +106,9 @@ if (existsSync(SKILL_DIR)) {
   warn("Skill not found (already removed)");
 }
 
-// Keep state dir (companion data) — user might want it back
+// Keep state dir (companion data) — user might want it back.
+// This is profile-scoped when CLAUDE_CONFIG_DIR is set, so other
+// profiles' buddies are unaffected.
 if (existsSync(STATE_DIR)) {
   warn(`Companion data kept at ${STATE_DIR} — delete manually if not needed`);
 }

--- a/hooks/buddy-comment.sh
+++ b/hooks/buddy-comment.sh
@@ -5,7 +5,10 @@
 # This hook extracts it and updates the status line bubble.
 # The HTML comment is invisible in rendered markdown output.
 
-STATE_DIR="$HOME/.claude-buddy"
+# shellcheck source=../scripts/paths.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../scripts/paths.sh"
+
+STATE_DIR="$BUDDY_STATE_DIR"
 # Session ID: sanitized tmux pane number, or "default" outside tmux
 SID="${TMUX_PANE#%}"
 SID="${SID:-default}"

--- a/hooks/name-react.sh
+++ b/hooks/name-react.sh
@@ -3,7 +3,10 @@
 # Detects the buddy's name in the user's message → status line reaction.
 # No cooldown — name mentions are intentional.
 
-STATE_DIR="$HOME/.claude-buddy"
+# shellcheck source=../scripts/paths.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../scripts/paths.sh"
+
+STATE_DIR="$BUDDY_STATE_DIR"
 STATUS_FILE="$STATE_DIR/status.json"
 # Session ID: sanitized tmux pane number, or "default" outside tmux
 SID="${TMUX_PANE#%}"

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -4,7 +4,10 @@
 #
 # Combined: PR #4 species reactions + PR #6 session isolation + PR #13 field fix
 
-STATE_DIR="$HOME/.claude-buddy"
+# shellcheck source=../scripts/paths.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../scripts/paths.sh"
+
+STATE_DIR="$BUDDY_STATE_DIR"
 # Session ID: sanitized tmux pane number, or "default" outside tmux
 SID="${TMUX_PANE#%}"
 SID="${SID:-default}"

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Path resolvers for claude-buddy shell scripts.
+#
+# Must stay in sync with server/path.ts. Source this file early:
+#   source "$(dirname "$0")/../scripts/paths.sh"
+# …and consumers get BUDDY_STATE_DIR, CLAUDE_CFG_DIR, CLAUDE_SETTINGS_FILE,
+# and CLAUDE_USER_CONFIG.
+#
+# Resolution rules (must match server/path.ts):
+#   - If CLAUDE_CONFIG_DIR is set → everything lives under it
+#     (settings.json, skills/, .claude.json inside the config dir, and
+#      buddy state at $CLAUDE_CONFIG_DIR/buddy-state).
+#   - Else (single-profile default) → $HOME/.claude, $HOME/.claude.json,
+#     $HOME/.claude-buddy.
+
+if [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
+  CLAUDE_CFG_DIR="$CLAUDE_CONFIG_DIR"
+else
+  CLAUDE_CFG_DIR="$HOME/.claude"
+fi
+
+CLAUDE_SETTINGS_FILE="$CLAUDE_CFG_DIR/settings.json"
+
+# .claude.json: inside CLAUDE_CONFIG_DIR when set, else $HOME. We never
+# fall back to $HOME when CLAUDE_CONFIG_DIR is set — doing so would break
+# profile isolation (enabling buddy in one profile could mutate the
+# home-level file that a different profile reads).
+if [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
+  CLAUDE_USER_CONFIG="$CLAUDE_CONFIG_DIR/.claude.json"
+else
+  CLAUDE_USER_CONFIG="$HOME/.claude.json"
+fi
+
+if [[ -n "${CLAUDE_CONFIG_DIR:-}" ]]; then
+  BUDDY_STATE_DIR="$CLAUDE_CONFIG_DIR/buddy-state"
+else
+  BUDDY_STATE_DIR="$HOME/.claude-buddy"
+fi
+
+export CLAUDE_CFG_DIR CLAUDE_SETTINGS_FILE CLAUDE_USER_CONFIG BUDDY_STATE_DIR

--- a/server/achievements.ts
+++ b/server/achievements.ts
@@ -11,9 +11,9 @@
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { buddyStateDir } from "./path.ts";
 
-const STATE_DIR = join(homedir(), ".claude-buddy");
+const STATE_DIR = buddyStateDir();
 const EVENTS_FILE = join(STATE_DIR, "events.json");
 const DAYS_FILE = join(STATE_DIR, "active_days.json");
 const UNLOCKED_FILE = join(STATE_DIR, "unlocked.json");

--- a/server/index.ts
+++ b/server/index.ts
@@ -45,6 +45,11 @@ import {
   cleanupPluginState,
 } from "./state.ts";
 import {
+  buddyStateDir,
+  claudeConfigDir,
+  claudeSettingsPath,
+} from "./path.ts";
+import {
   getReaction, generatePersonalityPrompt,
 } from "./reactions.ts";
 import { renderCompanionCardMarkdown } from "./art.ts";
@@ -493,7 +498,7 @@ server.tool(
             type: "text",
             text:
               "Status line enabled! Restart Claude Code to see your buddy in the status line.\n\n" +
-              "Note: this writes an entry to ~/.claude/settings.json that `claude plugin uninstall` does not remove. " +
+              `Note: this writes an entry to ${claudeSettingsPath()} that \`claude plugin uninstall\` does not remove. ` +
               "Run `/buddy uninstall` before uninstalling the plugin to clean it up.",
           },
         ],
@@ -516,17 +521,21 @@ server.tool(
 
 server.tool(
   "buddy_uninstall",
-  "Clean up claude-buddy's writes to ~/.claude/settings.json and transient session files in ~/.claude-buddy/, in preparation for `claude plugin uninstall`. Companion data (menagerie, status, config) is intentionally preserved so reinstalling restores the buddy. The tool only cleans the plugin's own settings — it never removes a foreign statusLine.",
+  "Clean up claude-buddy's writes to Claude Code's settings.json and transient session files in the buddy state dir (resolved via CLAUDE_CONFIG_DIR), in preparation for `claude plugin uninstall`. Companion data (menagerie, status, config) is intentionally preserved so reinstalling restores the buddy. The tool only cleans the plugin's own settings — it never removes a foreign statusLine.",
   {},
   async () => {
     const result = cleanupPluginState();
+
+    const settingsPath = claudeSettingsPath();
+    const stateDir = buddyStateDir();
+    const pluginsCacheDir = join(claudeConfigDir(), "plugins", "cache", "claude-buddy");
 
     const lines: string[] = [];
     lines.push("claude-buddy: settings.json cleanup complete.");
     lines.push("");
     lines.push(
       result.statusLineRemoved
-        ? "  \u2713 statusLine entry removed from ~/.claude/settings.json"
+        ? `  \u2713 statusLine entry removed from ${settingsPath}`
         : "  \u2014 no buddy statusLine was present (nothing to remove)",
     );
     if (result.foreignStatusLineKept) {
@@ -535,15 +544,15 @@ server.tool(
       );
     }
     lines.push(
-      `  \u2713 ${result.transientFilesRemoved} transient session file(s) removed from ~/.claude-buddy/`,
+      `  \u2713 ${result.transientFilesRemoved} transient session file(s) removed from ${stateDir}`,
     );
-    lines.push("  \u2014 companion data at ~/.claude-buddy/ preserved");
+    lines.push(`  \u2014 companion data at ${stateDir} preserved`);
     lines.push("");
     lines.push("Now run these commands via the Bash tool, in order:");
     lines.push("");
     lines.push("  claude plugin uninstall claude-buddy@claude-buddy");
     lines.push("  claude plugin marketplace remove claude-buddy");
-    lines.push("  rm -rf ~/.claude/plugins/cache/claude-buddy");
+    lines.push(`  rm -rf ${pluginsCacheDir}`);
     lines.push("");
     lines.push(
       "After those three commands the plugin is fully removed. Restart Claude Code to apply.",

--- a/server/path.test.ts
+++ b/server/path.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for server/paths.ts. The resolvers read process.env on each
+ * call, so we stub CLAUDE_CONFIG_DIR per test and restore it afterwards.
+ * Anything that compares against homedir() assumes the tests run on a
+ * system where $HOME is set — true on Linux/macOS CI. If that invariant
+ * ever breaks, drop the HOME-dependent cases and assert only the
+ * env-var branches.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { homedir } from "os";
+import { join } from "path";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+
+import {
+  buddyStateDir,
+  claudeConfigDir,
+  claudeSettingsPath,
+  claudeSkillDir,
+  claudeUserConfigPath,
+} from "./path.ts";
+
+const origConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+function restoreEnv() {
+  if (origConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = origConfigDir;
+}
+
+describe("claudeConfigDir", () => {
+  afterEach(restoreEnv);
+
+  test("returns $HOME/.claude when CLAUDE_CONFIG_DIR is unset", () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    expect(claudeConfigDir()).toBe(join(homedir(), ".claude"));
+  });
+
+  test("returns CLAUDE_CONFIG_DIR when set", () => {
+    process.env.CLAUDE_CONFIG_DIR = "/tmp/fake-profile";
+    expect(claudeConfigDir()).toBe("/tmp/fake-profile");
+  });
+
+  test("treats empty CLAUDE_CONFIG_DIR as unset", () => {
+    process.env.CLAUDE_CONFIG_DIR = "";
+    expect(claudeConfigDir()).toBe(join(homedir(), ".claude"));
+  });
+});
+
+describe("claudeSettingsPath / claudeSkillDir", () => {
+  afterEach(restoreEnv);
+
+  test("puts settings.json inside the active config dir", () => {
+    process.env.CLAUDE_CONFIG_DIR = "/tmp/profile-a";
+    expect(claudeSettingsPath()).toBe("/tmp/profile-a/settings.json");
+    expect(claudeSkillDir("buddy")).toBe("/tmp/profile-a/skills/buddy");
+  });
+
+  test("falls back to ~/.claude when CLAUDE_CONFIG_DIR is unset", () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    expect(claudeSettingsPath()).toBe(join(homedir(), ".claude", "settings.json"));
+    expect(claudeSkillDir("buddy")).toBe(join(homedir(), ".claude", "skills", "buddy"));
+  });
+});
+
+describe("claudeUserConfigPath", () => {
+  let profileDir: string;
+
+  beforeEach(() => {
+    profileDir = mkdtempSync(join(tmpdir(), "claude-buddy-paths-"));
+  });
+
+  afterEach(() => {
+    rmSync(profileDir, { recursive: true, force: true });
+    restoreEnv();
+  });
+
+  test("prefers $CLAUDE_CONFIG_DIR/.claude.json when it exists", () => {
+    process.env.CLAUDE_CONFIG_DIR = profileDir;
+    const inDir = join(profileDir, ".claude.json");
+    writeFileSync(inDir, "{}");
+    expect(claudeUserConfigPath()).toBe(inDir);
+  });
+
+  test("points at the profile even when only $HOME/.claude.json exists (no cross-profile leak)", () => {
+    process.env.CLAUDE_CONFIG_DIR = profileDir; // empty, no in-dir .claude.json
+    // $HOME/.claude.json probably exists on the test runner. The
+    // resolver MUST NOT fall back to it — that would let one profile
+    // mutate the home-level file a different profile reads.
+    expect(claudeUserConfigPath()).toBe(join(profileDir, ".claude.json"));
+  });
+
+  test("returns $HOME/.claude.json when CLAUDE_CONFIG_DIR is unset", () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    expect(claudeUserConfigPath()).toBe(join(homedir(), ".claude.json"));
+  });
+});
+
+describe("buddyStateDir", () => {
+  afterEach(restoreEnv);
+
+  test("CLAUDE_CONFIG_DIR puts state inside the profile dir", () => {
+    process.env.CLAUDE_CONFIG_DIR = "/tmp/profile";
+    expect(buddyStateDir()).toBe("/tmp/profile/buddy-state");
+  });
+
+  test("default is ~/.claude-buddy when CLAUDE_CONFIG_DIR is unset", () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    expect(buddyStateDir()).toBe(join(homedir(), ".claude-buddy"));
+  });
+});

--- a/server/path.ts
+++ b/server/path.ts
@@ -1,6 +1,19 @@
 // Path utilities and helpers
+//
+// Two related concerns live here:
+//   1. Path normalization (Windows compat) — toUnixPath().
+//   2. Resolution of Claude Code config / state paths — claudeConfigDir,
+//      claudeSettingsPath, claudeSkillDir, claudeUserConfigPath, buddyStateDir.
+//      These honor CLAUDE_CONFIG_DIR so claude-buddy works with Claude Code's
+//      multi-account layout (one CLAUDE_CONFIG_DIR per profile).
+//
+// The shell counterpart of (2) lives in scripts/paths.sh and MUST stay in sync.
 
-// Path normalization (Windows compat)
+import { join } from "path";
+import { homedir } from "os";
+
+// ─── (1) Path normalization ─────────────────────────────────────────────────
+
 // Node's path.join() produces backslash paths on Windows, which bash treats as
 // escape sequences, stripping them entirely (e.g. C:\Users -> C:Users).
 // Use forward slashes in all paths written to config files.
@@ -13,4 +26,57 @@
  */
 export function toUnixPath(p: string): string {
   return p.replace(/\\/g, "/");
+}
+
+// ─── (2) Claude config / state path resolvers ───────────────────────────────
+//
+// Resolution rules:
+//   - If CLAUDE_CONFIG_DIR is set: everything lives under
+//     $CLAUDE_CONFIG_DIR/. .claude.json is preferred inside the config dir
+//     when present, falling back to $HOME/.claude.json for setups that
+//     keep it at $HOME. Buddy state goes to $CLAUDE_CONFIG_DIR/buddy-state.
+//   - If CLAUDE_CONFIG_DIR is NOT set: the single-profile defaults —
+//     ~/.claude/, ~/.claude.json, ~/.claude-buddy/.
+
+function envDir(name: string): string | undefined {
+  const v = process.env[name];
+  return v && v.length > 0 ? v : undefined;
+}
+
+export function claudeConfigDir(): string {
+  return envDir("CLAUDE_CONFIG_DIR") ?? join(homedir(), ".claude");
+}
+
+export function claudeSettingsPath(): string {
+  return join(claudeConfigDir(), "settings.json");
+}
+
+export function claudeSkillDir(name: string): string {
+  return join(claudeConfigDir(), "skills", name);
+}
+
+/**
+ * Resolve the path to Claude Code's user-config file (.claude.json).
+ *
+ * When CLAUDE_CONFIG_DIR is set the file lives inside it — we always
+ * resolve there so every read and write stays profile-scoped. Falling
+ * back to $HOME/.claude.json when the in-dir file is missing would
+ * break that isolation: installs in one profile could mutate the
+ * home-level file that a different profile reads. If the in-dir file
+ * doesn't exist yet, callers surface a clear "Start Claude Code once
+ * first" preflight error instead of silently writing to $HOME.
+ *
+ * When CLAUDE_CONFIG_DIR is unset we use $HOME/.claude.json — the
+ * single-profile default.
+ */
+export function claudeUserConfigPath(): string {
+  const cfgDir = envDir("CLAUDE_CONFIG_DIR");
+  if (cfgDir) return join(cfgDir, ".claude.json");
+  return join(homedir(), ".claude.json");
+}
+
+export function buddyStateDir(): string {
+  const cfgDir = envDir("CLAUDE_CONFIG_DIR");
+  if (cfgDir) return join(cfgDir, "buddy-state");
+  return join(homedir(), ".claude-buddy");
 }

--- a/server/paths_sh.test.ts
+++ b/server/paths_sh.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Smoke tests for scripts/paths.sh — asserts that the shell resolver
+ * produces the same answers as server/paths.ts for each env-var
+ * combination. Keeps the two in lockstep; when one is updated the
+ * other must follow, and these tests catch the drift.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join, resolve } from "path";
+
+const PATHS_SH = resolve(import.meta.dir, "..", "scripts", "paths.sh");
+
+type Env = Record<string, string | null>;
+
+/** Run `source paths.sh` in bash under the given env overrides and
+ *  capture the resolved variables. `null` means "unset this var". */
+function sourcePaths(overrides: Env): Record<string, string> {
+  const env: Record<string, string> = {};
+  // Preserve essentials so bash can start and find binaries.
+  for (const k of ["HOME", "PATH", "USER"]) {
+    if (process.env[k]) env[k] = process.env[k]!;
+  }
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v !== null) env[k] = v;
+  }
+
+  const script = `source "${PATHS_SH}"
+printf 'CLAUDE_CFG_DIR=%s\\n' "$CLAUDE_CFG_DIR"
+printf 'CLAUDE_SETTINGS_FILE=%s\\n' "$CLAUDE_SETTINGS_FILE"
+printf 'CLAUDE_USER_CONFIG=%s\\n' "$CLAUDE_USER_CONFIG"
+printf 'BUDDY_STATE_DIR=%s\\n' "$BUDDY_STATE_DIR"`;
+
+  const result = spawnSync("bash", ["-c", script], { env, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`bash exited ${result.status}: ${result.stderr}`);
+  }
+  const parsed: Record<string, string> = {};
+  for (const line of result.stdout.split("\n").filter(Boolean)) {
+    const idx = line.indexOf("=");
+    parsed[line.slice(0, idx)] = line.slice(idx + 1);
+  }
+  return parsed;
+}
+
+describe("scripts/paths.sh (CLAUDE_CONFIG_DIR unset)", () => {
+  const env = sourcePaths({ CLAUDE_CONFIG_DIR: null });
+
+  test("CLAUDE_CFG_DIR defaults to $HOME/.claude", () => {
+    expect(env.CLAUDE_CFG_DIR).toBe(join(homedir(), ".claude"));
+  });
+
+  test("CLAUDE_SETTINGS_FILE points under the config dir", () => {
+    expect(env.CLAUDE_SETTINGS_FILE).toBe(join(homedir(), ".claude", "settings.json"));
+  });
+
+  test("CLAUDE_USER_CONFIG is $HOME/.claude.json", () => {
+    expect(env.CLAUDE_USER_CONFIG).toBe(join(homedir(), ".claude.json"));
+  });
+
+  test("BUDDY_STATE_DIR defaults to $HOME/.claude-buddy", () => {
+    expect(env.BUDDY_STATE_DIR).toBe(join(homedir(), ".claude-buddy"));
+  });
+});
+
+describe("scripts/paths.sh (CLAUDE_CONFIG_DIR set)", () => {
+  test("all paths live under $CLAUDE_CONFIG_DIR", () => {
+    const profile = mkdtempSync(join(tmpdir(), "claude-buddy-sh-"));
+    try {
+      const env = sourcePaths({ CLAUDE_CONFIG_DIR: profile });
+      expect(env.CLAUDE_CFG_DIR).toBe(profile);
+      expect(env.CLAUDE_SETTINGS_FILE).toBe(join(profile, "settings.json"));
+      expect(env.BUDDY_STATE_DIR).toBe(join(profile, "buddy-state"));
+    } finally {
+      rmSync(profile, { recursive: true, force: true });
+    }
+  });
+
+  test("CLAUDE_USER_CONFIG prefers $CLAUDE_CONFIG_DIR/.claude.json when present", () => {
+    const profile = mkdtempSync(join(tmpdir(), "claude-buddy-sh-"));
+    try {
+      writeFileSync(join(profile, ".claude.json"), "{}");
+      const env = sourcePaths({ CLAUDE_CONFIG_DIR: profile });
+      expect(env.CLAUDE_USER_CONFIG).toBe(join(profile, ".claude.json"));
+    } finally {
+      rmSync(profile, { recursive: true, force: true });
+    }
+  });
+
+  test("CLAUDE_USER_CONFIG points at the profile even when only $HOME/.claude.json exists (no cross-profile leak)", () => {
+    const profile = mkdtempSync(join(tmpdir(), "claude-buddy-sh-"));
+    // HOME is a real dir where $HOME/.claude.json probably exists on the
+    // test runner. The resolver MUST NOT fall back to it — otherwise
+    // enabling buddy in a profile could mutate the home-level file.
+    try {
+      const env = sourcePaths({ CLAUDE_CONFIG_DIR: profile });
+      expect(env.CLAUDE_USER_CONFIG).toBe(join(profile, ".claude.json"));
+    } finally {
+      rmSync(profile, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/state.ts
+++ b/server/state.ts
@@ -1,8 +1,12 @@
 /**
- * State management — reads/writes companion data to ~/.claude-buddy/
+ * State management — reads/writes companion data to the buddy state dir.
+ *
+ * The state dir resolves via server/paths.ts (honors CLAUDE_CONFIG_DIR).
+ * Default: ~/.claude-buddy/. With CLAUDE_CONFIG_DIR set:
+ * $CLAUDE_CONFIG_DIR/buddy-state/.
  *
  * Storage layout (v3 — single manifest):
- *   ~/.claude-buddy/
+ *   <state-dir>/
  *     menagerie.json   <- SSOT: { active, companions: { [slot]: Companion } }
  *     reaction.$SID.json  <- transient reaction state (session-scoped)
  *     status.json      <- compact state for the status-line shell script
@@ -26,11 +30,15 @@ import {
   rmSync,
 } from "fs";
 import { join } from "path";
-import { homedir } from "os";
 import type { Companion } from "./engine.ts";
-import { toUnixPath } from "./path.ts";
+import {
+  buddyStateDir,
+  claudeSettingsPath,
+  claudeUserConfigPath,
+  toUnixPath,
+} from "./path.ts";
 
-export const STATE_DIR = join(homedir(), ".claude-buddy");
+export const STATE_DIR = buddyStateDir();
 const MANIFEST_FILE = join(STATE_DIR, "menagerie.json");
 const CONFIG_FILE = join(STATE_DIR, "config.json");
 
@@ -286,9 +294,7 @@ export function saveReaction(reaction: string, reason: string): void {
 
 export function resolveUserId(): string {
   try {
-    const claudeJson = JSON.parse(
-      readFileSync(join(homedir(), ".claude.json"), "utf8"),
-    );
+    const claudeJson = JSON.parse(readFileSync(claudeUserConfigPath(), "utf8"));
     return claudeJson.oauthAccount?.accountUuid ?? claudeJson.userID ?? "anon";
   } catch {
     return "anon";
@@ -375,7 +381,7 @@ export function writeStatusState(
 
 // ─── Claude Code settings.json patching (for buddy_statusline tool) ──────────
 
-export const CLAUDE_SETTINGS_PATH = join(homedir(), ".claude", "settings.json");
+export const CLAUDE_SETTINGS_PATH = claudeSettingsPath();
 
 /**
  * Write settings.statusLine pointing to the given buddy-status script.

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -13,7 +13,10 @@
 # so the buddy doesn't show up twice (once in status line, once in wrapper panel).
 [ "$BUDDY_SHELL" = "1" ] && exit 0
 
-STATE="$HOME/.claude-buddy/status.json"
+# shellcheck source=../scripts/paths.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../scripts/paths.sh"
+
+STATE="$BUDDY_STATE_DIR/status.json"
 # Session ID: sanitized tmux pane number, or "default" outside tmux
 SID="${TMUX_PANE#%}"
 SID="${SID:-default}"
@@ -219,9 +222,9 @@ BUBBLE=""
 if [ -n "$ACHIEVEMENT" ] && [ "$ACHIEVEMENT" != "null" ] && [ "$ACHIEVEMENT" != "" ]; then
     BUBBLE=$'\xf0\x9f\x8f\x86'" $ACHIEVEMENT"
 fi
-REACTION_FILE="$HOME/.claude-buddy/reaction.$SID.json"
+REACTION_FILE="$BUDDY_STATE_DIR/reaction.$SID.json"
 REACTION_TTL=0
-CONFIG_FILE="$HOME/.claude-buddy/config.json"
+CONFIG_FILE="$BUDDY_STATE_DIR/config.json"
 if [ -f "$CONFIG_FILE" ]; then
     _ttl=$(jq -r '.reactionTTL // 0' "$CONFIG_FILE" 2>/dev/null || echo 0)
     case "$_ttl" in ''|*[!0-9]*) ;; *) REACTION_TTL="$_ttl" ;; esac


### PR DESCRIPTION
Closes #59.

Rebased onto current `main` (picks up #63 which removed `popup/` — that dir is no longer in the PR). Three things requested upfront:
1. Resolver tests — `server/path.test.ts` covers env set vs unset for each of `claudeConfigDir`, `claudeSettingsPath`, `claudeSkillDir`, `claudeUserConfigPath`, `buddyStateDir`, plus a regression test for the no-cross-profile-leak invariant. `server/paths_sh.test.ts` exercises the shell counterpart in real bash subshells.
2. Multi-profile note added under Quick Start in `README.md`.
3. Every commit signed off (DCO).

## Summary

- Resolvers added directly to `server/path.ts` (alongside the existing `toUnixPath` utility from #60). The shell counterpart lives in `scripts/paths.sh`.
- All TS call sites in `cli/*` and `server/*` route through the resolvers — including `cli/tui.tsx` (the interactive dashboard, ~17 paths) and `cli/buddy-shell.ts` (the PTY wrapper). Single-profile defaults (`~/.claude/`, `~/.claude.json`, `~/.claude-buddy/`) are unchanged when `CLAUDE_CONFIG_DIR` is unset.
- `cli/install.ts` prints `Target profile: <path>` at the top of the install banner so users immediately see which profile they're targeting. `cli/doctor.ts` and `cli/tui.tsx` surface the resolved paths in their diagnostic output.
- Shell scripts under `hooks/` and `statusline/` source `scripts/paths.sh` and use `$BUDDY_STATE_DIR`.
- `.claude.json` is always resolved inside `CLAUDE_CONFIG_DIR` when set — no fallback to `$HOME/.claude.json`, since that would let one profile's install mutate a different profile's user config.
- Defensive `mkdirSync` before the `.claude.json` write in `cli/backup.ts` restore, since the parent dir is no longer guaranteed to exist under the profile-scoped layout.

## Installing into a profile

Pass `CLAUDE_CONFIG_DIR` inline on both install and uninstall:

```sh
CLAUDE_CONFIG_DIR=~/.claude-personal bun run install-buddy
CLAUDE_CONFIG_DIR=~/.claude-personal bun run uninstall
```

(Or `export CLAUDE_CONFIG_DIR=...` once in the shell beforehand.) The new `Target profile: …` banner line at the top of the install output makes the active dir obvious so the env var being unset is impossible to miss.

## Test plan

- [x] `bun install` clean
- [x] `bun run typecheck` clean
- [x] `bun test` green (127 pass, 0 fail, 9 files)
- [x] Manual smoke: real `bun run install-buddy` into `~/.claude-personal` correctly placed skill, MCP entry, settings hooks, and per-profile menagerie under that dir; nothing landed in `~/.claude/` or `~/.claude.json`