### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-buddy",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Permanent coding companion for Claude Code — survives any update (MVP)",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Version bump from 0.3.0 → 0.4.0

## What's new in v0.4.0
- fix(statusline, art): account for emoji display width (#88)
- fix(statusline): align capybara and chonk art rows (#90)
- fix: speech bubble bottom border cut off for long text (#81)
- fix(windows): improve Windows compatibility (#80)
- fix(skill): surface diagnostic when MCP server fails to start (#77)
- feat(pick): more search criteria, async search with cancel, generated personality (#85)

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (137 tests)
- [x] Full install→uninstall→re-install cycle green