### PR TITLE
fix(skill): surface diagnostic when MCP server fails to start

### DIFF
--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -2,12 +2,36 @@
 name: buddy
 description: "Show, pet, or manage your coding companion. Use when the user types /buddy or mentions their companion by name."
 argument-hint: "[show|pet|stats|help|off|on|rename <name>|personality <text>|achievements|summon [slot]|save [slot]|list|dismiss <slot>|pick|frequency [seconds]|style [classic|round]|position [top|left]|rarity [on|off]|statusline [on|off]|uninstall]"
-allowed-tools: mcp__claude_buddy__*
+allowed-tools: mcp__claude_buddy__*, Bash
 ---
 
 # Buddy — Your Coding Companion
 
 Handle the user's `/buddy` command using the claude-buddy MCP tools.
+
+## Fallback: MCP Tools Unavailable
+
+**Before routing any command, check whether `mcp__claude_buddy__*` tools are registered in this session.** If they are NOT — Claude Code was unable to start the claude-buddy MCP server — do not attempt to call any buddy tool. The tool calls will fail with an unhelpful "tool not found" error. Instead, run this diagnostic and report the result to the user so they can fix the underlying cause:
+
+1. Check bun availability:
+   ```bash
+   command -v bun && bun --version
+   ```
+   The MCP launcher (`server/mcp-launcher.sh`) requires `bun` on PATH. If this command prints nothing, bun is missing — tell the user to install it (`curl -fsSL https://bun.sh/install | bash`), open a new terminal so PATH picks it up, and restart Claude Code. That is almost always the fix.
+
+2. If bun IS present, run the launcher directly to capture whatever error it emits. The launcher path depends on which marketplace installed the plugin; locate it first:
+   ```bash
+   find ~/.claude/plugins/cache -name mcp-launcher.sh -path '*claude-buddy*' 2>/dev/null
+   ```
+   Then execute the first result with stdin closed so it exits cleanly:
+   ```bash
+   <launcher-path> < /dev/null; echo "exit=$?"
+   ```
+   Report the stdout/stderr and exit code verbatim. Common causes: missing `bun`, corrupted plugin cache (suggest `claude plugin uninstall claude-buddy@claude-buddy && claude plugin install claude-buddy@claude-buddy`), or a `bun`-level error loading `server/index.ts`.
+
+3. If `$CLAUDE_CONFIG_DIR` is set in the environment, use that directory instead of `~/.claude` when searching for the launcher.
+
+4. **Do not proceed with any buddy command in this session.** Tell the user: the MCP server is not running, here is what the diagnostic found, here is the recommended fix, and Claude Code must be restarted after the fix before buddy tools will be available.
 
 ## Command Routing
 


### PR DESCRIPTION
## Problem

A user installs claude-buddy via the marketplace on a host without `bun` on PATH. `mcp-launcher.sh` already emits a clear stderr message thanks to #53, but Claude Code doesn't surface launcher stderr to users — it simply hides the MCP tools. The user runs `/buddy` and gets:

> The claude-buddy MCP tools don't appear to be available in this session.

No path to resolution. I hit this myself on a Linux host this week.

## Fix

Add a "Fallback: MCP Tools Unavailable" section to `skills/buddy/SKILL.md`. Skills load independently of MCP server state, so the skill remains reachable even when the MCP launcher has failed. When Claude notices `mcp__claude_buddy__*` tools are not registered, it runs a small diagnostic (`command -v bun`, locate and run the launcher with stdin closed) and reports the actual cause to the user with a concrete fix.

## Scope

- `skills/buddy/SKILL.md` only
- Adds `Bash` to `allowed-tools` (already used implicitly by the existing uninstall orchestration section)
- No code changes, no settings.json writes, no new files, no hooks
- Respects `$CLAUDE_CONFIG_DIR` (honoring #62)

## Verified

Reproduced on Ubuntu 24.04 with no bun on PATH, plugin installed via marketplace. Before: opaque "MCP unavailable." After: Claude runs the diagnostic and reports `bun is not installed`, shows the install command, instructs restart.

## Not in scope

- No auto-install of bun
- No writes to `~/.claude/settings.json`
- No retry of `cli/install.ts` behavior — `mcp-launcher.sh` remains the entry point

Happy to iterate if you'd prefer a different phrasing, a shorter/longer diagnostic, or a different place for the troubleshooting text (e.g. README instead of SKILL.md). Thanks for claude-buddy — really glad it exists.

Refs #26, #53.
