### PR TITLE
fix(windows): improve Windows compatibility for jq, terminal width, and owl placement, now places correctly in CLI on windows.

### DIFF
--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -38,3 +38,19 @@ else
 fi
 
 export CLAUDE_CFG_DIR CLAUDE_SETTINGS_FILE CLAUDE_USER_CONFIG BUDDY_STATE_DIR
+
+# Windows: Chocolatey installs a PowerShell shim for jq that doesn't work in
+# Git Bash. If jq is not found on PATH, check the real Chocolatey binary path
+# and common Windows locations, then prepend to PATH so all scripts find it.
+if ! command -v jq >/dev/null 2>&1; then
+    for _jq_candidate in \
+        "/c/ProgramData/chocolatey/lib/jq/tools/jq.exe" \
+        "/c/tools/jq/jq.exe" \
+        "$HOME/bin/jq.exe" \
+        "/usr/local/bin/jq.exe"; do
+        if [ -x "$_jq_candidate" ]; then
+            export PATH="$(dirname "$_jq_candidate"):$PATH"
+            break
+        fi
+    done
+fi

--- a/server/mcp-launcher.sh
+++ b/server/mcp-launcher.sh
@@ -11,7 +11,11 @@ if ! command -v bun >/dev/null 2>&1; then
 
 claude-buddy's MCP server runs on bun. Install it with:
 
+  Linux / macOS:
     curl -fsSL https://bun.sh/install | bash
+
+  Windows (PowerShell):
+    powershell -c "irm bun.sh/install.ps1 | iex"
 
 Then open a new shell (so PATH picks up bun) and restart Claude Code.
 EOF

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -92,6 +92,11 @@ for _ in 1 2 3 4 5; do
     fi
 done
 [ "${COLS:-0}" -lt 40 ] 2>/dev/null && COLS=${COLUMNS:-0}
+# Windows: /proc and TTY device detection don't exist; use PowerShell as fallback
+if [ "${COLS:-0}" -lt 40 ] 2>/dev/null; then
+    _ps_cols=$(powershell.exe -NoProfile -Command "(Get-Host).UI.RawUI.WindowSize.Width" 2>/dev/null | tr -d '\r\n')
+    case "$_ps_cols" in ''|*[!0-9]*) ;; *) [ "$_ps_cols" -gt 40 ] 2>/dev/null && COLS=$_ps_cols ;; esac
+fi
 [ "${COLS:-0}" -lt 40 ] 2>/dev/null && COLS=125
 
 # ─── Species art: 3 frames each (F0, F1, F2) ────────────────────────────────


### PR DESCRIPTION
Fixes three issues that block Windows users from getting
   claude-buddy working out of the box:
  
   1. jq not found (scripts/paths.sh)
   Chocolatey installs a PowerShell shim for jq that silently fails
    in Git Bash — the shim references a relative path that doesn't
   resolve in a subprocess context. All shell scripts exit with no
   output because jq returns empty strings. Fix: paths.sh now
   searches common Windows locations for the real jq.exe when jq 
   isn't on PATH.
  
   2. Owl renders off-screen (statusline/buddy-status.sh)
   /proc and TTY device detection both fail on Windows, so terminal
    width falls back to 125. If the actual window is narrower, the
   right-alignment spacer pushes all content off the right edge —
   users see only .----------… or nothing. Fix: add a PowerShell
   fallback for width detection before the hardcoded 125 default.
  
   3. bun install message (server/mcp-launcher.sh)
   Error message only showed the curl | bash install method. Added
   the Windows PowerShell equivalent: irm bun.sh/install.ps1 | iex.
  
   Tested on Windows 11 with Git Bash and Claude Code CLI.