### PR TITLE
fix: use IFS instead of mapfile

### DIFF
--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -52,7 +52,10 @@ if [ -z "$FRAME_BODY" ]; then
     FRAME_BODY=$'            \n    (°°)    \n    (  )    \n            \n            '
 fi
 
-mapfile -t ART_LINES <<< "$FRAME_BODY"
+ART_LINES=()
+while IFS= read -r line; do
+    ART_LINES+=("$line")
+done <<< "$FRAME_BODY"
 
 # ─── Rarity color (pC4 = dark theme, the default) ────────────────────────────
 NC=$'\033[0m'


### PR DESCRIPTION
Instead of relying on mapfile, this PR changes to use IFS `read -r`, which is supported by bash versions from 2.05 upwards.

fixes: https://github.com/1270011/claude-buddy/issues/104

Tests ran successfully:
```
  ⎿  bun test v1.3.12 (700fc117)

      246 pass
      0 fail
      28553 expect() calls
     Ran 246 tests across 10 files. [211.00ms]
```