### PR TITLE
docs: add new commands to README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ claude-buddy/
 | `/buddy style [classic\|round]` | Bubble border style (tmux only) |
 | `/buddy position [top\|left]` | Bubble position (tmux only) |
 | `/buddy rarity [on\|off]` | Show or hide stars + rarity line (tmux only) |
+| `/buddy width [10-60]` | Set bubble text width in chars (tmux only) |
+| `/buddy margin [0-20]` | Set right-side margin (tmux only) |
+| `/buddy statusline [on\|off]` | Enable or disable buddy in the status line |
+| `/buddy statusline combined` | Show rate-limit usage bars alongside buddy (needs python3) |
+| `/buddy statusline basic` | Switch back to buddy-only status line |
 | `/buddy help` | Show all buddy commands |
 
 ### CLI


### PR DESCRIPTION
Adds /buddy width, /buddy margin, /buddy statusline combined|basic to the Commands Reference table.