### PR TITLE
fix: speech bubble bottom border cut off for long text

### DIFF
--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -372,8 +372,15 @@ if [ $BUBBLE_COUNT -gt 2 ]; then
 fi
 
 # ─── Output: merged bubble box + connector + art per line ─────────────────────
-for (( i=0; i<ART_COUNT; i++ )); do
-    art_part="${ALL_COLORS[$i]}${ALL_LINES[$i]}${NC}"
+TOTAL_BUBBLE=$(( BUBBLE_START + BUBBLE_COUNT ))
+MAX_LINES=$(( ART_COUNT > TOTAL_BUBBLE ? ART_COUNT : TOTAL_BUBBLE ))
+for (( i=0; i<MAX_LINES; i++ )); do
+    # Art part: actual art line or blank filler
+    if [ $i -lt $ART_COUNT ]; then
+        art_part="${ALL_COLORS[$i]}${ALL_LINES[$i]}${NC}"
+    else
+        art_part=$(printf '%*s' "$ART_W" '')
+    fi
 
     if [ $BUBBLE_COUNT -gt 0 ]; then
         bi=$(( i - BUBBLE_START ))


### PR DESCRIPTION
## Summary

- The output loop in `buddy-status.sh` was bounded by `ART_COUNT`, so when the speech bubble had more lines than the buddy art (5+ text lines), the bottom border was silently clipped
- Changed the loop bound to `max(ART_COUNT, BUBBLE_START + BUBBLE_COUNT)` and pad with blank art lines when the bubble is taller than the buddy

## Test plan

- [x] Run `bun test` — all 127 tests pass
- [x] Trigger a long buddy reaction (5+ lines) and verify the bottom border `.------'` renders correctly
- [x] Verify short reactions (1-3 lines) still render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)