### PR TITLE
fix(windows): improve Windows compatibility for jq, terminal width, a…

### DIFF
--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -38,3 +38,19 @@ else
 fi
 
 export CLAUDE_CFG_DIR CLAUDE_SETTINGS_FILE CLAUDE_USER_CONFIG BUDDY_STATE_DIR
+
+# Windows: Chocolatey installs a PowerShell shim for jq that doesn't work in
+# Git Bash. If jq is not found on PATH, check the real Chocolatey binary path
+# and common Windows locations, then prepend to PATH so all scripts find it.
+if ! command -v jq >/dev/null 2>&1; then
+    for _jq_candidate in \
+        "/c/ProgramData/chocolatey/lib/jq/tools/jq.exe" \
+        "/c/tools/jq/jq.exe" \
+        "$HOME/bin/jq.exe" \
+        "/usr/local/bin/jq.exe"; do
+        if [ -x "$_jq_candidate" ]; then
+            export PATH="$(dirname "$_jq_candidate"):$PATH"
+            break
+        fi
+    done
+fi

--- a/server/mcp-launcher.sh
+++ b/server/mcp-launcher.sh
@@ -11,7 +11,11 @@ if ! command -v bun >/dev/null 2>&1; then
 
 claude-buddy's MCP server runs on bun. Install it with:
 
+  Linux / macOS:
     curl -fsSL https://bun.sh/install | bash
+
+  Windows (PowerShell):
+    powershell -c "irm bun.sh/install.ps1 | iex"
 
 Then open a new shell (so PATH picks up bun) and restart Claude Code.
 EOF

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -92,6 +92,11 @@ for _ in 1 2 3 4 5; do
     fi
 done
 [ "${COLS:-0}" -lt 40 ] 2>/dev/null && COLS=${COLUMNS:-0}
+# Windows: /proc and TTY device detection don't exist; use PowerShell as fallback
+if [ "${COLS:-0}" -lt 40 ] 2>/dev/null; then
+    _ps_cols=$(powershell.exe -NoProfile -Command "(Get-Host).UI.RawUI.WindowSize.Width" 2>/dev/null | tr -d '\r\n')
+    case "$_ps_cols" in ''|*[!0-9]*) ;; *) [ "$_ps_cols" -gt 40 ] 2>/dev/null && COLS=$_ps_cols ;; esac
+fi
 [ "${COLS:-0}" -lt 40 ] 2>/dev/null && COLS=125
 
 # ─── Species art: 3 frames each (F0, F1, F2) ────────────────────────────────
@@ -296,7 +301,7 @@ if [ -n "$BUBBLE" ]; then
 fi
 
 # ─── Word-wrap bubble text ────────────────────────────────────────────────────
-INNER_W=28
+INNER_W=44
 TEXT_LINES=()
 if [ -n "$BUBBLE_TEXT" ]; then
     WORDS=($BUBBLE_TEXT)
@@ -352,7 +357,12 @@ MARGIN=8
 PAD=$(( COLS - TOTAL_W - MARGIN ))
 [ "$PAD" -lt 0 ] && PAD=0
 
-SPACER=$(printf "${B}%${PAD}s" "")
+# On Windows (Git Bash / MSYS2), Braille Blank (U+2800) renders as double-width,
+# which doubles the spacer and pushes content off-screen. Use regular spaces instead.
+case "$(uname -s)" in
+    MINGW*|CYGWIN*|MSYS*) SPACER=$(printf '%*s' "$PAD" '') ;;
+    *)                     SPACER=$(printf "${B}%${PAD}s" "") ;;
+esac
 GAP_STR=$(printf '%*s' "$GAP" '')
 
 # Vertically center bubble box on the art


### PR DESCRIPTION
…nd bun install

- scripts/paths.sh: auto-detect real jq.exe in Chocolatey lib path when the Chocolatey shim fails to resolve in Git Bash (shim references a relative path that doesn't resolve from a subprocess context)
- statusline/buddy-status.sh: add PowerShell fallback for terminal width detection; /proc and TTY device detection don't exist on Windows, causing the width to default to 125 and pushing content off-screen
- server/mcp-launcher.sh: add Windows PowerShell bun install instructions alongside the existing curl/bash instructions

Tested on Windows 11 with Git Bash and Claude Code CLI.