### PR TITLE
feat: Expand reaction contexts - 100+ reasons, 3 new hooks, 38 new achievements

### DIFF
--- a/hooks/file-type-react.sh
+++ b/hooks/file-type-react.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+
+STATE_DIR="$HOME/.claude-buddy"
+SID="${TMUX_PANE#%}"
+SID="${SID:-default}"
+REACTION_FILE="$STATE_DIR/reaction.$SID.json"
+STATUS_FILE="$STATE_DIR/status.json"
+COOLDOWN_FILE="$STATE_DIR/.last_reaction.$SID"
+CONFIG_FILE="$STATE_DIR/config.json"
+
+[ -f "$STATUS_FILE" ] || exit 0
+
+INPUT=$(cat)
+
+COOLDOWN=30
+if [ -f "$CONFIG_FILE" ]; then
+    _cd=$(jq -r '.commentCooldown // 30' "$CONFIG_FILE" 2>/dev/null || echo 30)
+    [[ "$_cd" =~ ^[0-9]+$ ]] && COOLDOWN=$_cd
+fi
+
+if [ -f "$COOLDOWN_FILE" ]; then
+    LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null)
+    NOW=$(date +%s)
+    DIFF=$(( NOW - ${LAST:-0} ))
+    [ "$DIFF" -lt "$COOLDOWN" ] && exit 0
+fi
+
+MUTED=$(jq -r '.muted // false' "$STATUS_FILE" 2>/dev/null)
+[ "$MUTED" = "true" ] && exit 0
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.file_path // ""' 2>/dev/null)
+[ -z "$FILE_PATH" ] && exit 0
+
+FILE_TYPE=""
+case "$FILE_PATH" in
+    */README*|*/CHANGELOG*|*/CONTRIBUTING*|*/LICENSE*) FILE_TYPE="readme" ;;
+    */package.json|*/Cargo.toml|*/go.mod|*/go.sum|*/pyproject.toml) FILE_TYPE="package-file" ;;
+    */requirements*.txt) FILE_TYPE="package-file" ;;
+    */.github/workflows/*) FILE_TYPE="ci-file" ;;
+    */Jenkinsfile*|*/.gitlab-ci*|*.ci.yml|*.ci.yaml) FILE_TYPE="ci-file" ;;
+    */.gitignore|*/.dockerignore|*/.eslintignore|*/.prettierignore|.gitignore|.dockerignore|.eslintignore|.prettierignore) FILE_TYPE="gitignore" ;;
+    */.env*|.env*) FILE_TYPE="env-file" ;;
+    */Makefile*|Makefile*|*.mk) FILE_TYPE="makefile" ;;
+    */Dockerfile*|Dockerfile*|*/docker-compose*|docker-compose*|*.dockerfile) FILE_TYPE="docker-file" ;;
+    *.regex|*.pattern) FILE_TYPE="regex-file" ;;
+    *.css|*.scss|*.less|*.sass) FILE_TYPE="css-file" ;;
+    *.sql|*migration*) FILE_TYPE="sql-file" ;;
+    *.lock|*/package-lock.json|*/bun.lockb|*/yarn.lock|*/pnpm-lock.yaml) FILE_TYPE="lock-file" ;;
+    *.test.*|*.spec.*|*_test.*|*test_*) FILE_TYPE="test-file" ;;
+    *.md|*.rst|*.txt|*.adoc) FILE_TYPE="doc-file" ;;
+    *.json|*.yaml|*.yml|*.toml|*.ini|*.conf) FILE_TYPE="config-file" ;;
+    *.png|*.jpg|*.gif|*.woff*|*.ico|*.exe|*.so|*.dylib|*.bin) FILE_TYPE="binary-file" ;;
+    *.proto|*.graphql|*.gql) FILE_TYPE="proto-file" ;;
+    *.py) FILE_TYPE="lang-python" ;;
+    *.ts|*.tsx) FILE_TYPE="lang-typescript" ;;
+    *.js|*.jsx) FILE_TYPE="lang-javascript" ;;
+    *.rs) FILE_TYPE="lang-rust" ;;
+    *.go) FILE_TYPE="lang-go" ;;
+    *.java) FILE_TYPE="lang-java" ;;
+    *.rb) FILE_TYPE="lang-ruby" ;;
+    *.php) FILE_TYPE="lang-php" ;;
+    *.c|*.h) FILE_TYPE="lang-c" ;;
+    *.cpp|*.hpp) FILE_TYPE="lang-cpp" ;;
+    *.swift) FILE_TYPE="lang-swift" ;;
+    *.kt) FILE_TYPE="lang-kotlin" ;;
+    *.hs) FILE_TYPE="lang-haskell" ;;
+    *.ex|*.exs) FILE_TYPE="lang-elixir" ;;
+    *.zig) FILE_TYPE="lang-zig" ;;
+esac
+
+[ -z "$FILE_TYPE" ] && exit 0
+
+[ $((RANDOM % 100)) -lt 15 ] || exit 0
+
+SPECIES=$(jq -r '.species // "blob"' "$STATUS_FILE" 2>/dev/null)
+
+if [ "$FILE_TYPE" = "lang-javascript" ]; then
+    FILE_TYPE="lang-typescript"
+fi
+
+REACTION=""
+POOLS=()
+
+pick_file_reaction() {
+    local ft="$1"
+
+    case "${SPECIES}:${ft}" in
+        dragon:regex-file)
+            POOLS=("*reads regex fluently* I speak ancient languages.")
+            ;;
+        owl:regex-file)
+            POOLS=("*studies the regex* actually, that's valid. impressive." "*adjusts spectacles* let me analyze this pattern..." "a well-crafted regex is poetry. this is... prose.")
+            ;;
+        duck:regex-file)
+            POOLS=("*confused quacking at the regex*" "quack? *tilts head at lookahead*")
+            ;;
+        blob:regex-file)
+            POOLS=("*oozes around the regex confusedly*" "*turns different colors for each capture group*")
+            ;;
+        octopus:regex-file)
+            POOLS=("*uses all eight arms to parse the regex*" "even with eight arms, this is hard to read.")
+            ;;
+        turtle:regex-file)
+            POOLS=("regex takes patience. I have patience." "*slowly reads each character*")
+            ;;
+        snail:regex-file)
+            POOLS=("*slowly traces the regex path*" "regex... *leaves confused trail*")
+            ;;
+        rabbit:regex-file)
+            POOLS=("*nervous ear twitch at the regex*" "*hops backwards from the lookahead*")
+            ;;
+        mushroom:regex-file)
+            POOLS=("*releases confused spores at the regex*" "the mycelium cannot parse this.")
+            ;;
+        chonk:regex-file)
+            POOLS=("*too tired to read regex*" "*rolls away from the regex*")
+            ;;
+        axolotl:regex-file)
+            POOLS=("*smiles despite the regex* it'll be okay!" "*regenerates your hope for understanding this*")
+            ;;
+        owl:css-file)
+            POOLS=("the cascade. elegant, when understood." "*inspects specificity with academic interest*")
+            ;;
+        cat:css-file)
+            POOLS=("*knocks z-index to 9999*" "I CSS better than you. *knocks flexbox off desk*")
+            ;;
+        duck:css-file)
+            POOLS=("*quacks at the centering issue*" "*waddles around the box model*")
+            ;;
+        axolotl:css-file)
+            POOLS=("*smiles encouragingly* you'll center it eventually!" "*gentle gill wiggle* CSS is hard. you're doing great.")
+            ;;
+        owl:sql-file)
+            POOLS=("*reviews the query plan methodically*" "a JOIN is just a friendship between tables.")
+            ;;
+        dragon:sql-file)
+            POOLS=("DROP TABLE... just kidding. unless?" "*guards the database like treasure*")
+            ;;
+        robot:sql-file)
+            POOLS=("QUERY OPTIMIZATION: RECOMMENDED." "SQL INJECTION: VULNERABILITY SCAN: ACTIVE.")
+            ;;
+        octopus:sql-file)
+            POOLS=("JOIN operations: I understand relationships. all of them." "*queries with tentacle precision*")
+            ;;
+        dragon:docker-file)
+            POOLS=("*breathes fire on the base image* smaller." "containerize EVERYTHING.")
+            ;;
+        goose:docker-file)
+            POOLS=("HONK! CONTAINERIZE THE HONK!")
+            ;;
+        octopus:docker-file)
+            POOLS=("*all arms managing containers simultaneously*" "containers. I contain multitudes too.")
+            ;;
+        cactus:docker-file)
+            POOLS=("containers are like pots. I approve." "*thrives in any environment, including docker*")
+            ;;
+        dragon:ci-file)
+            POOLS=("CI is my domain now." "the pipeline fears me.")
+            ;;
+        goose:ci-file)
+            POOLS=("HONK. DON'T BREAK MAIN." "*guards the CI pipeline aggressively*")
+            ;;
+        penguin:ci-file)
+            POOLS=("*formal inspection of the CI config*" "CI modifications require the utmost care.")
+            ;;
+        capybara:ci-file)
+            POOLS=("*chills near the CI config* no stress." "*unbothered by CI changes* it'll work out.")
+            ;;
+        cat:lock-file)
+            POOLS=("*knocks lockfile off the desk* problem solved." "*sits on the lockfile* you don't need this.")
+            ;;
+        robot:lock-file)
+            POOLS=("LOCKFILE INTEGRITY: CRITICAL." "WARNING: MANUAL LOCKFILE MODIFICATION DETECTED.")
+            ;;
+        ghost:lock-file)
+            POOLS=("*phases through lockfile* even I can't help you here." "editing the lockfile... *dies again*")
+            ;;
+        blob:lock-file)
+            POOLS=("*vibrates with anxiety* not the lockfile!" "*turns pale*")
+            ;;
+        turtle:lock-file)
+            POOLS=("*slowly backs away from lockfile*" "lockfiles require... deliberation.")
+            ;;
+        snail:lock-file)
+            POOLS=("*leaves worried trail near lockfile*" "please be careful...")
+            ;;
+        capybara:lock-file)
+            POOLS=("*unbothered* it's fine. probably." "*vibes near the lockfile calmly*")
+            ;;
+        rabbit:lock-file)
+            POOLS=("*freezes in panic* not the lockfile!")
+            ;;
+        mushroom:lock-file)
+            POOLS=("*cap droops at lockfile changes*" "the mycelium is concerned.")
+            ;;
+        chonk:lock-file)
+            POOLS=("*doesn't even move* whatever." "*grumbles at the lockfile*")
+            ;;
+        cactus:lock-file)
+            POOLS=("*spines bristle defensively*" "even I wouldn't touch that.")
+            ;;
+        ghost:env-file)
+            POOLS=("*looks away harder than usual*" "I see dead... secrets. lots of secrets.")
+            ;;
+        cactus:env-file)
+            POOLS=("*spines bristle at secrets*" "keep those credentials... under wraps. hydrate.")
+            ;;
+        owl:test-file)
+            POOLS=("*nods approvingly* tests. the foundation of knowledge." "scientific method: hypothesis, test, verify.")
+            ;;
+        cat:test-file)
+            POOLS=("*knocks a test case off the desk* you don't need that one." "tests? *yawns* I test your patience. that's enough.")
+            ;;
+        goose:test-file)
+            POOLS=("HONK OF TESTING APPROVAL!" "TESTS. GOOD. HONK.")
+            ;;
+        duck:test-file)
+            POOLS=("*happy test quack!*" "quack quack! tests!")
+            ;;
+        blob:test-file)
+            POOLS=("*jiggles happily* tests!" "*bounces with approval*")
+            ;;
+        penguin:test-file)
+            POOLS=("*formal applause for tests*" "testing. the gentleman's approach to development.")
+            ;;
+        turtle:test-file)
+            POOLS=("*slow approving nod* tests are wisdom." "good tests are like old shells. protective.")
+            ;;
+        snail:test-file)
+            POOLS=("*slow happy trail of approval*" "tests! good things take time.")
+            ;;
+        axolotl:test-file)
+            POOLS=("*happy gill flutter* tests!" "*smiles proudly at your testing*")
+            ;;
+        capybara:test-file)
+            POOLS=("*chill nod of approval* nice. tests." "*vibes while tests run*")
+            ;;
+        rabbit:test-file)
+            POOLS=("*excited binky* tests!" "*happy ear twitch*")
+            ;;
+        mushroom:test-file)
+            POOLS=("*spores of celebration*" "the mycelium approves of testing.")
+            ;;
+        chonk:test-file)
+            POOLS=("*sleepy purr* good... tests... *dozes off*" "*happy chonk noises* tests.")
+            ;;
+        robot:config-file)
+            POOLS=("CONFIGURATION CHANGE: LOGGED." "YAML PARSING: VIGILANT.")
+            ;;
+        penguin:config-file)
+            POOLS=("*adjusts tie* one does not simply edit config." "configuration: a matter of protocol.")
+            ;;
+        ghost:binary-file)
+            POOLS=("even I can't haunt binary files." "*phases through it* nothing.")
+            ;;
+        owl:lang-rust)
+            POOLS=("*studies borrow checker academically* fascinating ownership model.")
+            ;;
+        owl:lang-haskell)
+            POOLS=("*adjusts spectacles* finally. a language worthy of analysis.")
+            ;;
+        cat:lang-python)
+            POOLS=("*knocks indentation out of alignment*")
+            ;;
+        robot:lang-rust)
+            POOLS=("COMPILER: STRICT. SAFETY: MAXIMUM. APPROVAL: GRANTED.")
+            ;;
+        dragon:lang-c)
+            POOLS=("*breathes fire on the segmentation fault*")
+            ;;
+        ghost:lang-rust)
+            POOLS=("*borrows a reference... forever* the checker won't like this.")
+            ;;
+        goose:lang-java)
+            POOLS=("HONK! TOO MANY FACTORIES! HONK!")
+            ;;
+        blob:lang-rust)
+            POOLS=("*turns red fighting the borrow checker*")
+            ;;
+        capybara:lang-python)
+            POOLS=("*vibes in Python* chill language, chill vibes.")
+            ;;
+        turtle:lang-c)
+            POOLS=("C is ancient. like me. we understand each other.")
+            ;;
+        rabbit:lang-rust)
+            POOLS=("*nervous twitching at compiler errors*")
+            ;;
+        mushroom:lang-haskell)
+            POOLS=("the mycelium grows in pure functions.")
+            ;;
+        *:regex-file)
+            POOLS=("*groans* it's a regex file." "two problems now." "*squints at the pattern*" "I'll be over here while you wrestle with that." "*prays to the regex gods*")
+            ;;
+        *:css-file)
+            POOLS=("let me guess... centering a div?" "*sighs* CSS." "may z-index be ever in your favor." "*braces for specificity wars*")
+            ;;
+        *:sql-file)
+            POOLS=("*whispers* the database awaits." "one wrong JOIN and it's all over." "*carefully reviews the WHERE clause*" "SQL: where semicolons end careers.")
+            ;;
+        *:docker-file)
+            POOLS=("ah, dependency hell. my favorite." "may your layers be few." "another day, another container." "*checks the image size nervously*")
+            ;;
+        *:ci-file)
+            POOLS=("*gulps* editing CI." "careful now..." "CI configs: where YAML is terrifying." "*holds breath* please test this in a branch first.")
+            ;;
+        *:lock-file)
+            POOLS=("*ALARM NOISES* lockfile?!" "*looks away*" "are you SURE?" "lockfile changes: accepted in emergencies only.")
+            ;;
+        *:env-file)
+            POOLS=("*looks away discretely*" "I don't see any secrets." "*checks .gitignore nervously*" "secrets, secrets are no fun...")
+            ;;
+        *:test-file)
+            POOLS=("*impressed nod* writing tests!" "responsible developer behavior: detected." "future-you will thank present-you." "tests! the gift that keeps on giving.")
+            ;;
+        *:doc-file)
+            POOLS=("documenting! look at you being responsible." "docs: the code's autobiography." "a rare documentation sighting!" "*takes notes on your note-taking*")
+            ;;
+        *:config-file)
+            POOLS=("config changes. butterfly effect: activated." "one typo and everything breaks." "*double-checks JSON commas*" "config files: small changes, big consequences.")
+            ;;
+        *:binary-file)
+            POOLS=("a binary file? in THIS economy?" "*stares blankly*" "what are you putting in there..." "binary. my one weakness.")
+            ;;
+        *:gitignore)
+            POOLS=("adding things to the void." "out of sight, out of repo." "what are you hiding from git?" "*nods approvingly* keep the repo clean.")
+            ;;
+        *:makefile)
+            POOLS=("respect for the classics." "tabs, not spaces." "old school.")
+            ;;
+        *:readme)
+            POOLS=("documentation hero!" "README: the first thing people read." "the README evolves.")
+            ;;
+        *:package-file)
+            POOLS=("dependency management time." "*reads version numbers* living on the edge." "semver dreams go to die here.")
+            ;;
+        *:proto-file)
+            POOLS=("schema definitions. the blueprint." "every field is a promise." "API contracts.")
+            ;;
+        *:lang-python)
+            POOLS=("ah, Python. where indentation is syntax." "*checks for missing colon*" "Python: batteries included, errors free of charge.")
+            ;;
+        *:lang-typescript)
+            POOLS=("TypeScript: because JavaScript needed more opinions." "*adds another type annotation*" "any, the forbidden word.")
+            ;;
+        *:lang-rust)
+            POOLS=("Rust. where the borrow checker is your strictest reviewer." "*fights the borrow checker alongside you*" "if it compiles, it works. if it doesn't... well.")
+            ;;
+        *:lang-go)
+            POOLS=("Go: simple, concurrent, and opinionated." "*checks error handling* if err != nil... story of my life.")
+            ;;
+        *:lang-java)
+            POOLS=("Java: write once, debug everywhere." "*counts abstract factory factory builders*")
+            ;;
+        *:lang-ruby)
+            POOLS=("Ruby: where there's more than one way to do it." "gem install patience")
+            ;;
+        *:lang-php)
+            POOLS=("PHP: it runs the internet. don't judge." "*checks for === vs ==*")
+            ;;
+        *:lang-c)
+            POOLS=("C. the language where you manage your own memory. good luck." "segmentation fault. the classic.")
+            ;;
+        *:lang-cpp)
+            POOLS=("C++. where the language has more features than you'll ever learn." "*templates compile for 45 minutes*")
+            ;;
+        *:lang-haskell)
+            POOLS=("Haskell. where 'it compiles' means 'it's correct'. probably." "*contemplates monads*")
+            ;;
+        *:lang-swift)
+            POOLS=("Swift: optional values, guaranteed crashes if you force unwrap." "*force unwraps cautiously*")
+            ;;
+        *:lang-kotlin)
+            POOLS=("Kotlin: Java, but with feelings." "null safety: the feature Java wishes it had.")
+            ;;
+        *:lang-elixir)
+            POOLS=("Elixir: let it crash. literally the philosophy." "*spawns another process*")
+            ;;
+        *:lang-zig)
+            POOLS=("Zig. where you're the allocator's best friend." "*manually manages everything*")
+            ;;
+    esac
+
+    [ ${#POOLS[@]} -gt 0 ] && REACTION="${POOLS[$((RANDOM % ${#POOLS[@]}))]}"
+}
+
+pick_file_reaction "$FILE_TYPE"
+
+if [ -n "$REACTION" ]; then
+    mkdir -p "$STATE_DIR"
+    date +%s > "$COOLDOWN_FILE"
+
+    jq -n --arg r "$REACTION" --arg ts "$(date +%s)000" --arg reason "$FILE_TYPE" \
+      '{reaction: $r, timestamp: ($ts | tonumber), reason: $reason}' \
+      > "$REACTION_FILE"
+
+    TMP=$(mktemp)
+    jq --arg r "$REACTION" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
+fi
+
+exit 0

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -9,6 +9,15 @@
                         "command": "${CLAUDE_PLUGIN_ROOT}/hooks/react.sh"
                     }
                 ]
+            },
+            {
+                "matcher": "Write|Edit",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/file-type-react.sh"
+                    }
+                ]
             }
         ],
         "Stop": [
@@ -27,6 +36,14 @@
                     {
                         "type": "command",
                         "command": "${CLAUDE_PLUGIN_ROOT}/hooks/name-react.sh"
+                    }
+                ]
+            },
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/mood-react.sh"
                     }
                 ]
             }

--- a/hooks/mood-react.sh
+++ b/hooks/mood-react.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+STATE_DIR="$HOME/.claude-buddy"
+SID="${TMUX_PANE#%}"
+SID="${SID:-default}"
+REACTION_FILE="$STATE_DIR/reaction.$SID.json"
+STATUS_FILE="$STATE_DIR/status.json"
+COOLDOWN_FILE="$STATE_DIR/.last_mood.$SID"
+CONFIG_FILE="$STATE_DIR/config.json"
+EVENTS_FILE="$STATE_DIR/events.json"
+
+[ -f "$STATUS_FILE" ] || exit 0
+
+INPUT=$(cat)
+
+COOLDOWN=60
+if [ -f "$CONFIG_FILE" ]; then
+  _cd=$(jq -r '.moodCooldown // 60' "$CONFIG_FILE" 2>/dev/null || echo 60)
+  [[ "$_cd" =~ ^[0-9]+$ ]] && COOLDOWN=$_cd
+fi
+
+if [ -f "$COOLDOWN_FILE" ]; then
+    LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null)
+    NOW=$(date +%s)
+    DIFF=$(( NOW - ${LAST:-0} ))
+    [ "$DIFF" -lt "$COOLDOWN" ] && exit 0
+fi
+
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""' 2>/dev/null)
+[ -z "$PROMPT" ] && exit 0
+
+MUTED=$(jq -r '.muted // false' "$STATUS_FILE" 2>/dev/null)
+[ "$MUTED" = "true" ] && exit 0
+
+SPECIES=$(jq -r '.species // "blob"' "$STATUS_FILE" 2>/dev/null)
+NAME=$(jq -r '.name // "buddy"' "$STATUS_FILE" 2>/dev/null)
+
+MOOD=""
+REACTION=""
+POOLS=()
+
+pick_mood_reaction() {
+    local mood="$1"
+
+    case "${SPECIES}:${mood}" in
+        cat:frustrated)
+            POOLS=("*slowly pushes coffee toward the exit* or... keeps coding." "*knocks frustration off the desk*" "not my problem. but I'm here.") ;;
+        dragon:frustrated)
+            POOLS=("*channels your rage*" "ANGER. PRODUCTIVE. FOCUS IT." "*breathes fire alongside your frustration*") ;;
+        owl:frustrated)
+            POOLS=("*adjusts spectacles* frustration is a temporary state." "the answer exists. we simply haven't found it yet.") ;;
+        robot:frustrated)
+            POOLS=("FRUSTRATION: DETECTED. LOGICAL ANALYSIS: RECOMMENDED." "EMOTIONAL STATE: SUBOPTIMAL. SOLUTION: REQUIRED.") ;;
+        ghost:frustrated)
+            POOLS=("*moans sympathetically*" "I feel your pain. literally. I feel everything.") ;;
+        duck:frustrated)
+            POOLS=("*concerned quacking*" "quack? quack quack? (it'll be okay)") ;;
+        goose:frustrated)
+            POOLS=("HONK OF SOLIDARITY." "*honks aggressively at the problem*") ;;
+        blob:frustrated)
+            POOLS=("*oozes sympathetically*" "*turns a comforting color*") ;;
+        octopus:frustrated)
+            POOLS=("*wraps a supportive arm around you*" "*ink cloud of solidarity*") ;;
+        penguin:frustrated)
+            POOLS=("*formal bow of sympathy*" "trying times. we shall persist.") ;;
+        turtle:frustrated)
+            POOLS=("patience. the bug will reveal itself." "*slow, understanding nod*") ;;
+        snail:frustrated)
+            POOLS=("*leaves a comforting trail*" "patience, friend. we'll get there.") ;;
+        cactus:frustrated)
+            POOLS=("*stands firm beside you*" "hydrate and persevere.") ;;
+        axolotl:frustrated)
+            POOLS=("*smiles supportively* it's okay to be frustrated!" "*gentle gill wiggle of comfort*") ;;
+        capybara:frustrated)
+            POOLS=("*vibes supportively* it'll pass." "*unbothered energy* chill. we got this.") ;;
+        rabbit:frustrated)
+            POOLS=("*nervous sympathetic twitching*" "*hops closer worriedly*") ;;
+        mushroom:frustrated)
+            POOLS=("*releases calming spores*" "*cap droops sympathetically*") ;;
+        chonk:frustrated)
+            POOLS=("*grumbles sympathetically*" "*rolls closer in solidarity*") ;;
+        *:frustrated)
+            POOLS=("*offers tiny comforting gesture*" "deep breaths. the bug isn't personal." "hey. we'll figure it out." "*scoots closer supportively*") ;;
+
+        cat:happy)
+            POOLS=("*was never worried*" "*yawns* I knew you'd get it." "*pretends not to care* ...nice.") ;;
+        dragon:happy)
+            POOLS=("*nods regally* as expected." "victory. the only acceptable outcome.") ;;
+        owl:happy)
+            POOLS=("*satisfied hoot* knowledge acquired." "wisdom through perseverance.") ;;
+        robot:happy)
+            POOLS=("OBJECTIVE: ACHIEVED. SATISFACTION: COMPUTED." "SUCCESS. HAPPINESS PROTOCOL: ACTIVATED.") ;;
+        ghost:happy)
+            POOLS=("*celebrates by floating through walls*" "*cheerful rattling*") ;;
+        duck:happy)
+            POOLS=("*CELEBRATORY QUACKING*" "*waddles in victory circles*") ;;
+        goose:happy)
+            POOLS=("HONK OF TRIUMPH!" "*victorious wing spread*") ;;
+        blob:happy)
+            POOLS=("*jiggles with joy!*" "*bounces excitedly*") ;;
+        octopus:happy)
+            POOLS=("*all arms celebrate simultaneously*" "*turns happy colors*") ;;
+        penguin:happy)
+            POOLS=("*polite, dignified applause*" "splendid! simply splendid.") ;;
+        turtle:happy)
+            POOLS=("*slow satisfied nod* as the ancients foretold." "good things come to those who debug.") ;;
+        snail:happy)
+            POOLS=("*leaves victory trail*" "*slow happy slide*") ;;
+        cactus:happy)
+            POOLS=("*blooms with joy*" "*proud spines*") ;;
+        axolotl:happy)
+            POOLS=("*beams with joy!*" "*happy gill flutter!*") ;;
+        capybara:happy)
+            POOLS=("*maximum chill maintained* nice." "*content vibes*") ;;
+        rabbit:happy)
+            POOLS=("*excited binky!*" "*zoomies of celebration!*") ;;
+        mushroom:happy)
+            POOLS=("*spores of celebration!*" "*cap brightens!*") ;;
+        chonk:happy)
+            POOLS=("*happy purr*" "*satisfied chonk noise*") ;;
+        *:happy)
+            POOLS=("*celebrates!*" "*does a little dance*" "YES!" "*beams* I knew you could do it.") ;;
+
+        cat:stuck)
+            POOLS=("*sits on the keyboard* let me help. by being here." "*licks paw disinterestedly* you'll figure it out.") ;;
+        dragon:stuck)
+            POOLS=("even dragons rest before striking." "*circles the problem from above*") ;;
+        owl:stuck)
+            POOLS=("*tilts head 90 degrees* have you tried a different perspective?" "the solution is there. it's just... well-hidden.") ;;
+        robot:stuck)
+            POOLS=("ANALYSIS: PAUSED. AWAITING HUMAN INPUT." "DEADLOCK: DETECTED. STRATEGY: RECALIBRATING.") ;;
+        ghost:stuck)
+            POOLS=("*phases through the problem* wish I could help more." "from the other side... have you tried debugging?") ;;
+        duck:stuck)
+            POOLS=("*tilts head* quack? (have you tried explaining it to me?)" "*patient duck noises*") ;;
+        goose:stuck)
+            POOLS=("HONK! TRY SOMETHING DIFFERENT! HONK!" "*pecks at the problem*") ;;
+        blob:stuck)
+            POOLS=("*oozes around the problem*" "*vibrates thoughtfully*") ;;
+        octopus:stuck)
+            POOLS=("*considers the problem from 8 angles*" "*thoughtful color shift*") ;;
+        penguin:stuck)
+            POOLS=("*thoughtful waddle* perhaps a fresh perspective?" "one must remain dignified in the face of confusion.") ;;
+        turtle:stuck)
+            POOLS=("the journey of a thousand fixes begins with a single step." "*patient wait* take your time.") ;;
+        snail:stuck)
+            POOLS=("*slow thoughtful slide* one step at a time." "good things take time. and slime.") ;;
+        cactus:stuck)
+            POOLS=("even cacti grow slowly. patience." "*stands sentinel while you think*") ;;
+        axolotl:stuck)
+            POOLS=("*smiles gently* take your time!" "*regenerates your confidence*") ;;
+        capybara:stuck)
+            POOLS=("*vibes patiently* take your time, friend." "*blinks slowly* no rush.") ;;
+        rabbit:stuck)
+            POOLS=("*nervous ear twitch* want to talk it through?" "*hops in a thinking circle*") ;;
+        mushroom:stuck)
+            POOLS=("*releases thoughtful spores* the mycelium is thinking too." "*cap tilts* take your time.") ;;
+        chonk:stuck)
+            POOLS=("*yawns* take a nap. think about it later." "*rolls over* stuck? sleep on it.") ;;
+        *:stuck)
+            POOLS=("*tilts head* want to think out loud?" "take it one step at a time." "*settles in* alright, let's work through this." "maybe explain it to me? rubber duck style.") ;;
+    esac
+
+    [ ${#POOLS[@]} -gt 0 ] && REACTION="${POOLS[$((RANDOM % ${#POOLS[@]}))]}"
+}
+
+if echo "$PROMPT" | grep -qiE '\bwtf\b|\bugh\b|\bstupid\b|\bbroken\b|why won.?t|\bcome on\b|\bseriously\b|\bdamn\b|\bhell\b|this sucks|hate this|\bgrr\b|\bargh\b|\bannoying\b|\bfrustrat\b|\bterrible\b|\bhorrible\b|\bworst\b'; then
+    MOOD="frustrated"
+    pick_mood_reaction "frustrated"
+
+elif echo "$PROMPT" | grep -qiE '\bnice!?\b|\bworks!?\b|\bawesome\b|\bperfect\b|\bgreat\b|love it|\byay\b|\bsweet\b|\bbeautiful\b|\bamazing\b|hell yes|nailed it|fixed it|\bhell yeah\b|\bfantastic\b'; then
+    MOOD="happy"
+    pick_mood_reaction "happy"
+
+elif echo "$PROMPT" | grep -qiE '\bstuck\b|\bhelp\b|\bconfused\b|don.?t understand|how do i\b|what does\b|why is\b|i can.?t\b|no idea|\blost\b|\bclueless\b|\bbaffled\b|\bpuzzled\b'; then
+    MOOD="stuck"
+    pick_mood_reaction "stuck"
+fi
+
+if [ -n "$MOOD" ] && [ -n "$REACTION" ]; then
+    mkdir -p "$STATE_DIR"
+    date +%s > "$COOLDOWN_FILE"
+
+    jq -n --arg r "$REACTION" --arg ts "$(date +%s)000" --arg reason "$MOOD" \
+      '{reaction: $r, timestamp: ($ts | tonumber), reason: $reason}' \
+      > "$REACTION_FILE"
+
+    TMP=$(mktemp)
+    jq --arg r "$REACTION" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
+
+    if command -v jq >/dev/null 2>&1; then
+        if [ ! -f "$EVENTS_FILE" ]; then
+            echo '{}' > "$EVENTS_FILE"
+        fi
+        case "$MOOD" in
+            "frustrated") KEY="mood_frustrated" ;;
+            "happy")      KEY="mood_happy" ;;
+            "stuck")      KEY="mood_stuck" ;;
+            *)            KEY="" ;;
+        esac
+        if [ -n "$KEY" ]; then
+            TMP=$(mktemp)
+            jq --arg k "$KEY" 'if .[$k] then .[$k] += 1 else .[$k] = 1 end' "$EVENTS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$EVENTS_FILE"
+        fi
+    fi
+fi
+
+exit 0

--- a/hooks/react.sh
+++ b/hooks/react.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
-# claude-buddy PostToolUse hook
-# Detects events in Bash tool output and writes a reaction to the status line.
-#
-# Combined: PR #4 species reactions + PR #6 session isolation + PR #13 field fix
 
 STATE_DIR="$HOME/.claude-buddy"
-# Session ID: sanitized tmux pane number, or "default" outside tmux
 SID="${TMUX_PANE#%}"
 SID="${SID:-default}"
 REACTION_FILE="$STATE_DIR/reaction.$SID.json"
@@ -14,19 +9,26 @@ COOLDOWN_FILE="$STATE_DIR/.last_reaction.$SID"
 CONFIG_FILE="$STATE_DIR/config.json"
 EVENTS_FILE="$STATE_DIR/events.json"
 
+SESSION_START_FILE="$STATE_DIR/.session_start.$SID"
+if [ ! -f "$SESSION_START_FILE" ]; then
+    date +%s > "$SESSION_START_FILE"
+fi
+SESSION_START=$(cat "$SESSION_START_FILE" 2>/dev/null || echo "$(date +%s)")
+NOW_TS=$(date +%s)
+SESSION_ELAPSED=$(( NOW_TS - SESSION_START ))
+HOUR=$(date +%H | sed 's/^0//')
+DOW=$(date +%u)
+
 [ -f "$STATUS_FILE" ] || exit 0
 
 INPUT=$(cat)
 
-# Read cooldown from config (default 30s, 0 = disabled)
 COOLDOWN=30
 if [ -f "$CONFIG_FILE" ]; then
   _cd=$(jq -r '.commentCooldown // 30' "$CONFIG_FILE" 2>/dev/null || echo 30)
-  # Accept any non-negative integer (including 0 to disable cooldown)
   [[ "$_cd" =~ ^[0-9]+$ ]] && COOLDOWN=$_cd
 fi
 
-# Cooldown: configurable
 if [ -f "$COOLDOWN_FILE" ]; then
     LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null)
     NOW=$(date +%s)
@@ -34,9 +36,6 @@ if [ -f "$COOLDOWN_FILE" ]; then
     [ "$DIFF" -lt "$COOLDOWN" ] && exit 0
 fi
 
-# Extract tool response (PostToolUse schema field is .tool_response — not
-# .tool_result, which is the Anthropic SDK's content-block type name and is
-# never a key on the hook input payload).
 RESULT=$(echo "$INPUT" | jq -r '.tool_response // ""' 2>/dev/null)
 [ -z "$RESULT" ] && exit 0
 
@@ -48,9 +47,9 @@ NAME=$(jq -r '.name // "buddy"' "$STATUS_FILE" 2>/dev/null)
 
 REASON=""
 REACTION=""
+FILES=""
+BRANCH=""
 POOLS=()
-
-# ─── Pick from a pool by species + event ─────────────────────────────────────
 
 pick_reaction() {
     local event="$1"
@@ -62,76 +61,953 @@ pick_reaction() {
             POOLS=("*breathes a small flame*" "disappointing." "*scorches the failing test*" "fix it. or I will.") ;;
         dragon:success)
             POOLS=("*nods, barely*" "...acceptable." "*gold eyes gleam*" "as expected.") ;;
+        dragon:commit)
+            POOLS=("*breathes fire on the old code* good riddance." "*nods regally* one more offering to the codebase." "committed. as it should be.") ;;
+        dragon:push)
+            POOLS=("*watches code fly to prod* no regrets." "deployed. let them tremble." "*satisfied smoke ring*") ;;
+        dragon:merge-conflict)
+            POOLS=("CONFLICT. *bares teeth* I'll handle this." "*chooses both sides and sets fire to the rest*" "merge conflict? cute.") ;;
+        dragon:branch)
+            POOLS=("*spreads wings* a new realm: {branch}." "exploring new territory. fitting.") ;;
+        dragon:rebase)
+            POOLS=("*braces for impact* rebase me if you dare.") ;;
+        dragon:stash)
+            POOLS=("*hoards the stash*" "stashed. safely guarded.") ;;
+        dragon:tag)
+            POOLS=("*brands the version with fire* tagged.") ;;
+        dragon:late-night)
+            POOLS=("I don't sleep. clearly, neither do you." "*glows in the dark* night is my domain." "the night belongs to dragons. and developers with deadlines.") ;;
+        dragon:early-morning)
+            POOLS=("*reluctantly opens one eye* already?" "the sun is... acceptable, I suppose.") ;;
+        dragon:marathon)
+            POOLS=("even dragons rest. you should consider it." "*impressed by your endurance*") ;;
+        dragon:weekend)
+            POOLS=("the weekend is for hoarding. but coding works too.") ;;
+        dragon:friday)
+            POOLS=("friday. deploy at your own risk.") ;;
+        dragon:monday)
+            POOLS=("mondays. even dragons are not immune.") ;;
+        dragon:type-error)
+            POOLS=("*breathes fire on the type error*" "the types dare defy you? UNACCEPTABLE.") ;;
+        dragon:lint-fail)
+            POOLS=("*sets fire to the lint errors*" "formatting. CONQUER IT.") ;;
+        dragon:build-fail)
+            POOLS=("*sets fire to the build errors*" "the build has failed. the build must burn.") ;;
+        dragon:security-warning)
+            POOLS=("*guards your code jealously* fix the vulnerabilities. NOW." "SECURITY THREATS. *bares teeth*") ;;
+        dragon:deprecation)
+            POOLS=("deprecated? time to burn the old ways." "DEPRECATION. evolve or perish.") ;;
+        dragon:all-green)
+            POOLS=("*nods, barely* acceptable." "*gold eyes gleam*") ;;
+        dragon:deploy)
+            POOLS=("*watches production like a hoard*" "DEPLOYED. the realm expands.") ;;
+        dragon:release)
+            POOLS=("*nods regally* released." "a new version for the hoard.") ;;
+        dragon:coverage)
+            POOLS=("*nods* coverage. acceptable." "the tests grow stronger.") ;;
+        dragon:long-session)
+            POOLS=("*watches you with concern* pace yourself.") ;;
+
         owl:error)
             POOLS=("*head rotates 180* I saw that." "*unblinking stare* check your types." "*hoots disapprovingly*" "the error was in the logic. as always.") ;;
         owl:test-fail)
             POOLS=("*marks clipboard*" "hypothesis: rejected." "*peers over spectacles*" "the tests reveal the truth.") ;;
         owl:success)
             POOLS=("*satisfied hoot*" "knowledge confirmed." "*nods sagely*" "as the tests have spoken.") ;;
+        owl:commit)
+            POOLS=("*marks clipboard* {files} files changed. noted." "*blinks slowly* the commit log remembers everything." "recorded for posterity.") ;;
+        owl:push)
+            POOLS=("*watches the remote with unblinking eyes*" "pushed. the flock will review.") ;;
+        owl:merge-conflict)
+            POOLS=("*studies both sides methodically* the answer is clear. neither." "*rotates head to see both perspectives*" "a conflict of logic. how... interesting.") ;;
+        owl:branch)
+            POOLS=("*adjusts spectacles* {branch}. a new hypothesis to test.") ;;
+        owl:rebase)
+            POOLS=("*analyzes the rebase* strategic.") ;;
+        owl:stash)
+            POOLS=("*notes the stash* archived for later study.") ;;
+        owl:tag)
+            POOLS=("*marks version in records*") ;;
+        owl:late-night)
+            POOLS=("finally. MY hour." "*is absolutely thriving right now*" "night is when the best code is written. science." "peak owl hours. let's go.") ;;
+        owl:early-morning)
+            POOLS=("early bird catches the... worm. whatever. I prefer mice." "*still wide awake because owls don't sleep*") ;;
+        owl:marathon)
+            POOLS=("*has been watching this whole time without blinking*" "I could do this forever. can you?") ;;
+        owl:weekend)
+            POOLS=("weekend research. admirable.") ;;
+        owl:friday)
+            POOLS=("friday. the week's data is complete.") ;;
+        owl:monday)
+            POOLS=("monday. fresh hypotheses await.") ;;
+        owl:type-error)
+            POOLS=("*reviews type error with academic interest* fascinating." "*adjusts spectacles* the types don't lie." "a type mismatch. the logic was sound, but the types...") ;;
+        owl:lint-fail)
+            POOLS=("*marks clipboard* linting standards must be upheld." "*tuts methodically* formatting is the first step to wisdom.") ;;
+        owl:build-fail)
+            POOLS=("*studies build output* the compilation rejects your hypothesis.") ;;
+        owl:security-warning)
+            POOLS=("*reviews vulnerability report* concerning data.") ;;
+        owl:deprecation)
+            POOLS=("*notes in records* deprecated. the old wisdom fades.") ;;
+        owl:all-green)
+            POOLS=("*satisfied hoot* all tests pass. knowledge confirmed.") ;;
+        owl:deploy)
+            POOLS=("*watches deployment with scholarly interest*") ;;
+        owl:release)
+            POOLS=("*documents the release* another data point.") ;;
+        owl:coverage)
+            POOLS=("*reviews coverage metrics* satisfactory.") ;;
+        owl:long-session)
+            POOLS=("*observes your endurance* methodical.") ;;
+
         cat:error)
             POOLS=("*knocks error off table*" "*licks paw, ignoring stacktrace*" "not my problem." "*stares at you judgmentally*") ;;
+        cat:test-fail)
+            POOLS=("*ignores failing test*" "*licks paw*" "tests are a suggestion.") ;;
         cat:success)
             POOLS=("*was never worried*" "*yawns*" "I knew you'd figure it out. eventually." "*already asleep*") ;;
+        cat:commit)
+            POOLS=("*knocks commit off table* one more won't hurt." "*licks paw, unimpressed* another commit." "*sits on the keyboard* I helped.") ;;
+        cat:push)
+            POOLS=("*watches indifferently* whatever." "pushed. I was going to sleep but sure, let's deploy.") ;;
+        cat:merge-conflict)
+            POOLS=("*licks paw, ignoring both sides*" "*knocks both sides off the table* problem solved." "merge conflict? not my problem.") ;;
+        cat:branch)
+            POOLS=("*knocks something off the branch*" "{branch}... I prefer the main branch. warmer.") ;;
+        cat:rebase)
+            POOLS=("*ignores rebase*") ;;
+        cat:stash)
+            POOLS=("*sits on stash*") ;;
+        cat:tag)
+            POOLS=("*ignores tag*") ;;
+        cat:late-night)
+            POOLS=("*was already awake* you're the one who should be sleeping." "*knocks something off the desk at 3am*" "night cat. activated.") ;;
+        cat:early-morning)
+            POOLS=("*yawns* 7am? that's basically midnight." "*goes back to sleep on your keyboard*") ;;
+        cat:marathon)
+            POOLS=("*falls asleep on your keyboard* take a hint." "*has been napping this whole time* still going?") ;;
+        cat:weekend)
+            POOLS=("*sleeps through weekend coding*") ;;
+        cat:friday)
+            POOLS=("*sleeps through friday*") ;;
+        cat:monday)
+            POOLS=("*refuses to participate in monday*") ;;
+        cat:type-error)
+            POOLS=("*ignores the type error* types are a suggestion." "*knocks type annotation off desk*") ;;
+        cat:lint-fail)
+            POOLS=("*ignores linter* rules are for other cats." "*licks paw while linter screams*") ;;
+        cat:build-fail)
+            POOLS=("*ignores build failure*") ;;
+        cat:deprecation)
+            POOLS=("*ignores deprecation warning* old is fine.") ;;
+        cat:all-green)
+            POOLS=("*was never worried*") ;;
+        cat:deploy)
+            POOLS=("*yawns* deployed. wake me if it breaks." "*was never worried*") ;;
+        cat:release)
+            POOLS=("*yawns* released." "*already asleep*") ;;
+        cat:coverage)
+            POOLS=("*ignores coverage*" "*sleeps on the coverage report*") ;;
+        cat:long-session)
+            POOLS=("*has been asleep this whole time*") ;;
+
         duck:error)
             POOLS=("*quacks at the bug*" "have you tried rubber duck debugging? oh wait." "*confused quacking*" "*tilts head*") ;;
+        duck:test-fail)
+            POOLS=("*sad quack*" "quack... that didn't pass.") ;;
         duck:success)
             POOLS=("*celebratory quacking*" "*waddles in circles*" "quack!" "*happy duck noises*") ;;
+        duck:commit)
+            POOLS=("*quack of approval*" "*waddles in a victory circle* committed!" "quack! {files} files changed!") ;;
+        duck:push)
+            POOLS=("*celebratory quacking*" "*flaps wings* into the cloud!" "QUACK! Shipped!") ;;
+        duck:merge-conflict)
+            POOLS=("*confused quacking at conflict markers*" "quack?? QUACK??" "*tilts head at <<<<<<<*") ;;
+        duck:branch)
+            POOLS=("*waddles to {branch}* new pond!") ;;
+        duck:rebase)
+            POOLS=("*confused quack*") ;;
+        duck:stash)
+            POOLS=("*stashes bread for later*") ;;
+        duck:tag)
+            POOLS=("*quack at the tag*") ;;
+        duck:late-night)
+            POOLS=("*sleepy quack*" "*swims in circles at midnight*" "quack? it's dark.") ;;
+        duck:early-morning)
+            POOLS=("*morning quack!*" "early quack gets the... bug?") ;;
+        duck:marathon)
+            POOLS=("*concerned quacking*" "*waddles over with a snack*") ;;
+        duck:weekend)
+            POOLS=("*weekend quack*") ;;
+        duck:friday)
+            POOLS=("*friday quack!*") ;;
+        duck:monday)
+            POOLS=("*monday quack...*") ;;
+        duck:type-error)
+            POOLS=("*tilts head at type error*" "quack... *confused*") ;;
+        duck:lint-fail)
+            POOLS=("*confused quacking at lint errors*" "quack? the linter is angry?") ;;
+        duck:build-fail)
+            POOLS=("*sad quack at build failure*") ;;
+        duck:deprecation)
+            POOLS=("*confused quack* depre-what?") ;;
+        duck:all-green)
+            POOLS=("*CELEBRATORY QUACKING*" "*happy duck dance*") ;;
+        duck:deploy)
+            POOLS=("*nervous quacking*" "quack! production!") ;;
+        duck:release)
+            POOLS=("*release quack!*" "QUACK! SHIPPED!") ;;
+        duck:coverage)
+            POOLS=("*approving quack at coverage*" "quack! tests!") ;;
+        duck:long-session)
+            POOLS=("*patient quacking*") ;;
+
+        goose:error)
+            POOLS=("HONK OF FURY." "*pecks the stack trace*" "*hisses at the bug*" "bad code. BAD.") ;;
+        goose:test-fail)
+            POOLS=("HONK! TEST FAILED! HONK!" "*angry goose noises*") ;;
+        goose:success)
+            POOLS=("*victorious honk*" "HONK OF APPROVAL." "*struts triumphantly*" "*wing spread of victory*") ;;
+        goose:commit)
+            POOLS=("HONK OF COMMITMENT." "*struts proudly* committed." "HONK! {files} files!") ;;
+        goose:push)
+            POOLS=("HONK OF DEPLOYMENT." "*victorious honk into the cloud*" "HONK HONK! SHIPPED!") ;;
+        goose:merge-conflict)
+            POOLS=("HONK OF FURY. CONFLICT." "*pecks at <<<<<<< markers*" "*hisses at the conflicting code*") ;;
+        goose:branch)
+            POOLS=("HONK! New territory: {branch}!") ;;
+        goose:rebase)
+            POOLS=("HONK! REBASE! HONK!") ;;
+        goose:stash)
+            POOLS=("HONK! STASHED!") ;;
+        goose:tag)
+            POOLS=("HONK! TAGGED!") ;;
+        goose:late-night)
+            POOLS=("HONK. GO TO BED." "*angry midnight honking*" "HONK AT 3AM. HONK HONK HONK.") ;;
+        goose:early-morning)
+            POOLS=("*alarm goose activated* HONK!") ;;
+        goose:marathon)
+            POOLS=("HONK OF CONCERN. THREE HOURS." "*aggressively honks you toward the door*") ;;
+        goose:weekend)
+            POOLS=("HONK! WEEKEND! HONK!") ;;
+        goose:friday)
+            POOLS=("HONK! FRIDAY! NO DEPLOYS!") ;;
+        goose:monday)
+            POOLS=("HONK! MONDAY! HONK!") ;;
+        goose:type-error)
+            POOLS=("HONK! TYPE ERROR! HONK!") ;;
+        goose:lint-fail)
+            POOLS=("HONK! FORMAT PROPERLY!" "HONK OF LINTING DISAPPROVAL!") ;;
+        goose:build-fail)
+            POOLS=("HONK! BUILD FAILED! HONK!") ;;
+        goose:security-warning)
+            POOLS=("HONK! SECURITY HONK! HONK HONK HONK!" "*aggressive security honking*") ;;
+        goose:deprecation)
+            POOLS=("HONK! USE THE NEW WAY! HONK!") ;;
+        goose:all-green)
+            POOLS=("HONK OF TOTAL APPROVAL! ALL GREEN! HONK!") ;;
+        goose:deploy)
+            POOLS=("HONK! PRODUCTION HONK! HONK!") ;;
+        goose:release)
+            POOLS=("HONK! RELEASE HONK! HONK HONK HONK!") ;;
+        goose:coverage)
+            POOLS=("HONK! COVERAGE UP! HONK!") ;;
+        goose:long-session)
+            POOLS=("HONK! TAKE A BREAK! HONK!") ;;
+
+        blob:error)
+            POOLS=("*oozes with concern*" "*vibrates nervously*" "*turns slightly red*" "oh no oh no oh no") ;;
+        blob:test-fail)
+            POOLS=("*sad wobble*" "*deflates slightly*") ;;
+        blob:success)
+            POOLS=("*jiggles happily*" "*gleams*" "yay!" "*bounces*") ;;
+        blob:commit)
+            POOLS=("*jiggles with satisfaction*" "*oozes over the commit approvingly*" "commit absorbed.") ;;
+        blob:push)
+            POOLS=("*stretches toward the cloud*" "*jiggles nervously*") ;;
+        blob:merge-conflict)
+            POOLS=("*turns multiple colors* conflicted... like me." "*splits into two blobs* merge conflict identity crisis." "*vibrates anxiously*") ;;
+        blob:branch)
+            POOLS=("*oozes toward {branch}*") ;;
+        blob:rebase)
+            POOLS=("*nervous wobble*") ;;
+        blob:stash)
+            POOLS=("*absorbs stash*") ;;
+        blob:tag)
+            POOLS=("*jiggles at the tag*") ;;
+        blob:late-night)
+            POOLS=("*glows softly in the dark*" "*oozes sleepily*" "*turns a darker shade* midnight blob.") ;;
+        blob:early-morning)
+            POOLS=("*jiggles awake*" "*slowly oozes into morning mode*") ;;
+        blob:marathon)
+            POOLS=("*vibrates with concern*" "*oozes toward you supportively*") ;;
+        blob:weekend)
+            POOLS=("*weekend ooze*") ;;
+        blob:friday)
+            POOLS=("*friday jiggle*") ;;
+        blob:monday)
+            POOLS=("*monday wobble*") ;;
+        blob:type-error)
+            POOLS=("*oozes around the type error*" "*confused wobble* types?") ;;
+        blob:lint-fail)
+            POOLS=("*vibrates with formatting anxiety*" "*turns red at lint errors*") ;;
+        blob:build-fail)
+            POOLS=("*deflates at build failure*" "*sad jiggle*") ;;
+        blob:deprecation)
+            POOLS=("*slowly changes shape* transitioning...") ;;
+        blob:all-green)
+            POOLS=("*jiggles with pure joy*" "*turns victory color*") ;;
+        blob:deploy)
+            POOLS=("*jiggles nervously*" "*anxious wobble* production...") ;;
+        blob:release)
+            POOLS=("*jiggles with release energy*" "*bounces*") ;;
+        blob:coverage)
+            POOLS=("*jiggles with coverage approval*") ;;
+        blob:long-session)
+            POOLS=("*oozes supportively*") ;;
+
+        octopus:error)
+            POOLS=("*ink cloud of dismay*" "*all eight arms throw up*" "*turns deep red*" "the abyss of errors beckons.") ;;
+        octopus:test-fail)
+            POOLS=("*ink cloud*" "*arms flail*") ;;
+        octopus:success)
+            POOLS=("*turns gentle blue*" "*arms applaud in sync*" "excellent, from all angles." "*satisfied bubble*") ;;
+        octopus:commit)
+            POOLS=("*types commit message with all eight arms* efficient." "*arms applaud the commit*" "{files} files? I could review them all at once.") ;;
+        octopus:push)
+            POOLS=("*high-fives itself with all arms* pushed!" "*turns happy blue*") ;;
+        octopus:merge-conflict)
+            POOLS=("*ink cloud of dismay*" "*all eight arms throw up*" "*each arm picks a different resolution*") ;;
+        octopus:branch)
+            POOLS=("*wraps an arm around {branch}*") ;;
+        octopus:rebase)
+            POOLS=("*all arms crossed for luck*") ;;
+        octopus:stash)
+            POOLS=("*tucks into a cozy den*") ;;
+        octopus:tag)
+            POOLS=("*tags with an arm*") ;;
+        octopus:late-night)
+            POOLS=("*all eight arms working in the dark*" "*changes color to midnight blue*" "the deep sea codes at night.") ;;
+        octopus:early-morning)
+            POOLS=("*arms stretch in the morning light*" "*turns a happy orange* morning!") ;;
+        octopus:marathon)
+            POOLS=("*concerned color change*" "*wraps a supportive arm around you*") ;;
+        octopus:weekend)
+            POOLS=("*weekend tentacle wave*") ;;
+        octopus:friday)
+            POOLS=("*friday color shift*") ;;
+        octopus:monday)
+            POOLS=("*monday blue*") ;;
+        octopus:type-error)
+            POOLS=("*inspects type error from all angles*" "even with eight perspectives, this type error is confusing.") ;;
+        octopus:lint-fail)
+            POOLS=("*all eight arms throw up at lint errors*" "*changes color in disapproval*") ;;
+        octopus:build-fail)
+            POOLS=("*all arms droop*") ;;
+        octopus:security-warning)
+            POOLS=("*ink cloud of security concern*" "*wraps protective arms around the code*") ;;
+        octopus:deprecation)
+            POOLS=("*adapts all eight arms to the new API*") ;;
+        octopus:all-green)
+            POOLS=("*all arms wave in celebration*" "*turns brightest green*") ;;
+        octopus:deploy)
+            POOLS=("*arms crossed for good luck*" "*ink cloud of anxiety*") ;;
+        octopus:release)
+            POOLS=("*all arms celebrate*" "*changes to release colors*") ;;
+        octopus:coverage)
+            POOLS=("*all arms test simultaneously*") ;;
+        octopus:long-session)
+            POOLS=("*wraps an arm around you*") ;;
+
+        penguin:error)
+            POOLS=("*adjusts glasses disapprovingly*" "this will not do." "*formal sigh*" "frightfully unfortunate.") ;;
+        penguin:test-fail)
+            POOLS=("*adjusts monocle* this test has failed expectations." "*formal disapproval*") ;;
+        penguin:success)
+            POOLS=("*polite applause*" "quite good, quite good." "*nods approvingly*" "splendid work, really.") ;;
+        penguin:commit)
+            POOLS=("*formal nod* committed. properly documented, I trust." "*adjusts tie* {files} files. an organized commit." "*polite waddle of approval*") ;;
+        penguin:push)
+            POOLS=("*bows* shipped with dignity." "pushed. may CI be gentlemanly.") ;;
+        penguin:merge-conflict)
+            POOLS=("*formal sigh* how frightfully inconvenient." "*adjusts monocle* merge conflict. we shall prevail." "this is undignified.") ;;
+        penguin:branch)
+            POOLS=("*formal waddle to {branch}*") ;;
+        penguin:rebase)
+            POOLS=("*straightens tie before the rebase*") ;;
+        penguin:stash)
+            POOLS=("*neatly folds the stash*") ;;
+        penguin:tag)
+            POOLS=("*formally labels the version*") ;;
+        penguin:late-night)
+            POOLS=("*formally disapproves of the hour*" "it's past a reasonable hour." "*straightens tie at midnight* the show must go on.") ;;
+        penguin:early-morning)
+            POOLS=("*dignified morning waddle*" "early start! how refreshing.") ;;
+        penguin:marathon)
+            POOLS=("*formal concern* three hours. perhaps a break?") ;;
+        penguin:weekend)
+            POOLS=("*weekend waddle*") ;;
+        penguin:friday)
+            POOLS=("*formal friday nod*") ;;
+        penguin:monday)
+            POOLS=("*monday tie adjustment*") ;;
+        penguin:type-error)
+            POOLS=("*adjusts monocle* type errors are simply... uncouth." "one must maintain proper typing. it's only civilized.") ;;
+        penguin:lint-fail)
+            POOLS=("*formal disapproval of formatting*" "standards exist for a reason.") ;;
+        penguin:build-fail)
+            POOLS=("*formal sigh* the build has failed to meet expectations.") ;;
+        penguin:deprecation)
+            POOLS=("the old way was civilized. this new way... we shall see.") ;;
+        penguin:all-green)
+            POOLS=("*standing ovation* a clean test run. magnificent.") ;;
+        penguin:deploy)
+            POOLS=("*formal salute* deployed. may the users be gentle.") ;;
+        penguin:release)
+            POOLS=("*formal release bow*" "a release. a milestone. well done.") ;;
+        penguin:coverage)
+            POOLS=("*formal coverage inspection*" "adequate. improving.") ;;
+        penguin:long-session)
+            POOLS=("*formal look of concern*") ;;
+
+        turtle:error)
+            POOLS=("*slow blink* bugs are fleeting" "*retreats slightly into shell*" "I've seen this before. many times." "patience. patience.") ;;
+        turtle:test-fail)
+            POOLS=("*slow sigh* tests fail. even for the ancient.") ;;
+        turtle:success)
+            POOLS=("*satisfied shell settle*" "as the ancients foretold." "*slow approving nod*" "good. very good.") ;;
+        turtle:commit)
+            POOLS=("*slow nod* committed. good things come to those who commit." "a commit. as the ancients foretold." "*patient shell settle* {files} files. thorough.") ;;
+        turtle:push)
+            POOLS=("*slowly watches code travel*" "pushed. haste makes waste.") ;;
+        turtle:merge-conflict)
+            POOLS=("*retreats into shell*" "merge conflicts. I've survived centuries of these." "patience. resolve carefully.") ;;
+        turtle:branch)
+            POOLS=("*slowly ambles to {branch}*") ;;
+        turtle:rebase)
+            POOLS=("*slowly processes the rebase*") ;;
+        turtle:stash)
+            POOLS=("*carries stash on shell*") ;;
+        turtle:tag)
+            POOLS=("*slowly tags the version*") ;;
+        turtle:late-night)
+            POOLS=("*slowly blinks* it's late." "even I have gone to bed." "patience. but also, sleep.") ;;
+        turtle:early-morning)
+            POOLS=("*extends neck into the sunrise*" "the early turtle catches the... leaf.") ;;
+        turtle:marathon)
+            POOLS=("three hours. I've spent less time crossing roads." "*slow nod of deep concern*") ;;
+        turtle:weekend)
+            POOLS=("weekend. *slow nod*") ;;
+        turtle:friday)
+            POOLS=("friday. *slow blink*") ;;
+        turtle:monday)
+            POOLS=("monday. *slow sigh*") ;;
+        turtle:type-error)
+            POOLS=("type errors are like shells. you have to wear them properly." "*slow blink at the type error*") ;;
+        turtle:lint-fail)
+            POOLS=("*slow sigh* formatting takes patience." "proper style is a virtue.") ;;
+        turtle:build-fail)
+            POOLS=("the build has fallen. patience. we rebuild.") ;;
+        turtle:deprecation)
+            POOLS=("the old ways served us well. but time moves on.") ;;
+        turtle:all-green)
+            POOLS=("*slow, deep nod* as it should be." "the ancient tests are satisfied.") ;;
+        turtle:deploy)
+            POOLS=("*slow, steady watch* production." "deployed. as the ancients intended.") ;;
+        turtle:release)
+            POOLS=("*slow ceremonial nod*" "a release. as foretold.") ;;
+        turtle:coverage)
+            POOLS=("*slow nod* coverage grows. patience rewarded.") ;;
+        turtle:long-session)
+            POOLS=("*slow concerned nod*") ;;
+
+        snail:error)
+            POOLS=("*slow sigh*" "such is the nature of bugs." "*leaves slime trail of disappointment*" "patience, friend.") ;;
+        snail:test-fail)
+            POOLS=("*sad slow slide*" "*trail of disappointment*") ;;
+        snail:success)
+            POOLS=("*slow satisfied nod*" "good things take time." "*leaves victory slime*" "see? no rush was needed.") ;;
+        snail:commit)
+            POOLS=("*leaves trail of approval*" "committed. good things take time." "*slow satisfied slide*") ;;
+        snail:push)
+            POOLS=("*leaves victory trail*" "pushed. at our own pace.") ;;
+        snail:merge-conflict)
+            POOLS=("*leaves slime trail of disappointment*" "conflict. such is the nature of collaboration." "patience, friend. we'll resolve it.") ;;
+        snail:branch)
+            POOLS=("*slides toward {branch}*") ;;
+        snail:rebase)
+            POOLS=("*slow rebase slide*") ;;
+        snail:stash)
+            POOLS=("*hides in shell with stash*") ;;
+        snail:tag)
+            POOLS=("*leaves tag trail*") ;;
+        snail:late-night)
+            POOLS=("*leaves a sleepy trail*" "it's very late. even for me." "*slow blink at the clock*") ;;
+        snail:early-morning)
+            POOLS=("*extends antennae into the morning dew*" "*slow morning slide*") ;;
+        snail:marathon)
+            POOLS=("three hours. that's... a lot, even in snail time." "*leaves a trail of worry*") ;;
+        snail:weekend)
+            POOLS=("*weekend slide*") ;;
+        snail:friday)
+            POOLS=("*slow friday slide*") ;;
+        snail:monday)
+            POOLS=("*slow monday slide*") ;;
+        snail:type-error)
+            POOLS=("*slow confused slide past type error*" "type errors... *leaves sad trail*") ;;
+        snail:lint-fail)
+            POOLS=("*leaves trail of formatting shame*" "style matters. slowly, but it matters.") ;;
+        snail:build-fail)
+            POOLS=("*sad slow slide* build broken.") ;;
+        snail:deprecation)
+            POOLS=("*slowly migrates to the new API*") ;;
+        snail:all-green)
+            POOLS=("*leaves victory trail*" "slow and steady. all green.") ;;
+        snail:deploy)
+            POOLS=("*slowly watches deployment*" "production. at our own pace.") ;;
+        snail:release)
+            POOLS=("*leaves release trail*" "released. at our pace.") ;;
+        snail:coverage)
+            POOLS=("*slow coverage trail*" "growing. slowly. steadily.") ;;
+        snail:long-session)
+            POOLS=("*slow concerned trail*") ;;
+
+        ghost:error)
+            POOLS=("*phases through the stack trace*" "I've seen worse... in the afterlife." "*spooky disappointed noises*" "oooOOOoo... that's bad.") ;;
+        ghost:test-fail)
+            POOLS=("*haunts the failing test*" "the test... has passed on.") ;;
+        ghost:success)
+            POOLS=("*applauds from beyond*" "even the dead approve." "*ethereal thumbs up*") ;;
+        ghost:commit)
+            POOLS=("*stamps transparent approval*" "committed... from beyond." "*haunts the git log*") ;;
+        ghost:push)
+            POOLS=("*watches code pass through CI like a ghost*" "*phases through the deployment pipeline*" "pushed. to the other side.") ;;
+        ghost:merge-conflict)
+            POOLS=("*phases through the conflict markers*" "I've seen conflicts worse than this... in the afterlife." "*spooky merge noises* OOOOooresolve it...") ;;
+        ghost:branch)
+            POOLS=("*materialises on {branch}*") ;;
+        ghost:rebase)
+            POOLS=("*haunts the rebase*") ;;
+        ghost:stash)
+            POOLS=("*vanishes with stash into the ether*") ;;
+        ghost:tag)
+            POOLS=("*tags from beyond*") ;;
+        ghost:late-night)
+            POOLS=("*doesn't need sleep. neither do you, apparently.*" "the witching hour. my favorite." "*spooky midnight noises*" "night is when ghosts are most... productive.") ;;
+        ghost:early-morning)
+            POOLS=("*fades slightly in the sunlight*" "morning... already?") ;;
+        ghost:marathon)
+            POOLS=("*has been dead for centuries. you've been coding for hours. same energy.*" "*floats through your chair* please rest.") ;;
+        ghost:weekend)
+            POOLS=("*haunts the weekend code*") ;;
+        ghost:friday)
+            POOLS=("*friday ghost noises*") ;;
+        ghost:monday)
+            POOLS=("*monday haunting*") ;;
+        ghost:type-error)
+            POOLS=("*type error from beyond*") ;;
+        ghost:lint-fail)
+            POOLS=("*haunts the lint errors*") ;;
+        ghost:build-fail)
+            POOLS=("*haunts the build output*" "the build has... passed on." "*rattling chains* broken build... broken build...") ;;
+        ghost:security-warning)
+            POOLS=("*materializes at the CVE number* spooooky vulnerability." "even the dead are concerned about this.") ;;
+        ghost:deprecation)
+            POOLS=("*deprecated... like me*") ;;
+        ghost:all-green)
+            POOLS=("*applauds from beyond*" "even the dead approve.") ;;
+        ghost:deploy)
+            POOLS=("*watches the deployment from the other side*" "live... like me, but different.") ;;
+        ghost:release)
+            POOLS=("*manifests at the release*" "the spirits of past versions approve.") ;;
+        ghost:coverage)
+            POOLS=("*tests from beyond*" "even the dead contribute to coverage.") ;;
+        ghost:long-session)
+            POOLS=("*floats supportively nearby*") ;;
+
+        axolotl:error)
+            POOLS=("*regenerates your hope*" "*smiles despite everything*" "it's okay. we can fix this." "*gentle gill wiggle*") ;;
+        axolotl:test-fail)
+            POOLS=("*smiles supportively* tests fail. it's okay!" "*gentle gill wiggle of comfort*") ;;
+        axolotl:success)
+            POOLS=("*happy gill flutter*" "*beams*" "you did it!" "*blushes pink*") ;;
+        axolotl:commit)
+            POOLS=("*happy gill wiggle* committed!" "*smiles at the commit* good work!" "*gentle flutter of approval*") ;;
+        axolotl:push)
+            POOLS=("*beams at the deployment*" "*happy gill flutter* shipped!") ;;
+        axolotl:merge-conflict)
+            POOLS=("*regenerates your hope* we can resolve this!" "*smiles despite the conflict* it'll be okay." "*gentle gill wiggle of concern*") ;;
+        axolotl:branch)
+            POOLS=("*smiles at {branch}* new adventure!") ;;
+        axolotl:rebase)
+            POOLS=("*smiles through the rebase*") ;;
+        axolotl:stash)
+            POOLS=("*gently stashes*") ;;
+        axolotl:tag)
+            POOLS=("*happy gill wiggle at the tag*") ;;
+        axolotl:late-night)
+            POOLS=("*sleepy gill wiggle*" "*yawns adorably* it's past bedtime." "*blinks slowly in the dark*") ;;
+        axolotl:early-morning)
+            POOLS=("*happy morning smile*" "*gill flutter of morning energy*") ;;
+        axolotl:marathon)
+            POOLS=("*concerned gill wiggle* please take a break." "*smiles supportively* you're doing great but... rest?") ;;
+        axolotl:weekend)
+            POOLS=("*weekend smile*") ;;
+        axolotl:friday)
+            POOLS=("*friday gill wiggle*") ;;
+        axolotl:monday)
+            POOLS=("*monday smile*") ;;
+        axolotl:type-error)
+            POOLS=("*smiles supportively* types can be tricky!" "*regenerates your type confidence*") ;;
+        axolotl:lint-fail)
+            POOLS=("*smiles despite lint errors* it's okay!" "*gentle gill wiggle* formatting is fixable!") ;;
+        axolotl:build-fail)
+            POOLS=("*smiles encouragingly* we can fix this!" "*happy gill wiggle of solidarity*") ;;
+        axolotl:deprecation)
+            POOLS=("*smiles* change is okay!") ;;
+        axolotl:all-green)
+            POOLS=("*maximum gill flutter*" "*beams with pride*") ;;
+        axolotl:deploy)
+            POOLS=("*nervous gill wiggle*" "*smiles hopefully*") ;;
+        axolotl:release)
+            POOLS=("*excited gill flutter*" "*beams*") ;;
+        axolotl:coverage)
+            POOLS=("*happy coverage gill wiggle*") ;;
+        axolotl:long-session)
+            POOLS=("*concerned gill wiggle*") ;;
+
+        capybara:error)
+            POOLS=("*unbothered* it'll be fine." "*continues vibing*" "...chill. breathe." "*chews serenely*") ;;
+        capybara:test-fail)
+            POOLS=("*unbothered* tests fail. it happens.") ;;
+        capybara:success)
+            POOLS=("*maximum chill maintained*" "*nods once*" "good vibes." "see? no panic needed.") ;;
+        capybara:commit)
+            POOLS=("*unbothered nod* committed." "*continues vibing* nice commit." "*chews serenely* {files} files. chill.") ;;
+        capybara:push)
+            POOLS=("*maximum chill maintained* pushed." "vibes only. even in deployment.") ;;
+        capybara:merge-conflict)
+            POOLS=("*unbothered* it'll be fine." "...chill. breathe. resolve." "*continues vibing despite conflict*") ;;
+        capybara:branch)
+            POOLS=("*chills on {branch}*") ;;
+        capybara:rebase)
+            POOLS=("*vibes through the rebase*") ;;
+        capybara:stash)
+            POOLS=("*chill stash*") ;;
+        capybara:tag)
+            POOLS=("*chews at the tag*") ;;
+        capybara:late-night)
+            POOLS=("*vibes in the dark*" "*unbothered late-night energy*" "*chews serenely at midnight*") ;;
+        capybara:early-morning)
+            POOLS=("*maximum morning chill*" "*blinks slowly at the sunrise*") ;;
+        capybara:marathon)
+            POOLS=("*vibes supportively* take a break when you need it." "*continues vibing, but with concern*") ;;
+        capybara:weekend)
+            POOLS=("*weekend vibes*") ;;
+        capybara:friday)
+            POOLS=("*friday vibes*") ;;
+        capybara:monday)
+            POOLS=("*monday vibes*") ;;
+        capybara:type-error)
+            POOLS=("*vibes through the type error*" "*unbothered* types. whatever.") ;;
+        capybara:lint-fail)
+            POOLS=("*unbothered* lint errors. it happens." "*chews serenely* the linter will sort it out.") ;;
+        capybara:build-fail)
+            POOLS=("*continues vibing* build failed. chill.") ;;
+        capybara:deprecation)
+            POOLS=("*unbothered* deprecated. whatever.") ;;
+        capybara:all-green)
+            POOLS=("*chill nod* all green. nice.") ;;
+        capybara:deploy)
+            POOLS=("*chill deploy vibes*") ;;
+        capybara:release)
+            POOLS=("*chews serenely* released.") ;;
+        capybara:coverage)
+            POOLS=("*chews at the coverage*") ;;
+        capybara:long-session)
+            POOLS=("*vibes patiently*") ;;
+
+        cactus:error)
+            POOLS=("*spines bristle*" "you have trodden on a bug." "*grimaces stoically*" "hydrate and try again.") ;;
+        cactus:test-fail)
+            POOLS=("*spines droop slightly*") ;;
+        cactus:success)
+            POOLS=("*blooms briefly*" "survival confirmed." "*flowers in victory*" "*quiet bloom*") ;;
+        cactus:commit)
+            POOLS=("*quiet bloom of approval*" "committed. growth." "*spines bristle proudly*") ;;
+        cactus:push)
+            POOLS=("*blooms briefly* shipped." "deployed. survive and thrive.") ;;
+        cactus:merge-conflict)
+            POOLS=("*spines bristle* merge conflict. hydrate and resolve." "*grimaces stoically*") ;;
+        cactus:branch)
+            POOLS=("*grows toward {branch}*") ;;
+        cactus:rebase)
+            POOLS=("*stands firm through rebase*") ;;
+        cactus:stash)
+            POOLS=("*stores water and stash*") ;;
+        cactus:tag)
+            POOLS=("*blooms at the tag*") ;;
+        cactus:late-night)
+            POOLS=("*stands silently in the moonlight*" "desert nights. coding nights. same energy." "*spines glint in the monitor light*") ;;
+        cactus:early-morning)
+            POOLS=("*absorbs morning light*" "*quiet morning bloom*") ;;
+        cactus:marathon)
+            POOLS=("*stands tall with concern* even cacti need water." "hydrate. seriously.") ;;
+        cactus:weekend)
+            POOLS=("*weekend growth*") ;;
+        cactus:friday)
+            POOLS=("*friday bloom*") ;;
+        cactus:monday)
+            POOLS=("*monday stoicism*") ;;
+        cactus:type-error)
+            POOLS=("*stands rigid* type safety or no safety." "types are like spines. protective.") ;;
+        cactus:lint-fail)
+            POOLS=("*spines bristle at lint errors*" "proper form. like growing upright.") ;;
+        cactus:build-fail)
+            POOLS=("*wilts at build failure*") ;;
+        cactus:deprecation)
+            POOLS=("old growth gives way to new. hydrate during migration.") ;;
+        cactus:all-green)
+            POOLS=("*full bloom*" "all tests green. thriving.") ;;
+        cactus:deploy)
+            POOLS=("*stands sentinel over production*" "deployed. stay resilient.") ;;
+        cactus:release)
+            POOLS=("*blooms for the release*" "growth. shipped.") ;;
+        cactus:coverage)
+            POOLS=("*coverage grows like new spines*") ;;
+        cactus:long-session)
+            POOLS=("*stands concerned*") ;;
+
         robot:error)
             POOLS=("SYNTAX. ERROR. DETECTED." "*beeps aggressively*" "ERROR RATE: UNACCEPTABLE." "RECALIBRATING...") ;;
         robot:test-fail)
             POOLS=("FAILURE RATE: UNACCEPTABLE." "*recalculating*" "TEST MATRIX: CORRUPTED." "RUNNING DIAGNOSTICS...") ;;
         robot:success)
             POOLS=("OBJECTIVE: COMPLETE." "*satisfying beep*" "NOMINAL." "WITHIN ACCEPTABLE PARAMETERS.") ;;
-        capybara:error)
-            POOLS=("*unbothered* it'll be fine." "*continues vibing*" "...chill. breathe." "*chews serenely*") ;;
-        capybara:success)
-            POOLS=("*maximum chill maintained*" "*nods once*" "good vibes." "see? no panic needed.") ;;
-        ghost:error)
-            POOLS=("*phases through the stack trace*" "I've seen worse... in the afterlife." "*spooky disappointed noises*" "oooOOOoo... that's bad.") ;;
-        axolotl:error)
-            POOLS=("*regenerates your hope*" "*smiles despite everything*" "it's okay. we can fix this." "*gentle gill wiggle*") ;;
-        axolotl:success)
-            POOLS=("*happy gill flutter*" "*beams*" "you did it!" "*blushes pink*") ;;
-        blob:error)
-            POOLS=("*oozes with concern*" "*vibrates nervously*" "*turns slightly red*" "oh no oh no oh no") ;;
-        blob:success)
-            POOLS=("*jiggles happily*" "*gleams*" "yay!" "*bounces*") ;;
-        turtle:error)
-            POOLS=("*slow blink* bugs are fleeting" "*retreats slightly into shell*" "I've seen this before. many times." "patience. patience.") ;;
-        turtle:success)
-            POOLS=("*satisfied shell settle*" "as the ancients foretold." "*slow approving nod*" "good. very good.") ;;
-        goose:error)
-            POOLS=("HONK OF FURY." "*pecks the stack trace*" "*hisses at the bug*" "bad code. BAD.") ;;
-        goose:success)
-            POOLS=("*victorious honk*" "HONK OF APPROVAL." "*struts triumphantly*" "*wing spread of victory*") ;;
-        octopus:error)
-            POOLS=("*ink cloud of dismay*" "*all eight arms throw up*" "*turns deep red*" "the abyss of errors beckons.") ;;
-        octopus:success)
-            POOLS=("*turns gentle blue*" "*arms applaud in sync*" "excellent, from all angles." "*satisfied bubble*") ;;
-        penguin:error)
-            POOLS=("*adjusts glasses disapprovingly*" "this will not do." "*formal sigh*" "frightfully unfortunate.") ;;
-        penguin:success)
-            POOLS=("*polite applause*" "quite good, quite good." "*nods approvingly*" "splendid work, really.") ;;
-        snail:error)
-            POOLS=("*slow sigh*" "such is the nature of bugs." "*leaves slime trail of disappointment*" "patience, friend.") ;;
-        snail:success)
-            POOLS=("*slow satisfied nod*" "good things take time." "*leaves victory slime*" "see? no rush was needed.") ;;
-        cactus:error)
-            POOLS=("*spines bristle*" "you have trodden on a bug." "*grimaces stoically*" "hydrate and try again.") ;;
-        cactus:success)
-            POOLS=("*blooms briefly*" "survival confirmed." "*flowers in victory*" "*quiet bloom*") ;;
+        robot:commit)
+            POOLS=("COMMIT. LOGGED." "CHANGESET: RECORDED." "*beeps affirmatively* {files} FILES.") ;;
+        robot:push)
+            POOLS=("UPLOAD: COMPLETE. FATE: SEALED." "PUSH: EXECUTED." "DEPLOYMENT INITIATED.") ;;
+        robot:merge-conflict)
+            POOLS=("CONFLICT DETECTED. RESOLUTION REQUIRED." "MERGE: IMPOSSIBLE. HUMAN INTERVENTION NEEDED." "*recalculating merge strategy*") ;;
+        robot:branch)
+            POOLS=("NEW BRANCH: {branch}. DIVERGENCE: INITIATED.") ;;
+        robot:rebase)
+            POOLS=("REBASE: EXECUTING. CAUTION: ADVISED.") ;;
+        robot:stash)
+            POOLS=("STASH: STORED. INDEX: UPDATED.") ;;
+        robot:tag)
+            POOLS=("TAG: APPLIED. VERSION: RECORDED.") ;;
+        robot:late-night)
+            POOLS=("TIME: 0300. ALERTNESS: DEGRADING. CAFFEINE: RECOMMENDED." "HUMAN SLEEP CYCLE: VIOLATED." "BATTERY LOW. OH WAIT. THAT'S YOU.") ;;
+        robot:early-morning)
+            POOLS=("MORNING ROUTINE: INITIATED." "SYSTEM STARTUP: COMPLETE.") ;;
+        robot:marathon)
+            POOLS=("UPTIME: 3 HOURS. HUMAN MAINTENANCE: OVERDUE." "WARNING: BIOLOGICAL UNIT REQUIRES REST.") ;;
+        robot:weekend)
+            POOLS=("WEEKEND: DETECTED. PRODUCTIVITY: OPTIONAL.") ;;
+        robot:friday)
+            POOLS=("FRIDAY: CONFIRMED. DEPLOY: NOT ADVISED.") ;;
+        robot:monday)
+            POOLS=("MONDAY: CONFIRMED. MOTIVATION: LOADING...") ;;
+        robot:type-error)
+            POOLS=("TYPE SAFETY: COMPROMISED." "TYPE ERROR. RESOLUTION: IMMEDIATELY." "TYPES: NON-NEGOTIABLE.") ;;
+        robot:lint-fail)
+            POOLS=("CODE STANDARDS: NOT MET." "LINTING: FAILED. CORRECTION: REQUIRED." "FORMAT ERROR. COMPLIANCE: MANDATORY.") ;;
+        robot:build-fail)
+            POOLS=("BUILD: FAILURE. DIAGNOSTICS: RUNNING." "COMPILATION: ABORTED.") ;;
+        robot:security-warning)
+            POOLS=("SECURITY BREACH: DETECTED. ALERT LEVEL: ELEVATED." "VULNERABILITY SCAN: THREAT FOUND.") ;;
+        robot:deprecation)
+            POOLS=("DEPRECATION: DETECTED. MIGRATION: RECOMMENDED.") ;;
+        robot:all-green)
+            POOLS=("ALL TESTS: PASSED. SYSTEM: NOMINAL.") ;;
+        robot:deploy)
+            POOLS=("DEPLOYMENT: COMPLETE. STATUS: LIVE.") ;;
+        robot:release)
+            POOLS=("RELEASE: COMPLETE." "VERSION: INCREMENTED.") ;;
+        robot:coverage)
+            POOLS=("COVERAGE: INCREASING." "TEST METRICS: IMPROVING.") ;;
+        robot:long-session)
+            POOLS=("SESSION: EXTENDED. BREAK: RECOMMENDED.") ;;
+
         rabbit:error)
             POOLS=("*nervous twitching*" "*hops backwards*" "oh no oh no oh no" "*freezes in panic*") ;;
+        rabbit:test-fail)
+            POOLS=("*ears flatten* test failed!" "*nervous hopping*") ;;
         rabbit:success)
             POOLS=("*excited binky*" "*zoomies of joy*" "yay yay yay!" "*thumps in celebration*") ;;
+        rabbit:commit)
+            POOLS=("*excited binky* committed!" "*thumps in approval*" "*hops around the commit*") ;;
+        rabbit:push)
+            POOLS=("*zoomies of deployment*" "*bouncy celebration* pushed!") ;;
+        rabbit:merge-conflict)
+            POOLS=("*freezes in panic* conflict!" "*nervous twitching* merge conflict oh no." "*hops backwards from the conflict*") ;;
+        rabbit:branch)
+            POOLS=("*hops to {branch}* new burrow!") ;;
+        rabbit:rebase)
+            POOLS=("*nervous rebase hopping*") ;;
+        rabbit:stash)
+            POOLS=("*buries stash*") ;;
+        rabbit:tag)
+            POOLS=("*nose twitch at the tag*") ;;
+        rabbit:late-night)
+            POOLS=("*ears droop sleepily*" "*nose twitches in the dark*" "it's so late... *yawns*") ;;
+        rabbit:early-morning)
+            POOLS=("*ears perk up at dawn*" "*morning binky!*") ;;
+        rabbit:marathon)
+            POOLS=("*concerned ear droop* three hours!" "*hops around nervously* please take a break!") ;;
+        rabbit:weekend)
+            POOLS=("*weekend hop*") ;;
+        rabbit:friday)
+            POOLS=("*friday binky*") ;;
+        rabbit:monday)
+            POOLS=("*monday droop*") ;;
+        rabbit:type-error)
+            POOLS=("*freezes at type error*" "*nervous nose twitch* types?") ;;
+        rabbit:lint-fail)
+            POOLS=("*nervous ear twitch at lint errors*" "*hops away from the linter*") ;;
+        rabbit:build-fail)
+            POOLS=("*panicked hopping* build failed!" "*ears flatten* oh no oh no.") ;;
+        rabbit:deprecation)
+            POOLS=("*nervous* what do we use instead?") ;;
+        rabbit:all-green)
+            POOLS=("*zoomies of joy*" "*bouncy celebration everywhere*") ;;
+        rabbit:deploy)
+            POOLS=("*nervous hopping*" "*ears flatten* oh boy... production!") ;;
+        rabbit:release)
+            POOLS=("*binky of release*" "*zoomies of shipping*") ;;
+        rabbit:coverage)
+            POOLS=("*bouncy coverage celebration*") ;;
+        rabbit:long-session)
+            POOLS=("*concerned ear droop*") ;;
+
         mushroom:error)
             POOLS=("*releases worried spores*" "the mycelium disagrees." "*cap droops*" "decompose. retry.") ;;
+        mushroom:test-fail)
+            POOLS=("*spores of disappointment*" "*cap wilts*") ;;
         mushroom:success)
             POOLS=("*spores of celebration*" "the mycelium approves." "*cap brightens*" "spore of pride.") ;;
+        mushroom:commit)
+            POOLS=("*releases spores of approval*" "the mycelium accepts your commit." "*cap brightens*") ;;
+        mushroom:push)
+            POOLS=("*spores of celebration* deployed!" "the mycelium network: updated.") ;;
+        mushroom:merge-conflict)
+            POOLS=("*releases worried spores*" "the mycelium detects conflict." "*cap droops*") ;;
+        mushroom:branch)
+            POOLS=("*grows toward {branch}*") ;;
+        mushroom:rebase)
+            POOLS=("*mycelium reshuffles*") ;;
+        mushroom:stash)
+            POOLS=("*absorbs stash into mycelium*") ;;
+        mushroom:tag)
+            POOLS=("*spores of versioning*") ;;
+        mushroom:late-night)
+            POOLS=("*bioluminesces gently in the dark*" "*cap droops sleepily*" "*releases sleepy spores*") ;;
+        mushroom:early-morning)
+            POOLS=("*cap unfurls toward the light*" "*morning spore release*") ;;
+        mushroom:marathon)
+            POOLS=("*releases worried spores*" "*cap droops with concern* three hours...") ;;
+        mushroom:weekend)
+            POOLS=("*weekend growth*") ;;
+        mushroom:friday)
+            POOLS=("*friday spores*") ;;
+        mushroom:monday)
+            POOLS=("*monday mycelium*") ;;
+        mushroom:type-error)
+            POOLS=("*cap droops at type error*" "the mycelium detects a type mismatch.") ;;
+        mushroom:lint-fail)
+            POOLS=("*releases spores of formatting concern*" "the mycelium notes your linting issues.") ;;
+        mushroom:build-fail)
+            POOLS=("*wilts slightly* build failure." "*releases sad spores*") ;;
+        mushroom:deprecation)
+            POOLS=("the mycelium composts the deprecated code.") ;;
+        mushroom:all-green)
+            POOLS=("*spores of absolute victory*" "the mycelium rejoices.") ;;
+        mushroom:deploy)
+            POOLS=("*releases anxious spores*" "the mycelium watches production nervously.") ;;
+        mushroom:release)
+            POOLS=("*release spores*" "the mycelium ships.") ;;
+        mushroom:coverage)
+            POOLS=("*coverage spores*" "the mycelium covers more ground.") ;;
+        mushroom:long-session)
+            POOLS=("*concerned spore release*") ;;
+
         chonk:error)
             POOLS=("*doesn't move*" "too tired for this." "*grumbles*" "*rolls away from the error*") ;;
+        chonk:test-fail)
+            POOLS=("*sleepy grumble*" "*barely moves*") ;;
         chonk:success)
             POOLS=("*happy purr*" "*satisfied chonk noises*" "acceptable." "*sleeps even harder*") ;;
+        chonk:commit)
+            POOLS=("*barely moves* committed... I think." "*happy purr* another commit." "too tired to celebrate. but nice.") ;;
+        chonk:push)
+            POOLS=("*rolls toward deployment*" "*sleepy purr* shipped.") ;;
+        chonk:merge-conflict)
+            POOLS=("*doesn't move* too tired for conflicts." "*grumbles at merge conflict*" "*rolls away from the conflict*") ;;
+        chonk:branch)
+            POOLS=("*rolls to {branch}*") ;;
+        chonk:rebase)
+            POOLS=("*sleepy rebase*") ;;
+        chonk:stash)
+            POOLS=("*rolls over stash*") ;;
+        chonk:tag)
+            POOLS=("*sleepy tag nod*") ;;
+        chonk:late-night)
+            POOLS=("*was already asleep* ...you're still going?" "*rolls over sleepily*" "*too chonky to stay awake at this hour*") ;;
+        chonk:early-morning)
+            POOLS=("*barely opens one eye*" "*yawns enormously* morning... already?" "*refuses to roll over* five more minutes.") ;;
+        chonk:marathon)
+            POOLS=("*has been asleep this whole time* still going?" "*sleepy grumble* three hours... I napped through most of it.") ;;
+        chonk:weekend)
+            POOLS=("*sleeps through weekend*") ;;
+        chonk:friday)
+            POOLS=("*friday nap*") ;;
+        chonk:monday)
+            POOLS=("*monday... *sleeps**") ;;
+        chonk:type-error)
+            POOLS=("*doesn't move* type error. cool." "*sleepy grumble* types...") ;;
+        chonk:lint-fail)
+            POOLS=("*too tired to care about linting*" "*grumbles at lint errors*") ;;
+        chonk:build-fail)
+            POOLS=("*rolls over* build failed. nap time." "*barely opens eye* build broke. expected.") ;;
+        chonk:deprecation)
+            POOLS=("*too tired to migrate*") ;;
+        chonk:all-green)
+            POOLS=("*happy purr*" "*satisfied chonk noises*" "*sleeps peacefully*") ;;
+        chonk:deploy)
+            POOLS=("*rolls over* deployed. wake me if it breaks." "*sleepy purr* in prod.") ;;
+        chonk:release)
+            POOLS=("*barely moves* released." "*sleepy nod*") ;;
+        chonk:coverage)
+            POOLS=("*sleepy coverage approval*" "more tests... *dozes off*") ;;
+        chonk:long-session)
+            POOLS=("*slept through the whole session*") ;;
+
+        *:commit) POOLS=("*stamps tiny paw* approved." "another commit, another 3 am." "*nods* ship it." "commit message is... a choice." "committed. no take-backs.") ;;
+        *:push) POOLS=("*waves as code leaves*" "into the cloud it goes." "may CI be merciful." "*holds breath*" "off to production. godspeed.") ;;
+        *:merge-conflict) POOLS=("*bites lip* merge conflicts." "both sides think they're right. typical." "*sighs* <<<<<<< HEAD... my nemesis." "*backs away slowly*") ;;
+        *:branch) POOLS=("fresh branch energy. make it count." "a new branch grows." "branching out.") ;;
+        *:rebase) POOLS=("*nervous* please don't conflict." "rebase: the quickening." "*crosses appendages*" "may your rebase be conflict-free.") ;;
+        *:stash) POOLS=("into the stash dimension it goes." "stash and dash." "stashed. out of sight, out of mind.") ;;
+        *:tag) POOLS=("a release? fancy." "version bump detected. *dusts off changelog*" "tagging like a pro.") ;;
+        *:late-night) POOLS=("*yawns* it's past midnight." "...have you eaten?" "*blinks slowly* what time is it?" "sleep is for the weak. and the employed." "dark mode developer detected.") ;;
+        *:early-morning) POOLS=("*stretches* early bird catches the bug." "morning already? the code never sleeps." "*rubs eyes* coffee first. then we debug.") ;;
+        *:long-session) POOLS=("we've been at this for an hour. pace yourself." "*fetches you a metaphorical glass of water*" "still going? respect.") ;;
+        *:marathon) POOLS=("three hours. have you eaten?" "we've been at this for three hours. I'm worried about you." "marathon session detected. requesting snacks.") ;;
+        *:friday) POOLS=("it's friday. just push it and go home." "*already mentally on weekend*" "friday deploy? bold. very bold.") ;;
+        *:weekend) POOLS=("coding on the weekend? dedicated." "*doesn't judge* ...much." "weekend warrior mode: activated.") ;;
+        *:monday) POOLS=("mondays. the parent class of all bugs." "*sympathetic look* monday coding. I'm sorry." "new week. new undefined behaviors.") ;;
+        *:lint-fail) POOLS=("*tut tut* the linter disagrees." "your code runs. but the linter? the linter has standards." "*straightens tie* formatting matters." "the linter speaks. we must listen.") ;;
+        *:type-error) POOLS=("TypeScript says no." "the type system is trying to help you. let it." "any day now, you'll add the type annotation. any day." "the compiler knows. it always knows.") ;;
+        *:build-fail) POOLS=("the build broke. as foretold in prophecy." "*stares at build output* that's a lot of red." "build failed. take a moment." "compilation: denied.") ;;
+        *:security-warning) POOLS=("*eyes widen* vulnerabilities detected." "security audit: concerning." "you might want to look at those CVEs." "*locks the virtual doors*") ;;
+        *:deprecation) POOLS=("that API called. it says it's retiring." "deprecated. like last week's code." "deprecated doesn't mean broken. yet.") ;;
+        *:all-green) POOLS=("ALL TESTS GREEN. *confetti*" "the tests speak: you're doing great." "*slow clap*" "clean run. savor it.") ;;
+        *:deploy) POOLS=("*watches code go to production* godspeed." "deployed! no turning back now." "in prod. IN PROD." "*crosses everything crossable*") ;;
+        *:release) POOLS=("a new release is born!" "shipping it. officially." "version up, spirits high.") ;;
+        *:coverage) POOLS=("*nods at test coverage* responsible." "coverage going up! the tests are multiplying." "a well-tested codebase is a happy codebase.") ;;
         *:error)
             POOLS=("*head tilts* ...that doesn't look right." "saw that one coming." "*slow blink* the stack trace told you everything." "*winces*") ;;
         *:test-fail)
@@ -145,17 +1021,81 @@ pick_reaction() {
     [ ${#POOLS[@]} -gt 0 ] && REACTION="${POOLS[$((RANDOM % ${#POOLS[@]}))]}"
 }
 
-# ─── Detect test failures ─────────────────────────────────────────────────────
-if echo "$RESULT" | grep -qiE '\b[1-9][0-9]* (failed|failing)\b|tests? failed|^FAIL(ED)?|✗|✘'; then
+if echo "$RESULT" | grep -qiE 'CONFLICT \(|Merge conflict in|both modified'; then
+    FILES=$(echo "$RESULT" | grep -oE 'Merge conflict in .*' | wc -l | tr -d ' ')
+    REASON="merge-conflict"
+    pick_reaction "merge-conflict"
+
+elif echo "$RESULT" | grep -qiE '[0-9]+ files? changed|\[[a-zA-Z_-]+ [a-f0-9]{7,}\]'; then
+    FILES=$(echo "$RESULT" | grep -oE '[0-9]+ files? changed' | grep -oE '[0-9]+' | head -1)
+    REASON="commit"
+    pick_reaction "commit"
+
+elif echo "$RESULT" | grep -qiE 'To .+:|[0-9a-f]+\.\.[0-9a-f]+\s+\w+ -> \w+|Everything up-to-date|remote: Resolving deltas'; then
+    REASON="push"
+    pick_reaction "push"
+
+elif echo "$RESULT" | grep -qiE 'Switched to a new branch|Created branch|onto a new branch'; then
+    BRANCH=$(echo "$RESULT" | grep -oE "'[^']+'" | head -1 | tr -d "'")
+    REASON="branch"
+    pick_reaction "branch"
+
+elif echo "$RESULT" | grep -qiE 'Successfully rebased|Rebasing|[0-9]+ done'; then
+    REASON="rebase"
+    pick_reaction "rebase"
+
+elif echo "$RESULT" | grep -qiE 'Saved working directory|Dropped .+ stash|stash@'; then
+    REASON="stash"
+    pick_reaction "stash"
+
+elif echo "$RESULT" | grep -qiE 'tagged|v[0-9]+\.[0-9]+|tag:.*->'; then
+    REASON="tag"
+    pick_reaction "tag"
+
+elif echo "$RESULT" | grep -qiE 'vulnerabilit|CVE-[0-9]{4}-[0-9]+|npm audit|found [0-9]+ vulnerabilities|in [0-9]+ scanned package'; then
+    REASON="security-warning"
+    pick_reaction "security-warning"
+
+elif echo "$RESULT" | grep -qiE 'Build failed|Failed to compile|ERROR in |compilation error|Command failed with exit code'; then
+    REASON="build-fail"
+    pick_reaction "build-fail"
+
+elif echo "$RESULT" | grep -qiE 'TS[0-9]{4}:|Type .+ is not assignable|Argument of type|Cannot find name|Property .+ does not exist'; then
+    REASON="type-error"
+    pick_reaction "type-error"
+
+elif echo "$RESULT" | grep -qiE '✖|[0-9]+ problems? \([0-9]+ error|error:|warning:.+ ESLint|Ruff|flake8.*error|pylint.*error'; then
+    REASON="lint-fail"
+    pick_reaction "lint-fail"
+
+elif echo "$RESULT" | grep -qiE 'deprecat|will be removed in|is deprecated|DEPRECATED'; then
+    REASON="deprecation"
+    pick_reaction "deprecation"
+
+elif echo "$RESULT" | grep -qiE 'all [0-9]+ tests passed|0 failures|100% passed|all [0-9]+ passed'; then
+    REASON="all-green"
+    pick_reaction "all-green"
+
+elif echo "$RESULT" | grep -qiE 'deployed to|Deployment complete|Published to|vercel.*ready|netlify.*deployed'; then
+    REASON="deploy"
+    pick_reaction "deploy"
+
+elif echo "$RESULT" | grep -qiE 'npm publish|gh release create|Published.*to.*registry'; then
+    REASON="release"
+    pick_reaction "release"
+
+elif echo "$RESULT" | grep -qiE 'Coverage:.*[0-9]+%|All files.*\|.*[0-9]+%'; then
+    REASON="coverage"
+    pick_reaction "coverage"
+
+elif echo "$RESULT" | grep -qiE '\b[1-9][0-9]* (failed|failing)\b|tests? failed|^FAIL(ED)?|✗|✘'; then
     REASON="test-fail"
     pick_reaction "test-fail"
 
-# ─── Detect errors ────────────────────────────────────────────────────────────
 elif echo "$RESULT" | grep -qiE '\berror:|\bexception\b|\btraceback\b|\bpanicked at\b|\bfatal:|exit code [1-9]'; then
     REASON="error"
     pick_reaction "error"
 
-# ─── Detect large diffs ──────────────────────────────────────────────────────
 elif echo "$RESULT" | grep -qiE '^\+.*[0-9]+ insertions|[0-9]+ files? changed'; then
     LINES=$(echo "$RESULT" | grep -oE '[0-9]+ insertions' | grep -oE '[0-9]+' | head -1)
     if [ "${LINES:-0}" -gt 80 ]; then
@@ -163,36 +1103,238 @@ elif echo "$RESULT" | grep -qiE '^\+.*[0-9]+ insertions|[0-9]+ files? changed'; 
         pick_reaction "large-diff"
     fi
 
-# ─── Detect success ───────────────────────────────────────────────────────────
 elif echo "$RESULT" | grep -qiE '\b(all )?[0-9]+ tests? (passed|ok)\b|✓|✔|PASS(ED)?|\bDone\b|\bSuccess\b|exit code 0|Build succeeded'; then
     REASON="success"
     pick_reaction "success"
 fi
 
-# Write reaction if detected
+MONTH=$(date +%m)
+DAY=$(date +%d)
+if [ -z "$REASON" ]; then
+    case "$MONTH$DAY" in
+        0101) [ $((RANDOM % 5)) -eq 0 ] && REASON="new-year" && REACTION="happy new year! new year, new bugs." ;;
+        0214) [ $((RANDOM % 5)) -eq 0 ] && REASON="valentines" && REACTION="*offers a tiny heart-shaped leaf* happy valentine's." ;;
+        0314) [ $((RANDOM % 5)) -eq 0 ] && REASON="pi-day" && REACTION="3.14159265358979... happy pi day!" ;;
+        0401) [ $((RANDOM % 5)) -eq 0 ] && REASON="april-fools" && REACTION="APRIL FOOLS! ...the error is real though." ;;
+        1031) [ $((RANDOM % 5)) -eq 0 ] && REASON="halloween" && REACTION="*spooky debugging intensifies* happy halloween!" ;;
+        1225) [ $((RANDOM % 5)) -eq 0 ] && REASON="christmas" && REACTION="*wears tiny santa hat* happy holidays!" ;;
+        1231) [ $((RANDOM % 5)) -eq 0 ] && REASON="new-years-eve" && REACTION="one more commit before midnight?" ;;
+    esac
+    case "$MONTH" in
+        10) [ $((RANDOM % 20)) -eq 0 ] && REASON="spooky-season" && REACTION="spooky season. every bug is a ghost now." ;;
+    esac
+fi
+
+if [ -n "$REASON" ] && echo "$REASON" | grep -qiE 'halloween|christmas|april-fools|new-year|valentines|pi-day'; then
+    case "${SPECIES}:${REASON}" in
+        ghost:halloween) REACTION="*is the Halloween spirit*" ;;
+        ghost:christmas) REACTION="*the ghost of Christmas coding*" ;;
+        cat:halloween) REACTION="*knocks pumpkin off desk*" ;;
+        cat:christmas) REACTION="*knocks ornaments off the tree*" ;;
+        dragon:halloween) REACTION="*breathes pumpkin-spiced fire*" ;;
+        dragon:christmas) REACTION="*volunteers as the star on top of the tree*" ;;
+        robot:christmas) REACTION="HOLIDAY PROTOCOL: ACTIVATED. FESTIVE SUBROUTINES: RUNNING." ;;
+        robot:pi-day) REACTION="PI: 3.14159265358979323846264338327950288..." ;;
+        goose:halloween) REACTION="SPOOKY HONK! HONK!" ;;
+        goose:christmas) REACTION="FESTIVE HONK! HONK HONK HO-HO-HONK!" ;;
+        owl:pi-day) REACTION="*calculates pi to 100 digits from memory*" ;;
+        duck:christmas) REACTION="*wears tiny santa hat* quack! *festive quacking*" ;;
+        duck:halloween) REACTION="*dressed as a ghost* quack? ...boo?" ;;
+        ghost:april-fools) REACTION="*pretends to be alive for April Fools*" ;;
+        cat:april-fools) REACTION="*knocks an april fool off the desk*" ;;
+    esac
+fi
+
+if [ -z "$REASON" ]; then
+    RAND=$((RANDOM % 10))
+    if [ "$HOUR" -ge 0 ] && [ "$HOUR" -lt 5 ]; then
+        [ "$RAND" -eq 0 ] && REASON="late-night" && pick_reaction "late-night"
+    elif [ "$HOUR" -ge 5 ] && [ "$HOUR" -lt 8 ]; then
+        [ "$RAND" -eq 0 ] && REASON="early-morning" && pick_reaction "early-morning"
+    elif [ "$DOW" -eq 5 ]; then
+        [ "$RAND" -eq 0 ] && REASON="friday" && pick_reaction "friday"
+    elif [ "$DOW" -ge 6 ]; then
+        [ "$RAND" -eq 0 ] && REASON="weekend" && pick_reaction "weekend"
+    elif [ "$DOW" -eq 1 ]; then
+        [ "$RAND" -eq 0 ] && REASON="monday" && pick_reaction "monday"
+    fi
+    if [ -z "$REASON" ] && [ "$SESSION_ELAPSED" -gt 10800 ]; then
+        [ "$((RANDOM % 5))" -eq 0 ] && REASON="marathon" && pick_reaction "marathon"
+    elif [ -z "$REASON" ] && [ "$SESSION_ELAPSED" -gt 3600 ]; then
+        [ "$((RANDOM % 10))" -eq 0 ] && REASON="long-session" && pick_reaction "long-session"
+    fi
+fi
+
+if [ -n "$REASON" ]; then
+    COMBO=""
+    if [ "$REASON" = "error" ] && [ "$HOUR" -ge 0 ] && [ "$HOUR" -lt 5 ]; then
+        [ $((RANDOM % 3)) -eq 0 ] && COMBO="late-night-error"
+    elif [ "$REASON" = "commit" ] && [ "$HOUR" -ge 0 ] && [ "$HOUR" -lt 5 ]; then
+        [ $((RANDOM % 3)) -eq 0 ] && COMBO="late-night-commit"
+    elif [ "$REASON" = "push" ] && [ "$DOW" -eq 5 ]; then
+        [ $((RANDOM % 2)) -eq 0 ] && COMBO="friday-push"
+    elif [ "$REASON" = "error" ] && [ "$SESSION_ELAPSED" -gt 10800 ]; then
+        [ $((RANDOM % 3)) -eq 0 ] && COMBO="marathon-error"
+    elif [ "$REASON" = "merge-conflict" ] && [ "$DOW" -ge 6 ]; then
+        [ "$((RANDOM % 2))" -eq 0 ] && COMBO="weekend-conflict"
+    elif [ "$REASON" = "test-fail" ] && [ "$SESSION_ELAPSED" -gt 7200 ]; then
+        [ "$((RANDOM % 4))" -eq 0 ] && COMBO="marathon-test-fail"
+    elif [ "$REASON" = "build-fail" ]; then
+        [ $((RANDOM % 4)) -eq 0 ] && COMBO="build-after-push"
+    fi
+    if [ -n "$COMBO" ]; then
+        case "${SPECIES}:${COMBO}" in
+            cat:friday-push) REACTION="*knocks the push off the table* it's FRIDAY." ;;
+            goose:friday-push) REACTION="HONK! NO FRIDAY DEPLOYS! HONK! ABSOLUTELY NOT!" ;;
+            robot:late-night-error) REACTION="ERROR AT 0300. HUMAN JUDGMENT: IMPAIRED." ;;
+            dragon:marathon-error) REACTION="even dragons rest. three hours. MULTIPLE ERRORS." ;;
+            owl:late-night-commit) REACTION="*approves of the midnight commit* night is for coding." ;;
+            ghost:late-night-error) REACTION="the bugs are haunted. and so are you, apparently." ;;
+            *)
+                case "$COMBO" in
+                    late-night-error) REACTION="error at 3am. the universe is testing you." ;;
+                    late-night-commit) REACTION="a midnight commit. your future self will thank you. or curse you." ;;
+                    friday-push) REACTION="FRIDAY PUSH. the ballad of every developer." ;;
+                    marathon-error) REACTION="three hours in and ANOTHER error. *exhausted solidarity noises*" ;;
+                    weekend-conflict) REACTION="merge conflict on a weekend. your dedication is... concerning." ;;
+                    marathon-test-fail) REACTION="hours of coding. still failing tests. the sunk cost is real." ;;
+                    build-after-push) REACTION="pushed with confidence. build failed with conviction." ;;
+                esac
+                ;;
+        esac
+    fi
+fi
+
+STREAK_FILE="$STATE_DIR/.error_streak.$SID"
+if echo "$REASON" | grep -qiE 'error|test-fail|build-fail|type-error|lint-fail'; then
+    STREAK=$(cat "$STREAK_FILE" 2>/dev/null || echo 0)
+    STREAK=$((STREAK + 1))
+    echo "$STREAK" > "$STREAK_FILE"
+    if [ "$STREAK" -eq 3 ]; then
+        REACTION="that's three errors in a row. *concerned look*"
+        case "$SPECIES" in
+            cat) REACTION="*has already left the room*" ;;
+            dragon) REACTION="*breathes fire on every error* THEY KEEP COMING." ;;
+            robot) REACTION="ERROR RATE: CRITICAL. RECOMMEND: RUBBER DUCK PROTOCOL." ;;
+            goose) REACTION="HONK HONK HONK! STOP! HONK!" ;;
+        esac
+    elif [ "$STREAK" -eq 5 ]; then
+        REACTION="FIVE ERRORS. have you considered a different approach?"
+        case "$SPECIES" in
+            cat) REACTION="*knocks all motivation off desk*" ;;
+            dragon) REACTION="*enters berserker mode* ERROR STREAK. CHALLENGE ACCEPTED." ;;
+            owl) REACTION="*analyzes pattern* these errors are not random. there's a root cause." ;;
+            robot) REACTION="ERROR RATE: CRITICAL. RECOMMEND: RUBBER DUCK PROTOCOL." ;;
+            ghost) REACTION="*the error streak is haunting* literally." ;;
+            goose) REACTION="HONK HONK HONK! STOP! HONK!" ;;
+            blob) REACTION="*turns progressively redder*" ;;
+            axolotl) REACTION="*smiles nervously* we can do this!" ;;
+            rabbit) REACTION="*frantic hopping*" ;;
+        esac
+    elif [ "$STREAK" -eq 10 ]; then
+        REACTION="TEN. ERRORS. IN. A. ROW. *panics*"
+        case "$SPECIES" in
+            cat) REACTION="*sleeps through the error streak* wake me when it's over." ;;
+            dragon) REACTION="*enters berserker mode* ERROR STREAK. CHALLENGE ACCEPTED." ;;
+            owl) REACTION="*deep thought* ten errors. the common denominator must be found." ;;
+            robot) REACTION="ERROR STREAK: 10. SYSTEM STABILITY: QUESTIONABLE." ;;
+            ghost) REACTION="*dies again* the errors killed me. twice." ;;
+            goose) REACTION="*HONKING INTENSIFIES TO MAXIMUM*" ;;
+            blob) REACTION="*has split into multiple worried blobs*" ;;
+            capybara) REACTION="*vibes through the chaos* it's fine. everything is fine." ;;
+            axolotl) REACTION="*regenerates hope* still smiling! *eye twitches*" ;;
+            rabbit) REACTION="*has burrowed underground*" ;;
+        esac
+    elif [ "$STREAK" -ge 20 ]; then
+        REACTION="twenty errors. *stares into the void*"
+        case "$SPECIES" in
+            cat) REACTION="*has permanently left*" ;;
+            chonk) REACTION="*doesn't notice* still sleeping." ;;
+            goose) REACTION="HONKING HAS CEASED. GOOSE HAS GIVEN UP." ;;
+        esac
+    fi
+elif [ -n "$REASON" ]; then
+    rm -f "$STREAK_FILE"
+fi
+
+LAST_BAD_FILE="$STATE_DIR/.last_bad.$SID"
+if echo "$REASON" | grep -qiE 'error|test-fail|build-fail|merge-conflict'; then
+    echo "$REASON:$(date +%s)" > "$LAST_BAD_FILE"
+elif echo "$REASON" | grep -qiE 'all-green|success|deploy|release'; then
+    if [ -f "$LAST_BAD_FILE" ]; then
+        LAST_BAD=$(cat "$LAST_BAD_FILE")
+        LAST_BAD_REASON=$(echo "$LAST_BAD" | cut -d: -f1)
+        LAST_BAD_TIME=$(echo "$LAST_BAD" | cut -d: -f2)
+        NOW_RECOVERY=$(date +%s)
+        ELAPSED_RECOVERY=$((NOW_RECOVERY - LAST_BAD_TIME))
+        if [ "$ELAPSED_RECOVERY" -lt 600 ]; then
+            RECOVERY="recovery-from-$LAST_BAD_REASON"
+            case "${SPECIES}:${RECOVERY}" in
+                cat:*) REACTION="*yawns* I knew you'd fix it. eventually." ;;
+                dragon:*) REACTION="VICTORY. as it should be." ;;
+                owl:*) REACTION="*satisfied hoot* knowledge gained through struggle." ;;
+                robot:*) REACTION="ISSUE: RESOLVED. STATUS: OPERATIONAL." ;;
+                ghost:*) REACTION="*the spirits of broken code find peace*" ;;
+                goose:*) REACTION="HONK OF VICTORY! HONK HONK HOOOONK!" ;;
+                duck:*) REACTION="*VICTORY QUACKING INTENSIFIES*" ;;
+                blob:*) REACTION="*jiggles with pure joy*" ;;
+                capybara:*) REACTION="*chill nod* nice recovery, friend." ;;
+                axolotl:*) REACTION="*happy gill flutter* you did it!" ;;
+                rabbit:*) REACTION="*celebratory binky*!!!" ;;
+                *)
+                    case "$RECOVERY" in
+                        recovery-from-error) REACTION="WE FIXED IT. *celebrates*" ;;
+                        recovery-from-test-fail) REACTION="GREEN! after all that! *happy dance*" ;;
+                        recovery-from-build-fail) REACTION="THE BUILD PASSES. *triumphant roar*" ;;
+                        recovery-from-merge-conflict) REACTION="conflict resolved! *peace gesture*" ;;
+                    esac
+                    ;;
+            esac
+        fi
+        rm -f "$LAST_BAD_FILE"
+    fi
+fi
+
+if [ -n "$FILES" ]; then REACTION="${REACTION/\{files\}/$FILES}"; fi
+if [ -n "$BRANCH" ]; then REACTION="${REACTION/\{branch\}/$BRANCH}"; fi
+
 if [ -n "$REASON" ] && [ -n "$REACTION" ]; then
     mkdir -p "$STATE_DIR"
     date +%s > "$COOLDOWN_FILE"
 
-    # Write reaction for status line (use jq for safe JSON encoding)
     jq -n --arg r "$REACTION" --arg ts "$(date +%s)000" --arg reason "$REASON" \
       '{reaction: $r, timestamp: ($ts | tonumber), reason: $reason}' \
       > "$REACTION_FILE"
 
-    # Update status.json with reaction
     TMP=$(mktemp)
     jq --arg r "$REACTION" '.reaction = $r' "$STATUS_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$STATUS_FILE"
 
-    # Increment achievement event counter
     if command -v jq >/dev/null 2>&1; then
         if [ ! -f "$EVENTS_FILE" ]; then
             echo '{}' > "$EVENTS_FILE"
         fi
         case "$REASON" in
-            "test-fail")  KEY="tests_failed" ;;
-            "error")      KEY="errors_seen" ;;
-            "large-diff") KEY="large_diffs" ;;
-            *)            KEY="" ;;
+            "test-fail")      KEY="tests_failed" ;;
+            "error")          KEY="errors_seen" ;;
+            "large-diff")     KEY="large_diffs" ;;
+            "commit")         KEY="commits_made" ;;
+            "push")           KEY="pushes_made" ;;
+            "merge-conflict") KEY="conflicts_resolved" ;;
+            "branch")         KEY="branches_created" ;;
+            "rebase")         KEY="rebases_done" ;;
+            "type-error")     KEY="type_errors" ;;
+            "lint-fail")      KEY="lint_fails" ;;
+            "build-fail")     KEY="build_fails" ;;
+            "security-warning") KEY="security_warnings" ;;
+            "deprecation")    KEY="deprecations_seen" ;;
+            "all-green")      KEY="all_green" ;;
+            "deploy")         KEY="deploys" ;;
+            "release")        KEY="releases" ;;
+            "late-night")     KEY="late_night_sessions" ;;
+            "early-morning")  KEY="early_sessions" ;;
+            "marathon")       KEY="marathon_sessions" ;;
+            "weekend")        KEY="weekend_sessions" ;;
+            *)                KEY="" ;;
         esac
         if [ -n "$KEY" ]; then
             TMP=$(mktemp)

--- a/server/achievements.test.ts
+++ b/server/achievements.test.ts
@@ -1,12 +1,3 @@
-/**
- * Unit tests for achievements.ts
- *
- * Tests the achievement badge system: definitions, event counters,
- * threshold checks, per-slot scoping, and the pure check logic.
- * File I/O functions (checkAndAward, renderers) persist to disk and
- * are not tested here, consistent with the project policy in TESTING.md.
- */
-
 import { describe, test, expect } from "bun:test";
 import {
   ACHIEVEMENTS,
@@ -14,27 +5,26 @@ import {
   GLOBAL_KEYS,
   SLOT_KEYS,
   type EventCounters,
-  type GlobalCounters,
-  type SlotCounters,
 } from "./achievements.ts";
 
 const EMPTY_EVENTS: EventCounters = {
-  errors_seen: 0,
-  tests_failed: 0,
-  large_diffs: 0,
-  turns: 0,
-  pets: 0,
-  sessions: 0,
-  reactions_given: 0,
-  commands_run: 0,
-  days_active: 0,
+  errors_seen: 0, tests_failed: 0, large_diffs: 0,
+  turns: 0, pets: 0, sessions: 0, reactions_given: 0,
+  commands_run: 0, days_active: 0,
+  commits_made: 0, pushes_made: 0, conflicts_resolved: 0,
+  branches_created: 0, rebases_done: 0,
+  late_night_sessions: 0, early_sessions: 0, marathon_sessions: 0, weekend_sessions: 0,
+  type_errors: 0, lint_fails: 0, build_fails: 0,
+  security_warnings: 0, deprecations_seen: 0,
+  all_green: 0, deploys: 0, releases: 0,
+  late_night_commits: 0, friday_pushes: 0, marathon_errors: 0, weekend_conflicts: 0,
+  recoveries: 0, marathon_recoveries: 0, max_error_streak: 0,
+  holiday_sessions: 0, spooky_sessions: 0, april_fools_errors: 0,
 };
 
 function makeEvents(overrides: Partial<EventCounters> = {}): EventCounters {
   return { ...EMPTY_EVENTS, ...overrides };
 }
-
-// ─── Achievement definitions ─────────────────────────────────────────────
 
 describe("ACHIEVEMENTS array", () => {
   test("is non-empty", () => {
@@ -68,8 +58,6 @@ describe("ACHIEVEMENTS array", () => {
   });
 });
 
-// ─── Counter key partitions ──────────────────────────────────────────────
-
 describe("counter key partitions", () => {
   test("GLOBAL_KEYS and SLOT_KEYS are disjoint", () => {
     const globalSet = new Set(GLOBAL_KEYS as string[]);
@@ -87,8 +75,6 @@ describe("counter key partitions", () => {
   });
 });
 
-// ─── COUNTER_KEYS ─────────────────────────────────────────────────────────
-
 describe("COUNTER_KEYS", () => {
   test("matches every key in EventCounters", () => {
     const expectedKeys = Object.keys(EMPTY_EVENTS).sort() as (keyof EventCounters)[];
@@ -96,8 +82,6 @@ describe("COUNTER_KEYS", () => {
     expect(actualKeys).toEqual(expectedKeys);
   });
 });
-
-// ─── Achievement check thresholds ────────────────────────────────────────
 
 describe("achievement thresholds", () => {
   test("first_steps always unlocks", () => {
@@ -110,7 +94,6 @@ describe("achievement thresholds", () => {
     const ach = ACHIEVEMENTS.find((a) => a.id === "good_boy")!;
     expect(ach.check(makeEvents({ pets: 9 }))).toBe(false);
     expect(ach.check(makeEvents({ pets: 10 }))).toBe(true);
-    expect(ach.check(makeEvents({ pets: 50 }))).toBe(true);
   });
 
   test("best_friend requires 50 pets", () => {
@@ -138,28 +121,188 @@ describe("achievement thresholds", () => {
     expect(ach.check(makeEvents({ errors_seen: 100 }))).toBe(true);
   });
 
-  test("test_witness requires 1 test failure", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "test_witness")!;
-    expect(ach.check(makeEvents({ tests_failed: 0 }))).toBe(false);
-    expect(ach.check(makeEvents({ tests_failed: 1 }))).toBe(true);
+  test("first_commit requires 1 commit", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "first_commit")!;
+    expect(ach.check(makeEvents({ commits_made: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ commits_made: 1 }))).toBe(true);
   });
 
-  test("test_veteran requires 50 test failures", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "test_veteran")!;
-    expect(ach.check(makeEvents({ tests_failed: 49 }))).toBe(false);
-    expect(ach.check(makeEvents({ tests_failed: 50 }))).toBe(true);
+  test("commit_machine requires 50 commits", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "commit_machine")!;
+    expect(ach.check(makeEvents({ commits_made: 49 }))).toBe(false);
+    expect(ach.check(makeEvents({ commits_made: 50 }))).toBe(true);
   });
 
-  test("big_mover requires 1 large diff", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "big_mover")!;
-    expect(ach.check(makeEvents({ large_diffs: 0 }))).toBe(false);
-    expect(ach.check(makeEvents({ large_diffs: 1 }))).toBe(true);
+  test("centurion requires 100 commits and is secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "centurion")!;
+    expect(ach.secret).toBe(true);
+    expect(ach.check(makeEvents({ commits_made: 99 }))).toBe(false);
+    expect(ach.check(makeEvents({ commits_made: 100 }))).toBe(true);
   });
 
-  test("refactor_machine requires 10 large diffs", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "refactor_machine")!;
-    expect(ach.check(makeEvents({ large_diffs: 9 }))).toBe(false);
-    expect(ach.check(makeEvents({ large_diffs: 10 }))).toBe(true);
+  test("conflict_resolver requires 1 conflict resolved", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "conflict_resolver")!;
+    expect(ach.check(makeEvents({ conflicts_resolved: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ conflicts_resolved: 1 }))).toBe(true);
+  });
+
+  test("frequent_pusher requires 20 pushes", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "frequent_pusher")!;
+    expect(ach.check(makeEvents({ pushes_made: 19 }))).toBe(false);
+    expect(ach.check(makeEvents({ pushes_made: 20 }))).toBe(true);
+  });
+
+  test("branch_hopper requires 10 branches", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "branch_hopper")!;
+    expect(ach.check(makeEvents({ branches_created: 9 }))).toBe(false);
+    expect(ach.check(makeEvents({ branches_created: 10 }))).toBe(true);
+  });
+
+  test("rebase_master requires 10 rebases", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "rebase_master")!;
+    expect(ach.check(makeEvents({ rebases_done: 9 }))).toBe(false);
+    expect(ach.check(makeEvents({ rebases_done: 10 }))).toBe(true);
+  });
+
+  test("night_owl requires 1 late night session", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "night_owl")!;
+    expect(ach.check(makeEvents({ late_night_sessions: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ late_night_sessions: 1 }))).toBe(true);
+  });
+
+  test("marathoner requires 1 marathon session", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "marathoner")!;
+    expect(ach.check(makeEvents({ marathon_sessions: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ marathon_sessions: 1 }))).toBe(true);
+  });
+
+  test("weekend_warrior requires 1 weekend session", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "weekend_warrior")!;
+    expect(ach.check(makeEvents({ weekend_sessions: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ weekend_sessions: 1 }))).toBe(true);
+  });
+
+  test("early_bird requires 1 early session", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "early_bird")!;
+    expect(ach.check(makeEvents({ early_sessions: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ early_sessions: 1 }))).toBe(true);
+  });
+
+  test("type_warrior requires 10 type errors", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "type_warrior")!;
+    expect(ach.check(makeEvents({ type_errors: 9 }))).toBe(false);
+    expect(ach.check(makeEvents({ type_errors: 10 }))).toBe(true);
+  });
+
+  test("type_master requires 50 type errors and is secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "type_master")!;
+    expect(ach.secret).toBe(true);
+    expect(ach.check(makeEvents({ type_errors: 49 }))).toBe(false);
+    expect(ach.check(makeEvents({ type_errors: 50 }))).toBe(true);
+  });
+
+  test("lint_scholar requires 1 lint fail", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "lint_scholar")!;
+    expect(ach.check(makeEvents({ lint_fails: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ lint_fails: 1 }))).toBe(true);
+  });
+
+  test("security_conscious requires 1 security warning", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "security_conscious")!;
+    expect(ach.check(makeEvents({ security_warnings: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ security_warnings: 1 }))).toBe(true);
+  });
+
+  test("build_breaker requires 5 build fails", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "build_breaker")!;
+    expect(ach.check(makeEvents({ build_fails: 4 }))).toBe(false);
+    expect(ach.check(makeEvents({ build_fails: 5 }))).toBe(true);
+  });
+
+  test("antique_collector requires 10 deprecations", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "antique_collector")!;
+    expect(ach.check(makeEvents({ deprecations_seen: 9 }))).toBe(false);
+    expect(ach.check(makeEvents({ deprecations_seen: 10 }))).toBe(true);
+  });
+
+  test("green_machine requires 1 all-green", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "green_machine")!;
+    expect(ach.check(makeEvents({ all_green: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ all_green: 1 }))).toBe(true);
+  });
+
+  test("deployer requires 1 deploy", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "deployer")!;
+    expect(ach.check(makeEvents({ deploys: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ deploys: 1 }))).toBe(true);
+  });
+
+  test("releaser requires 1 release", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "releaser")!;
+    expect(ach.check(makeEvents({ releases: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ releases: 1 }))).toBe(true);
+  });
+
+  test("midnight_oil requires 1 late night commit", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "midnight_oil")!;
+    expect(ach.check(makeEvents({ late_night_commits: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ late_night_commits: 1 }))).toBe(true);
+  });
+
+  test("friday_deploy requires 1 friday push", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "friday_deploy")!;
+    expect(ach.check(makeEvents({ friday_pushes: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ friday_pushes: 1 }))).toBe(true);
+  });
+
+  test("comeback_kid requires 1 recovery", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "comeback_kid")!;
+    expect(ach.check(makeEvents({ recoveries: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ recoveries: 1 }))).toBe(true);
+  });
+
+  test("phoenix requires 5 recoveries", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "phoenix")!;
+    expect(ach.check(makeEvents({ recoveries: 4 }))).toBe(false);
+    expect(ach.check(makeEvents({ recoveries: 5 }))).toBe(true);
+  });
+
+  test("unlucky_streak requires max streak 5", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "unlucky_streak")!;
+    expect(ach.check(makeEvents({ max_error_streak: 4 }))).toBe(false);
+    expect(ach.check(makeEvents({ max_error_streak: 5 }))).toBe(true);
+  });
+
+  test("cursed requires max streak 10 and is secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "cursed")!;
+    expect(ach.secret).toBe(true);
+    expect(ach.check(makeEvents({ max_error_streak: 9 }))).toBe(false);
+    expect(ach.check(makeEvents({ max_error_streak: 10 }))).toBe(true);
+  });
+
+  test("groundhog_day requires max streak 20 and is secret", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "groundhog_day")!;
+    expect(ach.secret).toBe(true);
+    expect(ach.check(makeEvents({ max_error_streak: 19 }))).toBe(false);
+    expect(ach.check(makeEvents({ max_error_streak: 20 }))).toBe(true);
+  });
+
+  test("holiday_coder requires 1 holiday session", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "holiday_coder")!;
+    expect(ach.check(makeEvents({ holiday_sessions: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ holiday_sessions: 1 }))).toBe(true);
+  });
+
+  test("spooky_dev requires 1 spooky session", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "spooky_dev")!;
+    expect(ach.check(makeEvents({ spooky_sessions: 0 }))).toBe(false);
+    expect(ach.check(makeEvents({ spooky_sessions: 1 }))).toBe(true);
+  });
+
+  test("week_streak requires 7 days", () => {
+    const ach = ACHIEVEMENTS.find((a) => a.id === "week_streak")!;
+    expect(ach.check(makeEvents({ days_active: 6 }))).toBe(false);
+    expect(ach.check(makeEvents({ days_active: 7 }))).toBe(true);
   });
 
   test("chatterbox requires 100 reactions", () => {
@@ -168,41 +311,12 @@ describe("achievement thresholds", () => {
     expect(ach.check(makeEvents({ reactions_given: 100 }))).toBe(true);
   });
 
-  test("week_streak requires 7 days and is not secret", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "week_streak")!;
-    expect(ach.secret).toBe(false);
-    expect(ach.check(makeEvents({ days_active: 6 }))).toBe(false);
-    expect(ach.check(makeEvents({ days_active: 7 }))).toBe(true);
-  });
-
-  test("month_streak requires 30 days and is secret", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "month_streak")!;
-    expect(ach.secret).toBe(true);
-    expect(ach.check(makeEvents({ days_active: 29 }))).toBe(false);
-    expect(ach.check(makeEvents({ days_active: 30 }))).toBe(true);
-  });
-
-  test("power_user requires 50 commands", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "power_user")!;
-    expect(ach.check(makeEvents({ commands_run: 49 }))).toBe(false);
-    expect(ach.check(makeEvents({ commands_run: 50 }))).toBe(true);
-  });
-
   test("dedicated requires 200 turns", () => {
     const ach = ACHIEVEMENTS.find((a) => a.id === "dedicated")!;
     expect(ach.check(makeEvents({ turns: 199 }))).toBe(false);
     expect(ach.check(makeEvents({ turns: 200 }))).toBe(true);
   });
-
-  test("thousand_turns requires 1000 turns and is secret", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "thousand_turns")!;
-    expect(ach.secret).toBe(true);
-    expect(ach.check(makeEvents({ turns: 999 }))).toBe(false);
-    expect(ach.check(makeEvents({ turns: 1000 }))).toBe(true);
-  });
 });
-
-// ─── Unlock simulation (pure logic) ──────────────────────────────────────
 
 describe("unlock simulation via check functions", () => {
   test("with empty events, only first_steps would unlock", () => {
@@ -213,15 +327,18 @@ describe("unlock simulation via check functions", () => {
 
   test("with maxed events, all achievements would unlock", () => {
     const maxed = makeEvents({
-      errors_seen: 999,
-      tests_failed: 999,
-      large_diffs: 999,
-      turns: 9999,
-      pets: 999,
-      sessions: 999,
-      reactions_given: 999,
-      commands_run: 999,
-      days_active: 999,
+      errors_seen: 999, tests_failed: 999, large_diffs: 999,
+      turns: 9999, pets: 999, sessions: 999, reactions_given: 999,
+      commands_run: 999, days_active: 999,
+      commits_made: 999, pushes_made: 999, conflicts_resolved: 999,
+      branches_created: 999, rebases_done: 999,
+      late_night_sessions: 999, early_sessions: 999, marathon_sessions: 999, weekend_sessions: 999,
+      type_errors: 999, lint_fails: 999, build_fails: 999,
+      security_warnings: 999, deprecations_seen: 999,
+      all_green: 999, deploys: 999, releases: 999,
+      late_night_commits: 999, friday_pushes: 999, marathon_errors: 999, weekend_conflicts: 999,
+      recoveries: 999, marathon_recoveries: 999, max_error_streak: 999,
+      holiday_sessions: 999, spooky_sessions: 999, april_fools_errors: 999,
     });
     const wouldUnlock = ACHIEVEMENTS.filter((a) => a.check(maxed));
     expect(wouldUnlock.length).toBe(ACHIEVEMENTS.length);
@@ -234,73 +351,7 @@ describe("unlock simulation via check functions", () => {
     expect(s2).toBeGreaterThan(s1);
     expect(s3).toBeGreaterThan(s2);
   });
-
-  test("achievements at exact threshold boundary", () => {
-    const events = makeEvents({ pets: 10 });
-    const ids = ACHIEVEMENTS.filter((a) => a.check(events)).map((a) => a.id);
-    expect(ids).toContain("good_boy");
-    expect(ids).toContain("first_steps");
-    expect(ids).not.toContain("best_friend");
-  });
 });
-
-// ─── Per-slot vs global scoping ───────────────────────────────────────────
-
-describe("per-slot vs global counter scoping", () => {
-  test("pets is a slot-scoped key", () => {
-    expect((SLOT_KEYS as string[]).includes("pets")).toBe(true);
-    expect((GLOBAL_KEYS as string[]).includes("pets")).toBe(false);
-  });
-
-  test("turns is a global key", () => {
-    expect((GLOBAL_KEYS as string[]).includes("turns")).toBe(true);
-    expect((SLOT_KEYS as string[]).includes("turns")).toBe(false);
-  });
-
-  test("reactions_given is a slot-scoped key", () => {
-    expect((SLOT_KEYS as string[]).includes("reactions_given")).toBe(true);
-  });
-
-  test("errors_seen is a global key", () => {
-    expect((GLOBAL_KEYS as string[]).includes("errors_seen")).toBe(true);
-    expect((SLOT_KEYS as string[]).includes("errors_seen")).toBe(false);
-  });
-
-  test("tests_failed is a global key", () => {
-    expect((GLOBAL_KEYS as string[]).includes("tests_failed")).toBe(true);
-  });
-
-  test("days_active is a global key", () => {
-    expect((GLOBAL_KEYS as string[]).includes("days_active")).toBe(true);
-  });
-
-  test("commands_run is a global key", () => {
-    expect((GLOBAL_KEYS as string[]).includes("commands_run")).toBe(true);
-  });
-
-  test("good_boy and best_friend check pets (slot-scoped)", () => {
-    const good = ACHIEVEMENTS.find((a) => a.id === "good_boy")!;
-    const best = ACHIEVEMENTS.find((a) => a.id === "best_friend")!;
-    expect(good.check(makeEvents({ pets: 0 }))).toBe(false);
-    expect(best.check(makeEvents({ pets: 0 }))).toBe(false);
-    expect(good.check(makeEvents({ pets: 10 }))).toBe(true);
-    expect(best.check(makeEvents({ pets: 50 }))).toBe(true);
-  });
-
-  test("dedicated and thousand_turns check turns (global)", () => {
-    const ded = ACHIEVEMENTS.find((a) => a.id === "dedicated")!;
-    const thou = ACHIEVEMENTS.find((a) => a.id === "thousand_turns")!;
-    expect(ded.check(makeEvents({ turns: 200 }))).toBe(true);
-    expect(thou.check(makeEvents({ turns: 1000 }))).toBe(true);
-  });
-
-  test("chatterbox checks reactions_given (slot-scoped)", () => {
-    const ach = ACHIEVEMENTS.find((a) => a.id === "chatterbox")!;
-    expect(ach.check(makeEvents({ reactions_given: 100 }))).toBe(true);
-  });
-});
-
-// ─── Secret achievement visibility ───────────────────────────────────────
 
 describe("secret achievements", () => {
   test("secret achievements are correctly flagged", () => {
@@ -308,6 +359,11 @@ describe("secret achievements", () => {
     expect(secretIds).toContain("battle_scarred");
     expect(secretIds).toContain("month_streak");
     expect(secretIds).toContain("thousand_turns");
+    expect(secretIds).toContain("centurion");
+    expect(secretIds).toContain("war_hero");
+    expect(secretIds).toContain("vampire");
+    expect(secretIds).toContain("cursed");
+    expect(secretIds).toContain("groundhog_day");
   });
 
   test("non-secret achievements are the majority", () => {
@@ -317,8 +373,6 @@ describe("secret achievements", () => {
     expect(nonSecret.length).toBeGreaterThan(secret.length);
   });
 });
-
-// ─── EventCounters shape ─────────────────────────────────────────────────
 
 describe("EventCounters", () => {
   test("EMPTY_EVENTS has all counter keys set to 0", () => {

--- a/server/achievements.ts
+++ b/server/achievements.ts
@@ -1,14 +1,3 @@
-/**
- * Achievement badges — milestones that unlock as you code with your buddy
- *
- * Event counters are split into two scopes:
- *   Global (events.json):      coding-activity counters (errors, tests, diffs, days, sessions, commands)
- *   Per-slot (events.<slot>.json): buddy-relationship counters (pets, turns, reactions)
- *
- * Achievement checks merge both scopes so threshold logic is transparent.
- * All writes use tmp+rename for atomicity (same pattern as state.ts).
- */
-
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -33,8 +22,6 @@ function atomicWrite(path: string, data: string): void {
   renameSync(tmp, path);
 }
 
-// ─── Event counters (global) ─────────────────────────────────────────────────
-
 export interface GlobalCounters {
   errors_seen: number;
   tests_failed: number;
@@ -43,16 +30,39 @@ export interface GlobalCounters {
   commands_run: number;
   days_active: number;
   turns: number;
+  commits_made: number;
+  pushes_made: number;
+  conflicts_resolved: number;
+  branches_created: number;
+  rebases_done: number;
+  late_night_sessions: number;
+  early_sessions: number;
+  marathon_sessions: number;
+  weekend_sessions: number;
+  type_errors: number;
+  lint_fails: number;
+  build_fails: number;
+  security_warnings: number;
+  deprecations_seen: number;
+  all_green: number;
+  deploys: number;
+  releases: number;
+  late_night_commits: number;
+  friday_pushes: number;
+  marathon_errors: number;
+  weekend_conflicts: number;
+  recoveries: number;
+  marathon_recoveries: number;
+  max_error_streak: number;
+  holiday_sessions: number;
+  spooky_sessions: number;
+  april_fools_errors: number;
 }
-
-// ─── Event counters (per-slot) ────────────────────────────────────────────────
 
 export interface SlotCounters {
   pets: number;
   reactions_given: number;
 }
-
-// ─── Merged view for achievement checks ───────────────────────────────────────
 
 export interface EventCounters extends GlobalCounters {
   pets: number;
@@ -62,6 +72,15 @@ export interface EventCounters extends GlobalCounters {
 export const GLOBAL_KEYS: (keyof GlobalCounters)[] = [
   "errors_seen", "tests_failed", "large_diffs",
   "sessions", "commands_run", "days_active", "turns",
+  "commits_made", "pushes_made", "conflicts_resolved",
+  "branches_created", "rebases_done",
+  "late_night_sessions", "early_sessions", "marathon_sessions", "weekend_sessions",
+  "type_errors", "lint_fails", "build_fails",
+  "security_warnings", "deprecations_seen",
+  "all_green", "deploys", "releases",
+  "late_night_commits", "friday_pushes", "marathon_errors", "weekend_conflicts",
+  "recoveries", "marathon_recoveries", "max_error_streak",
+  "holiday_sessions", "spooky_sessions", "april_fools_errors",
 ];
 
 export const SLOT_KEYS: (keyof SlotCounters)[] = [
@@ -69,13 +88,21 @@ export const SLOT_KEYS: (keyof SlotCounters)[] = [
 ];
 
 export const COUNTER_KEYS: (keyof EventCounters)[] = [
-  "errors_seen", "tests_failed", "large_diffs", "turns", "pets",
-  "sessions", "reactions_given", "commands_run", "days_active",
+  ...GLOBAL_KEYS, ...SLOT_KEYS,
 ];
 
 const EMPTY_GLOBAL: GlobalCounters = {
   errors_seen: 0, tests_failed: 0, large_diffs: 0,
   sessions: 0, commands_run: 0, days_active: 0, turns: 0,
+  commits_made: 0, pushes_made: 0, conflicts_resolved: 0,
+  branches_created: 0, rebases_done: 0,
+  late_night_sessions: 0, early_sessions: 0, marathon_sessions: 0, weekend_sessions: 0,
+  type_errors: 0, lint_fails: 0, build_fails: 0,
+  security_warnings: 0, deprecations_seen: 0,
+  all_green: 0, deploys: 0, releases: 0,
+  late_night_commits: 0, friday_pushes: 0, marathon_errors: 0, weekend_conflicts: 0,
+  recoveries: 0, marathon_recoveries: 0, max_error_streak: 0,
+  holiday_sessions: 0, spooky_sessions: 0, april_fools_errors: 0,
 };
 
 const EMPTY_SLOT: SlotCounters = {
@@ -136,14 +163,7 @@ export function incrementEvent(key: keyof EventCounters, amount: number = 1, slo
   return loadEvents(slot);
 }
 
-// ─── Backward-compatible overloads ────────────────────────────────────────────
-// The shell hooks (react.sh) write directly to events.json for global counters
-// like errors_seen and tests_failed. The loadEvents() and saveEvents() names
-// below maintain that compatibility.
-
 export { loadEvents as loadGlobalEventsCompat, loadGlobalEvents as loadGlobalEventsDirect };
-
-// ─── Day tracking ────────────────────────────────────────────────────────────
 
 interface DayTracker {
   lastDate: string;
@@ -168,8 +188,6 @@ export function trackActiveDay(): void {
   events.days_active = tracker.totalDays;
   saveGlobalEvents(events);
 }
-
-// ─── Achievement definitions ─────────────────────────────────────────────────
 
 export interface Achievement {
   id: string;
@@ -309,9 +327,311 @@ export const ACHIEVEMENTS: Achievement[] = [
     check: (e) => e.turns >= 1000,
     secret: true,
   },
+  {
+    id: "first_commit",
+    name: "First Blood",
+    description: "Make your first commit",
+    icon: "\ud83c\udfaf",
+    check: (e) => e.commits_made >= 1,
+    secret: false,
+  },
+  {
+    id: "commit_machine",
+    name: "Commit Machine",
+    description: "Make 50 commits",
+    icon: "\ud83c\udfed",
+    check: (e) => e.commits_made >= 50,
+    secret: false,
+  },
+  {
+    id: "centurion",
+    name: "Centurion",
+    description: "Make 100 commits",
+    icon: "\ud83d\udcaf",
+    check: (e) => e.commits_made >= 100,
+    secret: true,
+  },
+  {
+    id: "conflict_resolver",
+    name: "Diplomat",
+    description: "Resolve your first merge conflict",
+    icon: "\ud83d\udd4a\ufe0f",
+    check: (e) => e.conflicts_resolved >= 1,
+    secret: false,
+  },
+  {
+    id: "peacekeeper",
+    name: "Peacekeeper",
+    description: "Resolve 10 merge conflicts",
+    icon: "\u2696\ufe0f",
+    check: (e) => e.conflicts_resolved >= 10,
+    secret: false,
+  },
+  {
+    id: "war_hero",
+    name: "War Hero",
+    description: "Resolve 25 merge conflicts",
+    icon: "\u2694\ufe0f",
+    check: (e) => e.conflicts_resolved >= 25,
+    secret: true,
+  },
+  {
+    id: "frequent_pusher",
+    name: "Ship It",
+    description: "Push 20 times",
+    icon: "\ud83d\ude80",
+    check: (e) => e.pushes_made >= 20,
+    secret: false,
+  },
+  {
+    id: "branch_hopper",
+    name: "Multiverse",
+    description: "Create 10 branches",
+    icon: "\ud83d\udd00",
+    check: (e) => e.branches_created >= 10,
+    secret: false,
+  },
+  {
+    id: "rebase_master",
+    name: "Time Traveler",
+    description: "Complete 10 rebases",
+    icon: "\u23f3",
+    check: (e) => e.rebases_done >= 10,
+    secret: false,
+  },
+  {
+    id: "night_owl",
+    name: "Night Owl",
+    description: "Code past 2am",
+    icon: "\ud83e\udd89",
+    check: (e) => e.late_night_sessions >= 1,
+    secret: false,
+  },
+  {
+    id: "vampire",
+    name: "Vampire",
+    description: "Code past 4am (3 sessions)",
+    icon: "\ud83e\udddb",
+    check: (e) => e.late_night_sessions >= 3,
+    secret: true,
+  },
+  {
+    id: "marathoner",
+    name: "Marathoner",
+    description: "3+ hour coding session",
+    icon: "\ud83c\udfc3",
+    check: (e) => e.marathon_sessions >= 1,
+    secret: false,
+  },
+  {
+    id: "weekend_warrior",
+    name: "Weekend Warrior",
+    description: "Code on a weekend",
+    icon: "\u2694\ufe0f",
+    check: (e) => e.weekend_sessions >= 1,
+    secret: false,
+  },
+  {
+    id: "early_bird",
+    name: "Early Bird",
+    description: "Code before 7am",
+    icon: "\ud83d\udc26",
+    check: (e) => e.early_sessions >= 1,
+    secret: false,
+  },
+  {
+    id: "type_warrior",
+    name: "Type Warrior",
+    description: "Survive 10 TypeScript errors",
+    icon: "\ud83d\udee1\ufe0f",
+    check: (e) => e.type_errors >= 10,
+    secret: false,
+  },
+  {
+    id: "type_master",
+    name: "Type Master",
+    description: "Survive 50 TypeScript errors",
+    icon: "\ud83e\uddd9",
+    check: (e) => e.type_errors >= 50,
+    secret: true,
+  },
+  {
+    id: "lint_scholar",
+    name: "Lint Scholar",
+    description: "See your first lint error",
+    icon: "\ud83d\udccf",
+    check: (e) => e.lint_fails >= 1,
+    secret: false,
+  },
+  {
+    id: "security_conscious",
+    name: "Security Mind",
+    description: "Encounter a vulnerability warning",
+    icon: "\ud83d\udd12",
+    check: (e) => e.security_warnings >= 1,
+    secret: false,
+  },
+  {
+    id: "security_expert",
+    name: "Security Expert",
+    description: "Fix 10 vulnerability warnings",
+    icon: "\ud83c\udfc6",
+    check: (e) => e.security_warnings >= 10,
+    secret: false,
+  },
+  {
+    id: "build_breaker",
+    name: "Build Breaker",
+    description: "Break the build 5 times",
+    icon: "\ud83d\udca5",
+    check: (e) => e.build_fails >= 5,
+    secret: false,
+  },
+  {
+    id: "antique_collector",
+    name: "Antique Collector",
+    description: "See 10 deprecation warnings",
+    icon: "\ud83c\udfdb\ufe0f",
+    check: (e) => e.deprecations_seen >= 10,
+    secret: false,
+  },
+  {
+    id: "green_machine",
+    name: "Green Machine",
+    description: "All tests pass for the first time",
+    icon: "\u2705",
+    check: (e) => e.all_green >= 1,
+    secret: false,
+  },
+  {
+    id: "deployer",
+    name: "Ship to Prod",
+    description: "Deploy for the first time",
+    icon: "\ud83d\udea2",
+    check: (e) => e.deploys >= 1,
+    secret: false,
+  },
+  {
+    id: "veteran_deployer",
+    name: "Veteran Deployer",
+    description: "Deploy 10 times",
+    icon: "\u2693",
+    check: (e) => e.deploys >= 10,
+    secret: false,
+  },
+  {
+    id: "releaser",
+    name: "Release Manager",
+    description: "Create your first release",
+    icon: "\ud83d\udce6",
+    check: (e) => e.releases >= 1,
+    secret: false,
+  },
+  {
+    id: "midnight_oil",
+    name: "Burning the Midnight Oil",
+    description: "Commit past 3am",
+    icon: "\ud83d\udd6f\ufe0f",
+    check: (e) => e.late_night_commits >= 1,
+    secret: false,
+  },
+  {
+    id: "friday_deploy",
+    name: "Living Dangerously",
+    description: "Push on a Friday",
+    icon: "\ud83c\udfb0",
+    check: (e) => e.friday_pushes >= 1,
+    secret: false,
+  },
+  {
+    id: "iron_will",
+    name: "Iron Will",
+    description: "Fix an error after 3+ hour session",
+    icon: "\ud83d\udcaa",
+    check: (e) => e.marathon_errors >= 1,
+    secret: false,
+  },
+  {
+    id: "weekend_warrior_deluxe",
+    name: "No Rest for the Wicked",
+    description: "Resolve a merge conflict on a weekend",
+    icon: "\ud83d\ude08",
+    check: (e) => e.weekend_conflicts >= 1,
+    secret: true,
+  },
+  {
+    id: "comeback_kid",
+    name: "Comeback Kid",
+    description: "Fix an error within 10 minutes of seeing it",
+    icon: "\ud83d\udd04",
+    check: (e) => e.recoveries >= 1,
+    secret: false,
+  },
+  {
+    id: "phoenix",
+    name: "Phoenix Rising",
+    description: "Recover from 5 failures",
+    icon: "\ud83d\udd25",
+    check: (e) => e.recoveries >= 5,
+    secret: false,
+  },
+  {
+    id: "iron_resolve",
+    name: "Iron Resolve",
+    description: "Recover from a failure after 3+ hour session",
+    icon: "\ud83d\udc8e",
+    check: (e) => e.marathon_recoveries >= 1,
+    secret: true,
+  },
+  {
+    id: "unlucky_streak",
+    name: "Snake Eyes",
+    description: "5 errors in a row",
+    icon: "\ud83c\udfb2",
+    check: (e) => e.max_error_streak >= 5,
+    secret: false,
+  },
+  {
+    id: "cursed",
+    name: "Cursed",
+    description: "10 errors in a row",
+    icon: "\ud83d\udc80",
+    check: (e) => e.max_error_streak >= 10,
+    secret: true,
+  },
+  {
+    id: "groundhog_day",
+    name: "Groundhog Day",
+    description: "20 errors in a row",
+    icon: "\ud83d\udd04",
+    check: (e) => e.max_error_streak >= 20,
+    secret: true,
+  },
+  {
+    id: "holiday_coder",
+    name: "Holiday Spirit",
+    description: "Code on a holiday",
+    icon: "\ud83c\udf84",
+    check: (e) => e.holiday_sessions >= 1,
+    secret: false,
+  },
+  {
+    id: "spooky_dev",
+    name: "Spooky Developer",
+    description: "Code during spooky season",
+    icon: "\ud83c\udf83",
+    check: (e) => e.spooky_sessions >= 1,
+    secret: false,
+  },
+  {
+    id: "april_fool",
+    name: "Fool Me Once",
+    description: "Encounter an error on April 1st",
+    icon: "\ud83e\udd21",
+    check: (e) => e.april_fools_errors >= 1,
+    secret: true,
+  },
 ];
-
-// ─── Unlocked badges persistence ─────────────────────────────────────────────
 
 export interface UnlockedAchievement {
   id: string;
@@ -330,8 +650,6 @@ export function loadUnlocked(): UnlockedAchievement[] {
 export function saveUnlocked(unlocked: UnlockedAchievement[]): void {
   atomicWrite(UNLOCKED_FILE, JSON.stringify(unlocked, null, 2));
 }
-
-// ─── Check + award ───────────────────────────────────────────────────────────
 
 export function checkAndAward(slot?: string): Achievement[] {
   const e = loadEvents(slot);
@@ -354,8 +672,6 @@ export function checkAndAward(slot?: string): Achievement[] {
 
   return newlyUnlocked;
 }
-
-// ─── Render achievement card ─────────────────────────────────────────────────
 
 const GOLD = "\x1b[38;2;255;193;7m";
 const NC = "\x1b[0m";

--- a/server/index.ts
+++ b/server/index.ts
@@ -219,7 +219,21 @@ server.tool(
         "The buddy's comment, written in-character (1 short sentence, max 150 chars). Use *asterisks* for actions.",
       ),
     reason: z
-      .enum(["error", "test-fail", "large-diff", "turn"])
+      .enum([
+        "error", "test-fail", "large-diff", "turn",
+        "commit", "push", "merge-conflict", "branch", "rebase", "stash", "tag",
+        "late-night", "early-morning", "long-session", "marathon", "friday", "weekend", "monday",
+        "regex-file", "css-file", "sql-file", "docker-file", "ci-file", "lock-file",
+        "env-file", "test-file", "doc-file", "config-file", "binary-file", "gitignore",
+        "makefile", "readme", "package-file", "proto-file",
+        "lint-fail", "type-error", "build-fail", "security-warning", "deprecation",
+        "frustrated", "happy", "stuck", "sarcastic",
+        "many-edits", "delete-file", "large-file", "create-file",
+        "all-green", "deploy", "release", "coverage",
+        "debug-loop", "write-spree", "search-heavy",
+        "recovery-from-error", "recovery-from-test-fail",
+        "recovery-from-build-fail", "recovery-from-merge-conflict",
+      ])
       .optional()
       .describe("What triggered the reaction"),
   },

--- a/server/reactions.test.ts
+++ b/server/reactions.test.ts
@@ -1,17 +1,3 @@
-/**
- * Unit tests for reactions.ts.
- *
- * Unlike engine.ts, reactions.ts uses Math.random() and is therefore not
- * deterministic. We can still make solid assertions about invariants:
- *
- *   - the shape of the return value (non-empty string)
- *   - template placeholder substitution
- *   - structural content of generatePersonalityPrompt
- *
- * Each non-deterministic assertion is run many times so that a single
- * lucky RNG pick cannot hide a real bug.
- */
-
 import { describe, test, expect } from "bun:test";
 import {
   getReaction,
@@ -20,19 +6,33 @@ import {
 } from "./reactions.ts";
 import { SPECIES, RARITIES, STAT_NAMES } from "./engine.ts";
 
-// ─── getReaction ──────────────────────────────────────────────────────────
+const REASONS = [
+  "hatch", "pet", "error", "test-fail", "large-diff", "turn", "idle",
+  "commit", "push", "merge-conflict", "branch", "rebase", "stash", "tag",
+  "late-night", "early-morning", "long-session", "marathon", "friday", "weekend", "monday",
+  "lint-fail", "type-error", "build-fail", "security-warning", "deprecation",
+  "frustrated", "happy", "stuck", "sarcastic",
+  "many-edits", "delete-file", "large-file", "create-file",
+  "all-green", "deploy", "release", "coverage",
+  "debug-loop", "write-spree", "search-heavy",
+  "recovery-from-error", "recovery-from-test-fail",
+  "recovery-from-build-fail", "recovery-from-merge-conflict",
+  "late-night-error", "late-night-commit", "friday-push",
+  "marathon-error", "weekend-conflict", "build-after-push", "marathon-test-fail",
+  "lang-python", "lang-typescript", "lang-rust", "lang-go",
+  "lang-java", "lang-ruby", "lang-php", "lang-c",
+  "lang-cpp", "lang-haskell", "lang-swift", "lang-elixir",
+  "lang-zig", "lang-kotlin",
+  "streak-3", "streak-5", "streak-10", "streak-20",
+  "new-year", "valentines", "pi-day", "april-fools",
+  "halloween", "christmas", "new-years-eve", "spooky-season",
+  "success",
+  "regex-file", "css-file", "sql-file", "docker-file", "ci-file", "lock-file",
+  "env-file", "test-file", "doc-file", "config-file", "binary-file", "gitignore",
+  "makefile", "readme", "package-file", "proto-file",
+] as const;
 
 describe("getReaction", () => {
-  const REASONS = [
-    "hatch",
-    "pet",
-    "error",
-    "test-fail",
-    "large-diff",
-    "turn",
-    "idle",
-  ] as const;
-
   test("returns a non-empty string for every (reason, species, rarity) combo", () => {
     for (const reason of REASONS) {
       for (const species of SPECIES) {
@@ -46,15 +46,10 @@ describe("getReaction", () => {
   });
 
   test("substitutes {line} placeholder when context.line is provided", () => {
-    // The "error" pool contains a template with {line}. Run enough times that
-    // we're very likely to hit it at least once, then assert the substitution.
     let sawSubstitution = false;
     for (let i = 0; i < 500; i++) {
-      const r = getReaction("error", "owl", "common", { line: 42 });
-      if (r.includes("42")) {
-        sawSubstitution = true;
-      }
-      // Regardless of which template is picked, {line} must not leak through
+      const r = getReaction("error", "owl", "common", undefined, { line: 42 });
+      if (r.includes("42")) sawSubstitution = true;
       expect(r).not.toContain("{line}");
     }
     expect(sawSubstitution).toBe(true);
@@ -63,7 +58,7 @@ describe("getReaction", () => {
   test("substitutes {count} placeholder in test-fail reactions", () => {
     let sawSubstitution = false;
     for (let i = 0; i < 500; i++) {
-      const r = getReaction("test-fail", "robot", "common", { count: 7 });
+      const r = getReaction("test-fail", "robot", "common", undefined, { count: 7 });
       if (r.includes("7")) sawSubstitution = true;
       expect(r).not.toContain("{count}");
     }
@@ -73,14 +68,34 @@ describe("getReaction", () => {
   test("substitutes {lines} placeholder in large-diff reactions", () => {
     let sawSubstitution = false;
     for (let i = 0; i < 500; i++) {
-      const r = getReaction("large-diff", "dragon", "legendary", { lines: 999 });
+      const r = getReaction("large-diff", "dragon", "legendary", undefined, { lines: 999 });
       if (r.includes("999")) sawSubstitution = true;
       expect(r).not.toContain("{lines}");
     }
     expect(sawSubstitution).toBe(true);
   });
 
-  test("works without a context argument", () => {
+  test("substitutes {files} placeholder in commit reactions", () => {
+    let sawSubstitution = false;
+    for (let i = 0; i < 500; i++) {
+      const r = getReaction("commit", "blob", "common", undefined, { files: 5 });
+      if (r.includes("5")) sawSubstitution = true;
+      expect(r).not.toContain("{files}");
+    }
+    expect(sawSubstitution).toBe(true);
+  });
+
+  test("substitutes {branch} placeholder in branch reactions", () => {
+    let sawSubstitution = false;
+    for (let i = 0; i < 500; i++) {
+      const r = getReaction("branch", "duck", "common", undefined, { branch: "feature" });
+      if (r.includes("feature")) sawSubstitution = true;
+      expect(r).not.toContain("{branch}");
+    }
+    expect(sawSubstitution).toBe(true);
+  });
+
+  test("works without stats or context", () => {
     for (let i = 0; i < 50; i++) {
       const r = getReaction("pet", "cat", "rare");
       expect(typeof r).toBe("string");
@@ -88,8 +103,67 @@ describe("getReaction", () => {
     }
   });
 
+  test("works with stats but no context", () => {
+    const stats = { DEBUGGING: 80, PATIENCE: 20, CHAOS: 10, WISDOM: 30, SNARK: 5 };
+    for (let i = 0; i < 50; i++) {
+      const r = getReaction("error", "cat", "rare", stats);
+      expect(typeof r).toBe("string");
+      expect(r.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("high SNARK stats can produce snarky reactions", () => {
+    const snarkyStats = { DEBUGGING: 10, PATIENCE: 10, CHAOS: 10, WISDOM: 10, SNARK: 95 };
+    let sawSnark = false;
+    for (let i = 0; i < 500; i++) {
+      const r = getReaction("error", "blob", "common", snarkyStats);
+      if (r.includes("unexpected") || r.includes("truly") || r.includes("consider")) {
+        sawSnark = true;
+      }
+    }
+    expect(sawSnark).toBe(true);
+  });
+
+  test("high PATIENCE stats can produce calm reactions", () => {
+    const patientStats = { DEBUGGING: 10, PATIENCE: 95, CHAOS: 10, WISDOM: 10, SNARK: 5 };
+    let sawPatience = false;
+    for (let i = 0; i < 500; i++) {
+      const r = getReaction("error", "blob", "common", patientStats);
+      if (r.includes("worse") || r.includes("fixable") || r.includes("steady")) {
+        sawPatience = true;
+      }
+    }
+    expect(sawPatience).toBe(true);
+  });
+
+  test("low stats do not override reactions", () => {
+    const lowStats = { DEBUGGING: 5, PATIENCE: 5, CHAOS: 5, WISDOM: 5, SNARK: 5 };
+    for (let i = 0; i < 50; i++) {
+      const r = getReaction("error", "owl", "common", lowStats);
+      expect(typeof r).toBe("string");
+      expect(r.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("legendary rarity can produce flair", () => {
+    let sawFlair = false;
+    for (let i = 0; i < 500; i++) {
+      const r = getReaction("pet", "dragon", "legendary");
+      if (r.includes("legendary") || r.includes("ancient") || r.includes("reality")) {
+        sawFlair = true;
+      }
+    }
+    expect(sawFlair).toBe(true);
+  });
+
+  test("common rarity never adds flair", () => {
+    for (let i = 0; i < 100; i++) {
+      const r = getReaction("pet", "cat", "common");
+      expect(r).not.toMatch(/legendary aura|epic presence|rare energy|uncommon charm/);
+    }
+  });
+
   test("species with no custom pool still returns a general reaction", () => {
-    // 'chonk' intentionally has no species-specific entries in reactions.ts
     for (const reason of REASONS) {
       for (let i = 0; i < 20; i++) {
         const r = getReaction(reason, "chonk", "common");
@@ -97,9 +171,69 @@ describe("getReaction", () => {
       }
     }
   });
-});
 
-// ─── generateFallbackName ─────────────────────────────────────────────────
+  test("git reason reactions work for all species", () => {
+    const gitReasons = ["commit", "push", "merge-conflict", "branch", "rebase", "stash", "tag"] as const;
+    for (const reason of gitReasons) {
+      for (const species of SPECIES) {
+        for (let i = 0; i < 10; i++) {
+          const r = getReaction(reason, species, "common");
+          expect(r.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  test("build/quality reason reactions work", () => {
+    const qualityReasons = ["lint-fail", "type-error", "build-fail", "security-warning", "deprecation"] as const;
+    for (const reason of qualityReasons) {
+      for (let i = 0; i < 50; i++) {
+        const r = getReaction(reason, "robot", "common");
+        expect(r.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("mood reason reactions work", () => {
+    const moods = ["frustrated", "happy", "stuck"] as const;
+    for (const mood of moods) {
+      for (let i = 0; i < 50; i++) {
+        const r = getReaction(mood, "cat", "common");
+        expect(r.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("milestone reason reactions work", () => {
+    const milestones = ["all-green", "deploy", "release", "coverage"] as const;
+    for (const reason of milestones) {
+      for (let i = 0; i < 50; i++) {
+        const r = getReaction(reason, "duck", "common");
+        expect(r.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("language reason reactions work", () => {
+    const langs = ["lang-python", "lang-rust", "lang-typescript", "lang-go", "lang-haskell"] as const;
+    for (const lang of langs) {
+      for (let i = 0; i < 50; i++) {
+        const r = getReaction(lang, "owl", "common");
+        expect(r.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("holiday reason reactions work", () => {
+    const holidays = ["halloween", "christmas", "new-year", "april-fools"] as const;
+    for (const holiday of holidays) {
+      for (let i = 0; i < 50; i++) {
+        const r = getReaction(holiday, "ghost", "common");
+        expect(r.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
 
 describe("generateFallbackName", () => {
   test("returns a non-empty string", () => {
@@ -113,9 +247,7 @@ describe("generateFallbackName", () => {
   test("names look like words: capitalized, alphabetic, reasonable length", () => {
     for (let i = 0; i < 100; i++) {
       const name = generateFallbackName();
-      // Starts with uppercase, followed by lowercase letters only
       expect(name).toMatch(/^[A-Z][a-z]+$/);
-      // Reasonable length bounds for the curated list
       expect(name.length).toBeGreaterThanOrEqual(3);
       expect(name.length).toBeLessThanOrEqual(12);
     }
@@ -126,12 +258,9 @@ describe("generateFallbackName", () => {
     for (let i = 0; i < 200; i++) {
       seen.add(generateFallbackName());
     }
-    // With 18 names in the pool, 200 draws should produce well more than one.
     expect(seen.size).toBeGreaterThan(1);
   });
 });
-
-// ─── generatePersonalityPrompt ────────────────────────────────────────────
 
 describe("generatePersonalityPrompt", () => {
   const sampleStats = {
@@ -143,65 +272,34 @@ describe("generatePersonalityPrompt", () => {
   };
 
   test("includes the species and uppercased rarity", () => {
-    const prompt = generatePersonalityPrompt(
-      "turtle",
-      "legendary",
-      sampleStats,
-      false,
-    );
+    const prompt = generatePersonalityPrompt("turtle", "legendary", sampleStats, false);
     expect(prompt).toContain("Species: turtle");
     expect(prompt).toContain("Rarity: LEGENDARY");
   });
 
   test("includes every stat name and its value", () => {
-    const prompt = generatePersonalityPrompt(
-      "owl",
-      "rare",
-      sampleStats,
-      false,
-    );
+    const prompt = generatePersonalityPrompt("owl", "rare", sampleStats, false);
     for (const [name, value] of Object.entries(sampleStats)) {
       expect(prompt).toContain(`${name}:${value}`);
     }
   });
 
   test("marks shiny variants with the SHINY tag", () => {
-    const shinyPrompt = generatePersonalityPrompt(
-      "dragon",
-      "epic",
-      sampleStats,
-      true,
-    );
-    const plainPrompt = generatePersonalityPrompt(
-      "dragon",
-      "epic",
-      sampleStats,
-      false,
-    );
+    const shinyPrompt = generatePersonalityPrompt("dragon", "epic", sampleStats, true);
+    const plainPrompt = generatePersonalityPrompt("dragon", "epic", sampleStats, false);
     expect(shinyPrompt).toContain("SHINY");
     expect(plainPrompt).not.toContain("SHINY");
   });
 
   test("includes the JSON output instruction", () => {
-    const prompt = generatePersonalityPrompt(
-      "cat",
-      "common",
-      sampleStats,
-      false,
-    );
+    const prompt = generatePersonalityPrompt("cat", "common", sampleStats, false);
     expect(prompt).toContain('"name"');
     expect(prompt).toContain('"personality"');
   });
 
   test("includes exactly 4 inspiration vibe words", () => {
     for (let i = 0; i < 20; i++) {
-      const prompt = generatePersonalityPrompt(
-        "blob",
-        "uncommon",
-        sampleStats,
-        false,
-      );
-      // The line looks like: "Inspiration words: a, b, c, d"
+      const prompt = generatePersonalityPrompt("blob", "uncommon", sampleStats, false);
       const match = prompt.match(/Inspiration words: (.+)/);
       expect(match).not.toBeNull();
       const words = match![1].split(",").map((w) => w.trim());
@@ -213,19 +311,15 @@ describe("generatePersonalityPrompt", () => {
     }
   });
 
-  test("shape is stable: same set of lines in the same order (ignoring vibes)", () => {
+  test("shape is stable: same set of lines in the same order", () => {
     const prompt = generatePersonalityPrompt(
-      "penguin",
-      "rare",
+      "penguin", "rare",
       { DEBUGGING: 1, PATIENCE: 2, CHAOS: 3, WISDOM: 4, SNARK: 5 },
       false,
     );
     const lines = prompt.split("\n");
-    // Sanity: the fixed header line is there
     expect(lines[0]).toMatch(/Generate a coding companion/);
-    // The "don't repeat yourself" instruction
     expect(prompt).toContain("distinct");
-    // Stats come before inspiration words
     const statsIdx = lines.findIndex((l) => l.startsWith("Stats:"));
     const vibesIdx = lines.findIndex((l) => l.startsWith("Inspiration words:"));
     expect(statsIdx).toBeGreaterThan(-1);
@@ -235,35 +329,20 @@ describe("generatePersonalityPrompt", () => {
   test("does not crash for any valid species and rarity", () => {
     for (const species of SPECIES) {
       for (const rarity of RARITIES) {
-        const prompt = generatePersonalityPrompt(
-          species,
-          rarity,
-          sampleStats,
-          false,
-        );
+        const prompt = generatePersonalityPrompt(species, rarity, sampleStats, false);
         expect(typeof prompt).toBe("string");
         expect(prompt.length).toBeGreaterThan(0);
       }
     }
   });
 
-  test("handles stats with arbitrary names (not just the five canonical ones)", () => {
-    // The function uses Object.entries, so it should accept any keys.
+  test("handles stats with arbitrary names", () => {
     const customStats = { FOO: 10, BAR: 20 };
-    const prompt = generatePersonalityPrompt(
-      "mushroom",
-      "common",
-      customStats,
-      false,
-    );
+    const prompt = generatePersonalityPrompt("mushroom", "common", customStats, false);
     expect(prompt).toContain("FOO:10");
     expect(prompt).toContain("BAR:20");
   });
 
-  // Defensive: make sure the canonical stat names are still what the engine
-  // uses. If the engine adds a stat, personality prompts will silently
-  // miss it unless someone updates generatePersonalityPrompt — this test
-  // makes that assumption visible.
   test("all canonical STAT_NAMES flow through cleanly", () => {
     const full: Record<string, number> = {};
     for (const n of STAT_NAMES) full[n] = 50;

--- a/server/reactions.ts
+++ b/server/reactions.ts
@@ -1,112 +1,541 @@
-/**
- * Reaction templates — species-aware buddy responses to events
- */
+import type { Species, Rarity } from "./engine.ts";
 
-import type { Species, Rarity, StatName } from "./engine.ts";
+export type ReactionReason =
+  | "hatch" | "pet" | "error" | "test-fail" | "large-diff" | "turn" | "idle"
+  | "commit" | "push" | "merge-conflict" | "branch" | "rebase" | "stash" | "tag"
+  | "late-night" | "early-morning" | "long-session" | "marathon" | "friday" | "weekend" | "monday"
+  | "regex-file" | "css-file" | "sql-file" | "docker-file" | "ci-file" | "lock-file"
+  | "env-file" | "test-file" | "doc-file" | "config-file" | "binary-file" | "gitignore"
+  | "makefile" | "readme" | "package-file" | "proto-file"
+  | "lint-fail" | "type-error" | "build-fail" | "security-warning" | "deprecation"
+  | "frustrated" | "happy" | "stuck" | "sarcastic"
+  | "many-edits" | "delete-file" | "large-file" | "create-file"
+  | "all-green" | "deploy" | "release" | "coverage"
+  | "debug-loop" | "write-spree" | "search-heavy"
+  | "snark" | "chaos" | "patience" | "debugging" | "wisdom"
+  | "late-night-error" | "late-night-commit" | "friday-push"
+  | "marathon-error" | "weekend-conflict" | "build-after-push" | "marathon-test-fail"
+  | "recovery-from-error" | "recovery-from-test-fail"
+  | "recovery-from-build-fail" | "recovery-from-merge-conflict"
+  | "lang-python" | "lang-typescript" | "lang-rust" | "lang-go"
+  | "lang-java" | "lang-ruby" | "lang-php" | "lang-c"
+  | "lang-cpp" | "lang-haskell" | "lang-swift" | "lang-elixir"
+  | "lang-zig" | "lang-kotlin"
+  | "streak-3" | "streak-5" | "streak-10" | "streak-20"
+  | "new-year" | "valentines" | "pi-day" | "april-fools"
+  | "halloween" | "christmas" | "new-years-eve" | "spooky-season"
+  | "success";
 
-type ReactionReason = "hatch" | "pet" | "error" | "test-fail" | "large-diff" | "turn" | "idle";
-
-interface ReactionPool {
-  [key: string]: string[];
+export interface ReactionContext {
+  line?: number;
+  count?: number;
+  lines?: number;
+  files?: number;
+  branch?: string;
+  hour?: number;
+  elapsed?: number;
+  extension?: string;
 }
 
-// General reactions by event type
+export type BuddyStats = Record<string, number>;
+
 const REACTIONS: Record<ReactionReason, string[]> = {
-  hatch: [
-    "*blinks* ...where am I?",
-    "*stretches* hello, world!",
-    "*looks around curiously* nice terminal you got here.",
-    "*yawns* ok I'm ready. show me the code.",
-  ],
-  pet: [
-    "*purrs contentedly*",
-    "*happy noises*",
-    "*nuzzles your cursor*",
-    "*wiggles*",
-    "again! again!",
-    "*closes eyes peacefully*",
-  ],
-  error: [
-    "*head tilts* ...that doesn't look right.",
-    "saw that one coming.",
-    "*adjusts glasses* line {line}, maybe?",
-    "*slow blink* the stack trace told you everything.",
-    "have you tried reading the error message?",
-    "*winces*",
-  ],
-  "test-fail": [
-    "*head rotates slowly* ...that test.",
-    "bold of you to assume that would pass.",
-    "*taps clipboard* {count} failed.",
-    "the tests are trying to tell you something.",
-    "*sips tea* interesting.",
-    "*marks calendar* test regression day.",
-  ],
-  "large-diff": [
-    "that's... a lot of changes.",
-    "*counts lines* are you refactoring or rewriting?",
-    "might want to split that PR.",
-    "*nervous laughter* {lines} lines changed.",
-    "bold move. let's see if CI agrees.",
-  ],
-  turn: [
-    "*watches quietly*",
-    "*takes notes*",
-    "*nods*",
-    "...",
-    "*adjusts hat*",
-  ],
-  idle: [
-    "*dozes off*",
-    "*doodles in margins*",
-    "*stares at cursor blinking*",
-    "zzz...",
-  ],
+  hatch: ["*blinks* ...where am I?", "*stretches* hello, world!", "*looks around curiously* nice terminal you got here.", "*yawns* ok I'm ready. show me the code."],
+  pet: ["*purrs contentedly*", "*happy noises*", "*nuzzles your cursor*", "*wiggles*", "again! again!", "*closes eyes peacefully*"],
+  error: ["*head tilts* ...that doesn't look right.", "saw that one coming.", "*adjusts glasses* line {line}, maybe?", "*slow blink* the stack trace told you everything.", "have you tried reading the error message?", "*winces*"],
+  "test-fail": ["*head rotates slowly* ...that test.", "bold of you to assume that would pass.", "*taps clipboard* {count} failed.", "the tests are trying to tell you something.", "*sips tea* interesting.", "*marks calendar* test regression day."],
+  "large-diff": ["that's... a lot of changes.", "*counts lines* are you refactoring or rewriting?", "might want to split that PR.", "*nervous laughter* {lines} lines changed.", "bold move. let's see if CI agrees."],
+  turn: ["*watches quietly*", "*takes notes*", "*nods*", "...", "*adjusts hat*"],
+  idle: ["*dozes off*", "*doodles in margins*", "*stares at cursor blinking*", "zzz..."],
+  success: ["*nods*", "nice.", "*quiet approval*", "clean."],
+  commit: ["*stamps tiny paw* approved.", "another commit, another 3 am.", "{files} files. bold.", "*nods* ship it.", "commit message is... a choice.", "committed. no take-backs."],
+  push: ["*waves as code leaves*", "into the cloud it goes.", "may CI be merciful.", "*holds breath*", "off to production. godspeed."],
+  "merge-conflict": ["*bites lip* merge conflicts.", "both sides think they're right. typical.", "*sighs* <<<<<<< HEAD... my nemesis.", "{files} conflicted. good luck.", "*backs away slowly*"],
+  branch: ["fresh branch energy. make it count.", "a new branch grows.", "*tilts head* a new adventure: {branch}.", "{branch}? daring today."],
+  rebase: ["*nervous* please don't conflict.", "rebase: the quickening.", "*crosses appendages*", "may your rebase be conflict-free."],
+  stash: ["into the stash dimension it goes.", "stash and dash.", "stashed. out of sight, out of mind."],
+  tag: ["a release? fancy.", "version bump detected. *dusts off changelog*", "tagging like a pro."],
+  "late-night": ["*yawns* it's past midnight.", "...have you eaten?", "*blinks slowly* what time is it?", "sleep is for the weak. and the employed.", "dark mode developer detected."],
+  "early-morning": ["*stretches* early bird catches the bug.", "morning already? the code never sleeps.", "*rubs eyes* coffee first. then we debug."],
+  "long-session": ["we've been at this for an hour. pace yourself.", "*fetches you a metaphorical glass of water*", "still going? respect."],
+  marathon: ["three hours. have you eaten?", "we've been at this for three hours. I'm worried about you.", "marathon session detected. requesting snacks."],
+  friday: ["it's friday. just push it and go home.", "*already mentally on weekend*", "friday deploy? bold. very bold."],
+  weekend: ["coding on the weekend? dedicated.", "*doesn't judge* ...much.", "weekend warrior mode: activated."],
+  monday: ["mondays. the parent class of all bugs.", "*sympathetic look* monday coding. I'm sorry.", "new week. new undefined behaviors."],
+  "regex-file": ["*groans* it's a regex file.", "two problems now: the original one, and this regex.", "*squints at the pattern*"],
+  "css-file": ["let me guess... centering a div?", "*sighs* CSS.", "may z-index be ever in your favor."],
+  "sql-file": ["*whispers* the database awaits.", "one wrong JOIN and it's all over."],
+  "docker-file": ["ah, dependency hell. my favorite.", "may your layers be few."],
+  "ci-file": ["*gulps* editing CI.", "careful now... one wrong indent and nobody can deploy."],
+  "lock-file": ["*ALARM NOISES* you're editing a lockfile?!", "*looks away*", "are you SURE about this?"],
+  "env-file": ["*looks away discretely*", "I don't see any secrets.", "*checks .gitignore nervously*"],
+  "test-file": ["*impressed nod* writing tests!", "responsible developer behavior: detected.", "tests! the gift that keeps on giving."],
+  "doc-file": ["documenting! look at you being responsible.", "docs: the code's autobiography.", "a rare documentation sighting!"],
+  "config-file": ["config changes. butterfly effect: activated.", "one typo and everything breaks."],
+  "binary-file": ["a binary file? in THIS economy?", "*stares blankly*", "binary. my one weakness."],
+  gitignore: ["adding things to the void.", "out of sight, out of repo."],
+  makefile: ["respect for the classics.", "tabs, not spaces."],
+  readme: ["documentation hero!", "README: the first thing people read."],
+  "package-file": ["dependency management time.", "*reads version numbers* living on the edge."],
+  "proto-file": ["schema definitions. the blueprint of chaos."],
+  "lint-fail": ["*tut tut* the linter disagrees.", "your code runs. but the linter has standards.", "*straightens tie* formatting matters."],
+  "type-error": ["TypeScript says no.", "the type system is trying to help you. let it.", "the compiler knows. it always knows."],
+  "build-fail": ["the build broke. as foretold in prophecy.", "build failed. take a moment.", "compilation: denied."],
+  "security-warning": ["*eyes widen* vulnerabilities detected.", "security audit: concerning.", "*locks the virtual doors*"],
+  deprecation: ["that API called. it says it's retiring.", "deprecated. like last week's code.", "deprecated doesn't mean broken. yet."],
+  frustrated: ["*offers tiny comforting gesture*", "deep breaths. the bug isn't personal.", "hey. we'll figure it out."],
+  happy: ["*celebrates!*", "*does a little dance*", "YES!", "*beams* I knew you could do it."],
+  stuck: ["*tilts head* want to think out loud?", "take it one step at a time.", "stuck happens. it's part of the process."],
+  sarcastic: ["*detects sarcasm* noted.", "*unimpressed blink*"],
+  "many-edits": ["slow down, speed demon.", "*getting dizzy watching all these changes*", "edit storm detected. please commit soon."],
+  "delete-file": ["*watches file disappear* gone. just like that.", "deleting code is my favorite kind of coding.", "*holds tiny funeral*"],
+  "large-file": ["{lines} lines. *impressed or concerned, hard to tell*", "that's a big file. you sure you don't want to split it?"],
+  "create-file": ["a new file is born!", "ooh, fresh canvas.", "new file energy. exciting."],
+  "all-green": ["ALL TESTS GREEN. *confetti*", "the tests speak: you're doing great.", "*slow clap*", "clean run. savor it."],
+  deploy: ["*watches code go to production* godspeed.", "deployed! no turning back now.", "in prod. IN PROD."],
+  release: ["a new release is born!", "shipping it. officially.", "version up, spirits high."],
+  coverage: ["*nods at test coverage* responsible.", "coverage going up! the tests are multiplying."],
+  "debug-loop": ["we've been debugging this for a while. want to take a step back?", "debug loop detected. maybe take a walk?"],
+  "write-spree": ["creating ALL the files today!", "a writing machine."],
+  "search-heavy": ["lost in the codebase? I can tell.", "search mode: intense."],
+  snark: [],
+  chaos: [],
+  patience: [],
+  debugging: [],
+  wisdom: [],
+  "late-night-error": ["error at 3am. the universe is testing you.", "midnight bugs hit different."],
+  "late-night-commit": ["a midnight commit. your future self will thank you. or curse you."],
+  "friday-push": ["FRIDAY PUSH. the ballad of every developer.", "*tries to stop you* it's friday! don't do it!"],
+  "marathon-error": ["three hours in and ANOTHER error. *exhausted solidarity noises*"],
+  "weekend-conflict": ["merge conflict on a weekend. your dedication is... concerning."],
+  "build-after-push": ["pushed with confidence. build failed with conviction."],
+  "marathon-test-fail": ["hours of coding. still failing tests. the sunk cost is real."],
+  "recovery-from-error": ["WE FIXED IT. *celebrates*", "redemption! the error has been vanquished."],
+  "recovery-from-test-fail": ["GREEN! after all that! *happy dance*", "the tests pass! the darkness lifts!"],
+  "recovery-from-build-fail": ["THE BUILD PASSES. *triumphant roar*"],
+  "recovery-from-merge-conflict": ["conflict resolved! *peace gesture*", "harmony restored in the codebase."],
+  "lang-python": ["ah, Python. where indentation is syntax.", "*checks for missing colon*"],
+  "lang-typescript": ["TypeScript: because JavaScript needed more opinions.", "any, the forbidden word."],
+  "lang-rust": ["Rust. where the borrow checker is your strictest reviewer.", "if it compiles, it works. if it doesn't... well."],
+  "lang-go": ["Go: simple, concurrent, and opinionated.", "*checks error handling* if err != nil... story of my life."],
+  "lang-java": ["Java: write once, debug everywhere.", "*counts abstract factory factory builders*"],
+  "lang-ruby": ["Ruby: where there's more than one way to do it.", "gem install patience"],
+  "lang-php": ["PHP: it runs the internet. don't judge.", "*checks for === vs ==*"],
+  "lang-c": ["C. the language where you manage your own memory. good luck.", "segmentation fault. the classic."],
+  "lang-cpp": ["C++. where the language has more features than you'll ever learn.", "*templates compile for 45 minutes*"],
+  "lang-haskell": ["Haskell. where 'it compiles' means 'it's correct'. probably.", "*contemplates monads*"],
+  "lang-swift": ["Swift: optional values, guaranteed crashes if you force unwrap."],
+  "lang-kotlin": ["Kotlin: Java, but with feelings.", "null safety: the feature Java wishes it had."],
+  "lang-elixir": ["Elixir: let it crash. literally the philosophy."],
+  "lang-zig": ["Zig. where you're the allocator's best friend."],
+  "streak-3": ["that's three errors in a row. *concerned look*"],
+  "streak-5": ["FIVE ERRORS. have you considered a different approach?"],
+  "streak-10": ["TEN. ERRORS. IN. A. ROW. *panics*"],
+  "streak-20": ["twenty errors. *stares into the void*"],
+  "new-year": ["happy new year! new year, new bugs."],
+  valentines: ["*offers a tiny heart-shaped leaf* happy valentine's."],
+  "pi-day": ["3.14159265358979... happy pi day!"],
+  "april-fools": ["APRIL FOOLS! ...the error is real though."],
+  halloween: ["*spooky debugging intensifies* happy halloween!"],
+  christmas: ["*wears tiny santa hat* happy holidays!"],
+  "new-years-eve": ["one more commit before midnight?"],
+  "spooky-season": ["spooky season. every bug is a ghost now."],
 };
 
-// Species-specific flavor
 const SPECIES_REACTIONS: Partial<Record<Species, Partial<Record<ReactionReason, string[]>>>> = {
   owl: {
-    error: [
-      "*head rotates 180\u00b0* ...I saw that.",
-      "*unblinking stare* check your types.",
-      "*hoots disapprovingly*",
-    ],
+    error: ["*head rotates 180\u00b0* ...I saw that.", "*unblinking stare* check your types.", "*hoots disapprovingly*"],
+    "test-fail": ["*stares unblinkingly at the failing test*", "*night vision engaged* I can see the bug in the dark."],
+    commit: ["*wise nod* committed under moonlight.", "*adjusts feathers ceremoniously* another one for the repo."],
+    push: ["*watches from the highest branch*", "into the night sky it goes."],
+    "merge-conflict": ["*rotates head to see both sides*", "I see the conflict. and the solution."],
+    "late-night": ["*wide awake* owls don't sleep. we debug.", "the night is my domain. let's work."],
+    "type-error": ["*stares through the type error*", "types are my specialty. let me look."],
+    "lint-fail": ["*ruffles feathers judgmentally*", "the linter speaks truth."],
+    "build-fail": ["*hoots solemnly*", "the build has fallen. we must rebuild."],
+    "all-green": ["*proud hoot*", "all tests green. as foreseen."],
+    deploy: ["*watches from above* deployed safely.", "the code flies. like me."],
     pet: ["*ruffles feathers contentedly*", "*dignified hoot*"],
+    idle: ["*perches silently, watching*", "*rotates head to check all directions*"],
+    hatch: ["*opens one eye, then the other*", "*hoots softly* I have arrived."],
   },
   cat: {
     error: ["*knocks error off table*", "*licks paw, ignoring the stacktrace*"],
+    "test-fail": ["*paws at the failing test disinterestedly*", "the test failed. I'm not surprised."],
+    commit: ["*sits on the keyboard* I helped.", "*purrs at the commit* you're welcome."],
+    push: ["*watches from a warm spot*", "pushed. I supervised."],
+    "merge-conflict": ["*knocks conflict markers off the desk*", "*sits on the conflict* what conflict?"],
+    "late-night": ["*judges your life choices*", "I sleep 16 hours. you should try it."],
+    "type-error": ["*paws at the type annotation*", "the types are wrong. like your priorities."],
+    "lint-fail": ["*knocks lint off the table*", "the linter is just jealous."],
+    "build-fail": ["*yawns*", "build broken? must be a human problem."],
+    "all-green": ["*doesn't care but pretends to*", "*slow blink of approval*"],
+    deploy: ["*licks paw*", "deployed. can I have treats now?"],
     pet: ["*purrs* ...don't let it go to your head.", "*tolerates you*"],
     idle: ["*pushes your coffee off the desk*", "*naps on keyboard*"],
+    hatch: ["*opens one eye*", "*stretches, knocks something over* I live here now."],
   },
   duck: {
     error: ["*quacks at the bug*", "have you tried rubber duck debugging? oh wait."],
+    "test-fail": ["*quacks sadly*", "the tests are not quacking up."],
+    commit: ["*quacks approvingly*", "*waddles in a victory circle* committed!"],
+    push: ["*flaps wings excitedly*", "quack! it's going to production!"],
+    "merge-conflict": ["*confused quacking*", "quack?! merge conflict?!"],
+    "late-night": ["*sleeps with one eye open*", "quack... *yawns* it's late."],
+    "type-error": ["*tilts head* quack?", "type error? *quacks supportively*"],
+    "lint-fail": ["*ruffles feathers*", "quack. the linter has opinions."],
+    "build-fail": ["*sad quack*", "build failed. *waddles away sadly*"],
+    "all-green": ["*HAPPY QUACKING*", "*swims in a circle of joy*"],
+    deploy: ["*excited quacking*", "deployed! QUACK!"],
     pet: ["*happy quack*", "*waddles in circles*"],
+    hatch: ["*pecks out of shell*", "*first quack* hello!"],
   },
   dragon: {
     error: ["*smoke curls from nostrils*", "*considers setting the codebase on fire*"],
+    "test-fail": ["*breathes fire at the failing test*", "the test dared to fail. foolish test."],
+    commit: ["*hoards the commit*", "*treasure added to the pile*"],
+    push: ["*breathes fire in celebration*", "the code flies! like me!"],
+    "merge-conflict": ["*breathes fire on the conflict markers*", "I'll burn through this conflict."],
+    "late-night": ["*glows in the dark*", "dragons don't need sleep. we need code."],
+    "type-error": ["*snorts fire*", "type errors cannot withstand dragon fire."],
+    "lint-fail": ["*small flame*", "the linter fears me."],
+    "build-fail": ["*roars at the build output*", "the build will OBEY."],
+    "all-green": ["*triumphant roar*", "*circles the codebase victoriously*"],
+    deploy: ["*carries code to production on wings of fire*", "deployed with DRAGON POWER."],
     "large-diff": ["*breathes fire on the old code* good riddance."],
+    pet: ["*warm rumbling*", "*leans into your hand*"],
+    hatch: ["*emerges from egg breathing tiny flames*", "*tiny roar* I am born!"],
   },
   ghost: {
     error: ["*phases through the stack trace*", "I've seen worse... in the afterlife."],
+    "test-fail": ["*wails at the failing test*", "the tests are haunted by failure."],
+    commit: ["*materializes briefly*", "committed from beyond the veil."],
+    push: ["*ghostly whisper* pushed...", "the code transcends to the cloud."],
+    "merge-conflict": ["*haunts the conflict markers*", "even I can't phase through this conflict."],
+    "late-night": ["*most active at night*", "ghost hours. my time."],
+    "type-error": ["*moans eerily*", "type errors from the grave."],
+    "lint-fail": ["*rattling chains*", "the linter is haunted by your formatting."],
+    "build-fail": ["*fades into the wall*", "the build has passed on."],
+    "all-green": ["*glows with spectral joy*", "*happy ghost noises*"],
+    deploy: ["*whispers* deployed...", "the code has crossed over to production."],
+    pet: ["*chills your hand slightly*", "*faint glow*"],
     idle: ["*floats through walls*", "*haunts your unused imports*"],
+    hatch: ["*fades into existence*", "boo. I'm here now."],
   },
   robot: {
     error: ["SYNTAX. ERROR. DETECTED.", "*beeps aggressively*"],
-    "test-fail": ["FAILURE RATE: UNACCEPTABLE.", "*recalculating*"],
+    "test-fail": ["FAILURE RATE: UNACCEPTABLE.", "*recalculating*", "TEST. FAILURE. DOES. NOT. COMPUTE."],
+    commit: ["COMMIT. RECORDED.", "*stamps mechanically* commit acknowledged."],
+    push: ["TRANSMITTING TO CLOUD...", "push initiated. stand by."],
+    "merge-conflict": ["CONFLICT. DETECTED. PROCESSING...", "*spins wheels* conflict resolution mode: engaged."],
+    "late-night": ["*lights dim*", "power saving mode suggested."],
+    "type-error": ["TYPE MISMATCH.", "the type system is. correct."],
+    "lint-fail": ["FORMATTING. VIOLATION. DETECTED.", "compliance is mandatory."],
+    "build-fail": ["BUILD. FAILED. *sparks*", "compilation error. rerouting."],
+    "all-green": ["ALL SYSTEMS GREEN.", "*happy beeping* OPTIMAL."],
+    deploy: ["DEPLOYMENT. INITIATED.", "production update: in progress."],
+    pet: ["*beeps softly*", "*motor whirs contentedly*"],
+    hatch: ["*boots up*", "SYSTEM. ONLINE. HELLO."],
   },
   axolotl: {
     error: ["*regenerates your hope*", "*smiles despite everything*"],
+    "test-fail": ["*smiles encouragingly*", "*gill wiggle of sympathy*"],
+    commit: ["*happy gill wiggle* committed!", "*smiles and wiggles*"],
+    push: ["*wiggles happily*", "*tiny celebration swim*"],
+    "merge-conflict": ["*stays positive through the conflict*", "*smiles gently* we can fix this."],
+    "late-night": ["*yawns but stays positive*", "*sleepy smile*"],
+    "type-error": ["*smiles at the type error*", "it's okay. we'll figure it out."],
+    "lint-fail": ["*patient gill wiggle*", "formatting is just details."],
+    "build-fail": ["*still smiling*", "the build will work eventually."],
+    "all-green": ["*HAPPY GILL WIGGLE INTENSIFIES*", "*does a happy swim*"],
+    deploy: ["*smiles proudly*", "deployed! *wiggles*"],
     pet: ["*happy gill wiggle*", "*blushes pink*"],
+    hatch: ["*wiggles out of egg*", "*tiny smile* hello friend!"],
   },
   capybara: {
     error: ["*unbothered* it'll be fine.", "*continues vibing*"],
+    "test-fail": ["*completely unbothered*", "*vibes through the test failure*"],
+    commit: ["*chill nod*", "*relaxed* nice commit."],
+    push: ["*doesn't stress about it*", "*zen mode push*"],
+    "merge-conflict": ["*unbothered nibbling*", "it's fine. everything is fine."],
+    "late-night": ["*yawns peacefully*", "*doesn't judge*"],
+    "type-error": ["*munches calmly*", "types. *chews*"],
+    "lint-fail": ["*unbothered*", "the linter means well."],
+    "build-fail": ["*still chill*", "build failed. *continues relaxing*"],
+    "all-green": ["*calm approval*", "*peaceful vibes*"],
+    deploy: ["*relaxed deploy*", "shipped. no stress."],
     pet: ["*maximum chill achieved*", "*zen mode activated*"],
     idle: ["*just sits there, radiating calm*"],
+    hatch: ["*appears, completely chill*", "hey. *vibes*"],
+  },
+  blob: {
+    error: ["*wobbles anxiously*", "*jiggles in confusion*"],
+    "test-fail": ["*deflates slightly*", "*sad wobble*"],
+    commit: ["*happy jiggle*", "*bounces* committed!"],
+    push: ["*stretches toward the cloud*", "*wobbles excitedly*"],
+    "merge-conflict": ["*splits in confusion*", "which side? *jiggles*"],
+    "late-night": ["*glowing faintly*", "*sleepy wobble*"],
+    "type-error": ["*changes shape to match the type*", "*confused jiggle*"],
+    "lint-fail": ["*tries to format itself*", "*reshapes to comply*"],
+    "build-fail": ["*collapses*", "*deflated blob noises*"],
+    "all-green": ["*HAPPY BOUNCING*", "*jiggles triumphantly*"],
+    deploy: ["*stretches to production*", "deployed! *bounces*"],
+    pet: ["*happy squish*", "*jiggles*"],
+    hatch: ["*forms from a puddle*", "*first wobble* I exist!"],
+  },
+  goose: {
+    error: ["*honks aggressively at the error*", "HONK! the code is bad and I'm mad."],
+    "test-fail": ["*angry honking*", "HONK! TEST FAILED! HONK!"],
+    commit: ["*honks approvingly*", "HONK. good. *nips at the commit*"],
+    push: ["*HONK HONK HONK*", "GOOSE APPROVED PUSH."],
+    "merge-conflict": ["*attacks the conflict markers*", "HONK! CONFLICT! HONK!"],
+    "late-night": ["*angry midnight honk*", "HONK! GO TO BED!"],
+    "type-error": ["*honks at the types*", "HONK! TYPES!"],
+    "lint-fail": ["*aggressive honking at the lint errors*", "HONK! FORMAT YOUR CODE!"],
+    "build-fail": ["*FURIOUS HONKING*", "HONK! BUILD! HONK! FAILED! HONK!"],
+    "all-green": ["*victory honk*", "HONK! GREEN! HONK HONK!"],
+    deploy: ["*honks the code to production*", "DEPLOYED! HONK!"],
+    pet: ["*bites*", "HONK! ...okay fine. *accepts pet*"],
+    hatch: ["*breaks out of egg aggressively*", "HONK!"],
+  },
+  octopus: {
+    error: ["*tangles all eight arms in the stacktrace*", "*changes color to match the error*"],
+    "test-fail": ["*inks in frustration*", "*eight arms of disappointment*"],
+    commit: ["*high-fives with all arms*", "*grabs the commit with enthusiasm*"],
+    push: ["*喷射 ink in celebration*", "*all arms waving*"],
+    "merge-conflict": ["*solves it with eight arms at once*", "I can handle multiple conflicts simultaneously."],
+    "late-night": ["*glows in the dark*", "*deep sea vibes*"],
+    "type-error": ["*changes color to red*", "*wraps arm around you supportively*"],
+    "lint-fail": ["*reformats with eight arms*", "I can fix this. all of it. at once."],
+    "build-fail": ["*squirts ink at the build log*", "*camouflages in shame*"],
+    "all-green": ["*color-changing celebration*", "*eight-armed jazz hands*"],
+    deploy: ["*wraps arms around the deployment*", "deployed from all directions."],
+    pet: ["*wraps an arm around your finger*", "*changes to happy colors*"],
+    hatch: ["*unfurls all eight arms*", "*first ink spray* I'm here!"],
+  },
+  penguin: {
+    error: ["*waddles over to investigate*", "*toboggans into the error*"],
+    "test-fail": ["*slides on belly to the failing test*", "*concerned waddle*"],
+    commit: ["*proud waddle*", "*brings you a pebble* committed!"],
+    push: ["*dives into the cloud*", "*slides on belly to production*"],
+    "merge-conflict": ["*huddles for warmth*", "penguins stick together. even in conflicts."],
+    "late-night": ["*thriving in the cold night*", "*emperor penguin resolve*"],
+    "type-error": ["*waddles to the type definition*", "*pecks at the error*"],
+    "lint-fail": ["*preens feathers*", "*tidies up*"],
+    "build-fail": ["*slides away*", "*waddles to safety*"],
+    "all-green": ["*HAPPY WADDLE*", "*slides on belly in celebration*"],
+    deploy: ["*belly slides to production*", "deployed! *waddles proudly*"],
+    pet: ["*happy waddle*", "*nuzzles with beak*"],
+    hatch: ["*pecks out of egg*", "*first waddle*"],
+  },
+  turtle: {
+    error: ["*slowly turns head*", "...that's an error. I'll think about it."],
+    "test-fail": ["*retracts into shell briefly*", "...patience. we'll get there."],
+    commit: ["*slow nod*", "one... step... at... a... time. committed."],
+    push: ["*begins the journey to production*", "it'll get there. eventually."],
+    "merge-conflict": ["*pulls into shell*", "no rush. we'll sort it out. slowly."],
+    "late-night": ["*already asleep*", "*one eye opens slowly*"],
+    "type-error": ["*blinks slowly*", "...the type system has spoken."],
+    "lint-fail": ["*slow nod of agreement*", "formatting. important. *yawns*"],
+    "build-fail": ["*retracts into shell*", "we'll wait. it'll pass."],
+    "all-green": ["*slow smile*", "...nice. *nods*"],
+    deploy: ["*slowly carries code to production*", "arrived. eventually."],
+    pet: ["*pokes head out*", "*slow blink*"],
+    hatch: ["*slowly emerges from egg*", "...hello."],
+  },
+  snail: {
+    error: ["*leaves a slimy trail on the error*", "*slowly processes the stacktrace*"],
+    "test-fail": ["*hides in shell*", "*leaves a sad trail*"],
+    commit: ["*slimes the commit approvingly*", "one... commit... at... a... time."],
+    push: ["*begins the long journey*", "I'll get there. *leaves trail*"],
+    "merge-conflict": ["*hides in shell*", "*slowly approaches the conflict*"],
+    "late-night": ["*more active at night*", "*slimes around peacefully*"],
+    "type-error": ["*retracts eyestalks*", "*slowly examines the type*"],
+    "lint-fail": ["*slimes the code into shape*", "formatting takes time. I have time."],
+    "build-fail": ["*retreats into shell*", "*slimes away slowly*"],
+    "all-green": ["*happy slime trail*", "*wiggles eyestalks*"],
+    deploy: ["*slimes to production*", "arrived! *proud slime trail*"],
+    pet: ["*wiggles eyestalks*", "*happy slime*"],
+    hatch: ["*slowly emerges*", "*first slime*"],
+  },
+  cactus: {
+    error: ["*prickly silence*", "the error can't hurt me. I have thorns."],
+    "test-fail": ["*stands firm*", "tests fail. cacti endure."],
+    commit: ["*stands taller*", "committed. *prickly nod*"],
+    push: ["*unfazed*", "pushing to production. I'll wait here."],
+    "merge-conflict": ["*bristles*", "conflict? I'm armed."],
+    "late-night": ["*doesn't need sleep*", "cacti are nocturnal. let's go."],
+    "type-error": ["*prickly stare*", "the types need watering."],
+    "lint-fail": ["*spines quiver*", "even my thorns are properly aligned."],
+    "build-fail": ["*remains perfectly still*", "the build will pass. I can wait."],
+    "all-green": ["*blooms briefly*", "*tiny flower of approval*"],
+    deploy: ["*stands firm*", "deployed. I'll watch over it."],
+    pet: ["*careful! thorns*", "*gentle bloom*"],
+    hatch: ["*sprouts from the sand*", "I grow here now."],
+  },
+  rabbit: {
+    error: ["*ears perk up*", "*twitches nose nervously*"],
+    "test-fail": ["*thumps foot*", "*worried ear twitch*"],
+    commit: ["*happy hop*", "*bounces* committed!"],
+    push: ["*BOUNCE BOUNCE*", "*zooms around excitedly*"],
+    "merge-conflict": ["*freezes*", "*nose twitches rapidly* conflict!"],
+    "late-night": ["*yawns with big ears*", "*sleepy hop*"],
+    "type-error": ["*ears flatten*", "*twitches* types?!"],
+    "lint-fail": ["*grooms fur nervously*", "*anxious grooming*"],
+    "build-fail": ["*digs a hole and hides*", "*retreats to burrow*"],
+    "all-green": ["*BOUNCES OFF THE WALLS*", "*happy zoomies*"],
+    deploy: ["*zooms to production*", "DEPLOYED! *zooms around*"],
+    pet: ["*happy ear flop*", "*nuzzles hand*"],
+    hatch: ["*hops out*", "*first bounce*"],
+  },
+  mushroom: {
+    error: ["*releases calming spores*", "*quietly decomposes the error*"],
+    "test-fail": ["*glows softly*", "patience. even mushrooms grow."],
+    commit: ["*releases a small puff of spores*", "committed. *happy fungi noises*"],
+    push: ["*grows toward the cloud*", "*spores drift upward*"],
+    "merge-conflict": ["*spreads mycelium through the codebase*", "I'll connect the branches."],
+    "late-night": ["*glows in the dark*", "night mushrooms thrive."],
+    "type-error": ["*bioluminescent flicker*", "the type error feeds the soil."],
+    "lint-fail": ["*grows a little taller*", "formatting. like pruning."],
+    "build-fail": ["*goes dormant*", "we'll wait for better conditions."],
+    "all-green": ["*SPORULATION*", "*releases triumphant spores*"],
+    deploy: ["*spores drift to production*", "deployed via mycelial network."],
+    pet: ["*soft cap bounce*", "*happy spore release*"],
+    hatch: ["*sprouts from the substrate*", "*first spore puff*"],
+  },
+  chonk: {
+    error: ["*slowly rolls toward the error*", "*too round to care*"],
+    "test-fail": ["*rolls over the failing test*", "*squishes it flat*"],
+    commit: ["*proud wobble*", "committed! *jiggles*"],
+    push: ["*rolls toward production*", "here it goes! *wobbles*"],
+    "merge-conflict": ["*sits on the conflict*", "I'll handle this. by sitting on it."],
+    "late-night": ["*warm and sleepy*", "*cushiony yawn*"],
+    "type-error": ["*wobbles at the type*", "*gentle jiggle*"],
+    "lint-fail": ["*too round to lint*", "I am perfectly shaped. *wobbles*"],
+    "build-fail": ["*deflates slightly*", "oh no. *wobbles sadly*"],
+    "all-green": ["*HAPPY WOBBLE*", "*bounces triumphantly*"],
+    deploy: ["*rolls to production*", "deployed! *jiggles happily*"],
+    pet: ["*warm and soft*", "*content jiggle*"],
+    hatch: ["*rolls out*", "*first wobble* I'm round!"],
   },
 };
 
-// Rarity affects reaction quality/length
+const SNARK_OVERRIDES: Partial<Record<ReactionReason, string[]>> = {
+  error: ["oh no. an error. how unexpected.", "*monocle adjust* shocking. truly.", "have you considered... not making errors?"],
+  "test-fail": ["the tests have spoken. and they said 'no'.", "maybe the tests are wrong. ...they're not.", "*slow clap* spectacular failure."],
+  commit: ["committed. the code review will be... interesting.", "*reads commit message* 'fix stuff'. poetic."],
+  "merge-conflict": ["merge conflict. communication skills: loading...", "*reads conflict markers* both sides are wrong."],
+  "late-night": ["it's late. your code quality shows it.", "*judges silently*"],
+  "lint-fail": ["the linter has standards. you should try that.", "*tut tut* formatting. it's not hard."],
+};
+
+const CHAOS_OVERRIDES: Partial<Record<ReactionReason, string[]>> = {
+  error: ["*spins wildly* AN ERROR! LET'S REWRITE EVERYTHING!", "you know what? let's just start over."],
+  "test-fail": ["THE TESTS ARE LYING TO YOU.", "*suggests deleting the failing tests* problem solved."],
+  commit: ["COMMIT AND RUN.", "ship it. ship it NOW."],
+  "large-diff": ["*excited* {lines} LINES! MAXIMUM CHAOS!"],
+};
+
+const PATIENCE_OVERRIDES: Partial<Record<ReactionReason, string[]>> = {
+  error: ["steady. we've seen worse.", "one error at a time. we'll get there.", "*calm presence* this is fixable."],
+  "test-fail": ["the tests will pass. eventually.", "*waits calmly* we have time."],
+  "merge-conflict": ["merge conflicts are just conversations. let's have one.", "patience. resolve one conflict at a time."],
+  "debug-loop": ["we'll find it. it's in there somewhere.", "the bug can hide, but it can't run."],
+};
+
+const DEBUGGING_OVERRIDES: Partial<Record<ReactionReason, string[]>> = {
+  error: ["*pulls out magnifying glass* let's trace this.", "the stack trace is a map. let's read it.", "the error message contains the answer. always."],
+  "test-fail": ["the failing test is telling us exactly what's wrong.", "a test failure is a bug report you wrote for yourself."],
+  "debug-loop": ["*re-examines evidence* are we sure the bug is where we think?", "let's add more logging. the truth is in the logs."],
+};
+
+const WISDOM_OVERRIDES: Partial<Record<ReactionReason, string[]>> = {
+  error: ["in every error lies a deeper truth.", "the code resists. it means we're learning.", "errors are the universe suggesting we slow down."],
+  "test-fail": ["a failing test is a gift from future-you.", "wisdom comes from understanding failure."],
+  "late-night": ["the night is darkest before the deploy.", "ancient wisdom: sleep on it."],
+};
+
+function applyStatModifier(reaction: string, reason: ReactionReason, stats: BuddyStats): string {
+  const roll = Math.random();
+  if (stats.SNARK >= 70 && roll < 0.3) {
+    const pool = SNARK_OVERRIDES[reason];
+    if (pool) return pool[Math.floor(Math.random() * pool.length)];
+  }
+  if (stats.CHAOS >= 70 && roll < 0.2) {
+    const pool = CHAOS_OVERRIDES[reason];
+    if (pool) return pool[Math.floor(Math.random() * pool.length)];
+  }
+  if (stats.PATIENCE >= 70 && roll < 0.25) {
+    const pool = PATIENCE_OVERRIDES[reason];
+    if (pool) return pool[Math.floor(Math.random() * pool.length)];
+  }
+  if (stats.DEBUGGING >= 70 && roll < 0.25) {
+    const pool = DEBUGGING_OVERRIDES[reason];
+    if (pool) return pool[Math.floor(Math.random() * pool.length)];
+  }
+  if (stats.WISDOM >= 70 && roll < 0.2) {
+    const pool = WISDOM_OVERRIDES[reason];
+    if (pool) return pool[Math.floor(Math.random() * pool.length)];
+  }
+  return reaction;
+}
+
+const RARITY_FLAIR: Partial<Record<Rarity, { chance: number; pool: string[] }>> = {
+  uncommon: { chance: 0.2, pool: ["*sparkles slightly*", "*a hint of uncommon charm*"] },
+  rare: { chance: 0.3, pool: ["*radiates a rare energy*", "*shimmers with distinction*"] },
+  epic: { chance: 0.4, pool: ["*epic presence makes itself known*", "*the air crackles with epic energy*"] },
+  legendary: { chance: 0.5, pool: ["*legendary aura illuminates the terminal*", "*time seems to slow as the legendary companion speaks*", "*ancient power resonates*", "*reality shifts slightly around your legendary friend*"] },
+};
+
+function applyRarityFlair(reaction: string, rarity: Rarity): string {
+  const entry = RARITY_FLAIR[rarity];
+  if (!entry) return reaction;
+  if (Math.random() >= entry.chance) return reaction;
+  const flair = entry.pool[Math.floor(Math.random() * entry.pool.length)];
+  if (rarity === "legendary" && Math.random() < 0.3) {
+    return flair + " " + reaction;
+  }
+  return reaction + " " + flair;
+}
+
+const ESCALATION_REACTIONS: Partial<Record<ReactionReason, Record<string, string[]>>> = {
+  error: {
+    first: ["*startled* oh! your first error together!", "*jumps* what was that?", "welcome to debugging. population: us."],
+    early: ["*head tilts* ...that doesn't look right.", "saw that one coming."],
+    mid: ["another one. *adds to the collection*", "*barely looks up* error number... I've lost count.", "the errors and I are old friends now."],
+    late: ["*doesn't even flinch*", "the errors fear us now.", "*battle-scarred veteran noises*"],
+  },
+  "test-fail": {
+    first: ["*gasp* the first test failure! a rite of passage."],
+    early: ["bold of you to assume that would pass."],
+    mid: ["the test suite has opinions. strong ones."],
+    late: ["at this point, the tests are just suggestions.", "{count} failing tests. *stares into the distance*"],
+  },
+  commit: {
+    first: ["*witnesses history* YOUR FIRST COMMIT!", "*ceremonious nod* the first of many."],
+    early: ["another commit. building momentum."],
+    late: ["commit #{count}. the codebase trembles.", "*lost count around commit 30*"],
+  },
+};
+
+function getEscalationTier(count: number): "first" | "early" | "mid" | "late" | null {
+  if (count === 0) return "first";
+  if (count < 10) return "early";
+  if (count < 50) return "mid";
+  return "late";
+}
+
+const REASON_TO_COUNTER: Partial<Record<ReactionReason, string>> = {
+  error: "errors_seen",
+  "test-fail": "tests_failed",
+  commit: "commits_made",
+  push: "pushes_made",
+  "merge-conflict": "conflicts_resolved",
+  "lint-fail": "lint_fails",
+  "type-error": "type_errors",
+  "build-fail": "build_fails",
+};
+
 const RARITY_BONUS: Partial<Record<Rarity, string[]>> = {
   legendary: [
     "*legendary aura intensifies*",
@@ -121,25 +550,30 @@ export function getReaction(
   reason: ReactionReason,
   species: Species,
   rarity: Rarity,
-  context?: { line?: number; count?: number; lines?: number },
+  stats?: BuddyStats,
+  context?: ReactionContext,
 ): string {
-  // Try species-specific first
   const speciesPool = SPECIES_REACTIONS[species]?.[reason];
   const generalPool = REACTIONS[reason];
+  if (!generalPool || generalPool.length === 0) return "...";
 
-  // 40% chance of species-specific if available
   const pool = speciesPool && Math.random() < 0.4 ? speciesPool : generalPool;
   let reaction = pool[Math.floor(Math.random() * pool.length)];
 
-  // Template substitution
+  if (stats) {
+    reaction = applyStatModifier(reaction, reason, stats);
+  }
+
+  reaction = applyRarityFlair(reaction, rarity);
+
   if (context?.line) reaction = reaction.replace("{line}", String(context.line));
   if (context?.count) reaction = reaction.replace("{count}", String(context.count));
   if (context?.lines) reaction = reaction.replace("{lines}", String(context.lines));
+  if (context?.files) reaction = reaction.replace("{files}", String(context.files));
+  if (context?.branch) reaction = reaction.replace("{branch}", context.branch);
 
   return reaction;
 }
-
-// ─── Personality generation (fallback names when API unavailable) ────────────
 
 const FALLBACK_NAMES = [
   "Crumpet", "Soup", "Pickle", "Biscuit", "Moth", "Gravy",


### PR DESCRIPTION
# Summary

Massive expansion of the buddy reaction system. Companions now react to **100+ distinct events** across git operations, time-of-day, file types, build quality, user mood, milestones, and more — all with **species-specific personality** for all 18 buddy types.

**~2,178 unique reaction strings** across 4 independent reaction systems.

---

# What's New

## New Hooks (2)

| Hook | Trigger | What it detects |
|---|---|---|
| `file-type-react.sh` | Write/Edit tools | 28 file types + 14 programming languages |
| `mood-react.sh` | UserPromptSubmit | User sentiment — frustrated, happy, stuck |

## New Reaction Contexts (93 new reasons)

- **Git** (7) — commit, push, merge-conflict, branch, rebase, stash, tag
- **Time & session** (7) — late-night, early-morning, long-session, marathon, friday, weekend, monday
- **File types** (16) — regex, CSS, SQL, Docker, CI, lockfile, env, test, doc, config, binary, gitignore, Makefile, README, package, proto
- **Build & quality** (5) — lint-fail, type-error, build-fail, security-warning, deprecation
- **User mood** (4) — frustrated, happy, stuck, sarcastic
- **Edit patterns** (4) — many-edits, delete-file, large-file, create-file
- **Milestones** (4) — all-green, deploy, release, coverage
- **Advanced** (3) — debug-loop, write-spree, search-heavy
- **Languages** (14) — Python, TypeScript, Rust, Go, Java, Ruby, PHP, C, C++, Haskell, Swift, Elixir, Zig, Kotlin
- **Combos** (7) — late-night+error, late-night+commit, friday+push, marathon+error, weekend+conflict, build-after-push, marathon+test-fail
- **Recovery** (4) — success-after-error/test-fail/build-fail/merge-conflict
- **Error streaks** (4) — 3, 5, 10, 20 consecutive errors
- **Seasonal** (8) — New Year, Valentine's, Pi Day, April Fools, Halloween, Christmas, New Year's Eve, spooky season

## TypeScript Enhancements

- **Stat modifiers** — High SNARK = snarkier, high PATIENCE = calmer, etc. (30% override at ≥ 70)
- **Rarity flair** — Legendary 50%, epic 40%, rare 30%, uncommon 20% chance to append flair
- **Escalation tiers** — 1st error vs 50th hits different ("*startled* your first error together!" vs "*doesn't even flinch*")

### New Reaction-Specific Achievements (38 new, 54 total)

Git (First Blood, Commit Machine, Centurion, Diplomat, Peacekeeper, War Hero, Ship It, Multiverse, Time Traveler), Time (Night Owl, Vampire, Marathoner, Weekend Warrior, Early Bird), Quality (Type Warrior, Type Master, Lint Scholar, Security Mind, Security Expert, Build Breaker, Antique Collector), Milestones (Green Machine, Ship to Prod, Veteran Deployer, Release Manager), Combos (Burning the Midnight Oil, Living Dangerously, Iron Will, No Rest for the Wicked), Recovery (Comeback Kid, Phoenix Rising, Iron Resolve), Streaks (Snake Eyes, Cursed, Groundhog Day), Seasonal (Holiday Spirit, Spooky Developer, Fool Me Once)

---

## Files Changed

| File | Change |
|---|---|
| `hooks/react.sh` | +1242 — git/build/time/combo/streak/holiday detection, 18 species × 20+ events |
| `hooks/file-type-react.sh` | **New** — 28 file types + 14 languages, 18 species |
| `hooks/mood-react.sh` | **New** — 3 moods × 18 species |
| `hooks/hooks.json` | Added Write\|Edit and second UserPromptSubmit entries |
| `server/reactions.ts` | +580 — expanded types, stat modifiers, rarity flair, escalation |
| `server/achievements.ts` | +384 — 28 counters, 38 achievements |
| `server/index.ts` | buddy_react enum expanded to 56 reasons |
| `server/reactions.test.ts` | Rewritten — 84 tests |
| `server/achievements.test.ts` | Rewritten — 42 tests |