### PR TITLE
fix(statusline): add macOS terminal width detection

### DIFF
--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -73,10 +73,22 @@ PID=$$
 for _ in 1 2 3 4 5; do
     PID=$(ps -o ppid= -p "$PID" 2>/dev/null | tr -d ' ')
     [ -z "$PID" ] || [ "$PID" = "1" ] && break
+
+    # Linux: read PTY device from /proc
     PTY=$(readlink "/proc/${PID}/fd/0" 2>/dev/null)
     if [ -c "$PTY" ] 2>/dev/null; then
         COLS=$(stty size < "$PTY" 2>/dev/null | awk '{print $2}')
         [ "${COLS:-0}" -gt 40 ] 2>/dev/null && break
+    fi
+
+    # macOS: /proc doesn't exist — get TTY name from process table
+    TTY_NAME=$(ps -o tty= -p "$PID" 2>/dev/null | tr -d ' ')
+    if [ -n "$TTY_NAME" ] && [ "$TTY_NAME" != "??" ]; then
+        TTY_DEV="/dev/$TTY_NAME"
+        if [ -c "$TTY_DEV" ] 2>/dev/null; then
+            COLS=$(stty size < "$TTY_DEV" 2>/dev/null | awk '{print $2}')
+            [ "${COLS:-0}" -gt 40 ] 2>/dev/null && break
+        fi
     fi
 done
 [ "${COLS:-0}" -lt 40 ] 2>/dev/null && COLS=${COLUMNS:-0}

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -83,7 +83,7 @@ for _ in 1 2 3 4 5; do
 
     # macOS: /proc doesn't exist — get TTY name from process table
     TTY_NAME=$(ps -o tty= -p "$PID" 2>/dev/null | tr -d ' ')
-    if [ -n "$TTY_NAME" ] && [ "$TTY_NAME" != "??" ]; then
+    if [ -n "$TTY_NAME" ] && [ "$TTY_NAME" != "??" ] && [ "$TTY_NAME" != "?" ]; then
         TTY_DEV="/dev/$TTY_NAME"
         if [ -c "$TTY_DEV" ] 2>/dev/null; then
             COLS=$(stty size < "$TTY_DEV" 2>/dev/null | awk '{print $2}')


### PR DESCRIPTION
## Summary

The status line width detection walks parent PIDs and reads `/proc/{PID}/fd/0` to find the controlling TTY. This is Linux-only — macOS has no `/proc/` filesystem, so the loop silently fails and falls back to `COLS=125` regardless of actual terminal width.

This adds a macOS-compatible fallback using `ps -o tty=` to extract the TTY name from the process table, then reads the device at `/dev/{tty}`.

- Linux path (`/proc/`) runs first and breaks on success — zero added cost
- macOS path (`ps -o tty=`) runs only when `/proc/` fails
- Also works as a Linux fallback for edge cases where `/proc/{PID}/fd/0` is unreadable
- Filters both `??` and `?` (procps-ng format) for processes without a controlling terminal
- Tested on macOS Darwin 25.3.0 — correctly detects terminal width from a non-TTY subprocess

## Test plan

- [ ] macOS: verify `COLS` matches actual terminal width (not 125 fallback)
- [ ] Linux: verify existing `/proc/` path still works and macOS block is skipped
- [ ] Narrow terminal: verify graceful fallback to `COLS=125` when no TTY is found