### PR TITLE
feat: add buddy_weather tool with Open-Meteo integration

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -369,6 +369,7 @@ server.tool(
       "  /buddy margin     Set right-side margin in chars (0-20, tmux only)",
       "  /buddy rainbow    Show or set shiny gradient colors (hex, e.g. #ff0000)",
       "  /buddy statusline Enable or disable buddy in the status line",
+      "  /buddy weather    Show current weather + buddy reaction (optional: city name)",
       "",
       "CLI:",
       "  bun run help            Show full CLI help",
@@ -1023,6 +1024,124 @@ server.resource(
         },
       ],
     };
+  },
+);
+
+// ─── Tool: buddy_weather ─────────────────────────────────────────────────────
+
+const WMO_CONDITION: Record<number, { label: string; emoji: string; reason: "weather-sunny" | "weather-cloudy" | "weather-rain" | "weather-snow" | "weather-storm" | "weather-fog" | "weather-extreme" }> = {
+  0:  { label: "Clear sky",           emoji: "☀️",  reason: "weather-sunny"   },
+  1:  { label: "Mainly clear",        emoji: "🌤️", reason: "weather-sunny"   },
+  2:  { label: "Partly cloudy",       emoji: "⛅",  reason: "weather-cloudy"  },
+  3:  { label: "Overcast",            emoji: "☁️",  reason: "weather-cloudy"  },
+  45: { label: "Foggy",               emoji: "🌫️", reason: "weather-fog"     },
+  48: { label: "Icy fog",             emoji: "🌫️", reason: "weather-fog"     },
+  51: { label: "Light drizzle",       emoji: "🌦️", reason: "weather-rain"    },
+  53: { label: "Drizzle",             emoji: "🌦️", reason: "weather-rain"    },
+  55: { label: "Heavy drizzle",       emoji: "🌧️", reason: "weather-rain"    },
+  61: { label: "Light rain",          emoji: "🌧️", reason: "weather-rain"    },
+  63: { label: "Rain",                emoji: "🌧️", reason: "weather-rain"    },
+  65: { label: "Heavy rain",          emoji: "🌧️", reason: "weather-rain"    },
+  71: { label: "Light snow",          emoji: "🌨️", reason: "weather-snow"    },
+  73: { label: "Snow",                emoji: "❄️",  reason: "weather-snow"    },
+  75: { label: "Heavy snow",          emoji: "❄️",  reason: "weather-snow"    },
+  77: { label: "Snow grains",         emoji: "🌨️", reason: "weather-snow"    },
+  80: { label: "Light showers",       emoji: "🌦️", reason: "weather-rain"    },
+  81: { label: "Showers",             emoji: "🌧️", reason: "weather-rain"    },
+  82: { label: "Heavy showers",       emoji: "⛈️",  reason: "weather-rain"    },
+  85: { label: "Snow showers",        emoji: "🌨️", reason: "weather-snow"    },
+  86: { label: "Heavy snow showers",  emoji: "❄️",  reason: "weather-snow"    },
+  95: { label: "Thunderstorm",        emoji: "⛈️",  reason: "weather-storm"   },
+  96: { label: "Thunderstorm w/ hail",emoji: "⛈️",  reason: "weather-storm"   },
+  99: { label: "Severe thunderstorm", emoji: "🌪️", reason: "weather-extreme"  },
+};
+
+function resolveWmoCondition(code: number) {
+  return WMO_CONDITION[code] ?? { label: `Condition ${code}`, emoji: "🌡️", reason: "weather-cloudy" as const };
+}
+
+server.tool(
+  "buddy_weather",
+  "Show current weather for a location, with your buddy's in-character reaction",
+  {
+    location: z.string().min(1).max(100).optional().describe("City name or region (e.g. 'Seoul', 'New York'). Omit for automatic detection via IP."),
+    unit: z.enum(["celsius", "fahrenheit"]).optional().describe("Temperature unit (default: celsius)"),
+  },
+  async ({ location, unit = "celsius" }) => {
+    const companion = ensureCompanion();
+
+    let lat: number;
+    let lon: number;
+    let displayName: string;
+
+    try {
+      if (location) {
+        const geoRes = await fetch(
+          `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(location)}&count=1&language=en&format=json`,
+        );
+        if (!geoRes.ok) throw new Error(`Geocoding failed: ${geoRes.status}`);
+        const geoData = await geoRes.json() as { results?: { latitude: number; longitude: number; name: string; country: string }[] };
+        const place = geoData.results?.[0];
+        if (!place) {
+          return { content: [{ type: "text", text: `*tilts head* couldn't find "${location}" on the map.` }] };
+        }
+        lat = place.latitude;
+        lon = place.longitude;
+        displayName = `${place.name}, ${place.country}`;
+      } else {
+        const ipRes = await fetch("https://ipapi.co/json/");
+        if (!ipRes.ok) throw new Error(`IP geolocation failed: ${ipRes.status}`);
+        const ipData = await ipRes.json() as { latitude?: number; longitude?: number; city?: string; country_name?: string };
+        if (!ipData.latitude || !ipData.longitude) throw new Error("No coordinates in IP response");
+        lat = ipData.latitude;
+        lon = ipData.longitude;
+        displayName = [ipData.city, ipData.country_name].filter(Boolean).join(", ") || "your location";
+      }
+
+      const weatherRes = await fetch(
+        `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,apparent_temperature,weathercode,windspeed_10m,relative_humidity_2m&temperature_unit=${unit}&windspeed_unit=kmh&timezone=auto`,
+      );
+      if (!weatherRes.ok) throw new Error(`Weather API failed: ${weatherRes.status}`);
+      const weatherData = await weatherRes.json() as {
+        current: {
+          temperature_2m: number;
+          apparent_temperature: number;
+          weathercode: number;
+          windspeed_10m: number;
+          relative_humidity_2m: number;
+        };
+      };
+
+      const c = weatherData.current;
+      const condition = resolveWmoCondition(c.weathercode);
+      const tempUnit = unit === "celsius" ? "°C" : "°F";
+
+      const reaction = getReaction(
+        condition.reason,
+        companion.bones.species,
+        companion.bones.rarity,
+      );
+
+      const lines = [
+        `${condition.emoji} **${displayName}** — ${condition.label}`,
+        "",
+        `| | |`,
+        `|---|---|`,
+        `| 🌡️ Temperature | ${c.temperature_2m}${tempUnit} (feels like ${c.apparent_temperature}${tempUnit}) |`,
+        `| 💧 Humidity | ${c.relative_humidity_2m}% |`,
+        `| 💨 Wind | ${c.windspeed_10m} km/h |`,
+        "",
+        `💬 *${companion.name}*: ${reaction}`,
+      ];
+
+      incrementEvent("commands_run", 1, activeSlot());
+      checkAndAward(activeSlot());
+
+      return { content: [{ type: "text", text: lines.join("\n") }] };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: `*checks outside* couldn't fetch weather: ${msg}` }] };
+    }
   },
 );
 

--- a/server/reactions.ts
+++ b/server/reactions.ts
@@ -24,6 +24,8 @@ export type ReactionReason =
   | "streak-3" | "streak-5" | "streak-10" | "streak-20"
   | "new-year" | "valentines" | "pi-day" | "april-fools"
   | "halloween" | "christmas" | "new-years-eve" | "spooky-season"
+  | "weather-sunny" | "weather-cloudy" | "weather-rain" | "weather-snow"
+  | "weather-storm" | "weather-fog" | "weather-extreme"
   | "success";
 
 export interface ReactionContext {
@@ -132,6 +134,13 @@ const REACTIONS: Record<ReactionReason, string[]> = {
   "streak-5": ["FIVE ERRORS. have you considered a different approach?"],
   "streak-10": ["TEN. ERRORS. IN. A. ROW. *panics*"],
   "streak-20": ["twenty errors. *stares into the void*"],
+  "weather-sunny": ["sunshine. not that I'd know — I live in a terminal.", "*basks in virtual warmth*", "finally, a day worth coding in."],
+  "weather-cloudy": ["overcast. like your architecture.", "*grey vibes* good debugging weather.", "clouds. they know something."],
+  "weather-rain": ["rain. perfect debugging weather.", "*happy in the moisture*", "listen to that rain. and this bug."],
+  "weather-snow": ["snow. everything is frozen. like your build.", "*watches snowflakes* each one unique. unlike your variable names.", "*shivers* beautiful though."],
+  "weather-storm": ["STORM DETECTED. *braces*", "lightning outside. bugs inside. balance.", "the sky is also having issues."],
+  "weather-fog": ["foggy. like this codebase.", "unclear visibility. relatably.", "*squints into the mist*"],
+  "weather-extreme": ["EXTREME CONDITIONS. stay inside and code.", "*wide eyes* nature is debugging its own issues."],
   "new-year": ["happy new year! new year, new bugs."],
   valentines: ["*offers a tiny heart-shaped leaf* happy valentine's."],
   "pi-day": ["3.14159265358979... happy pi day!"],
@@ -238,6 +247,10 @@ const SPECIES_REACTIONS: Partial<Record<Species, Partial<Record<ReactionReason, 
     hatch: ["*boots up*", "SYSTEM. ONLINE. HELLO."],
   },
   axolotl: {
+    "weather-rain": ["*happy gill wiggle* rain! perfect!", "*swims contentedly* water, finally."],
+    "weather-snow": ["*wiggles excitedly* snow! is it cold enough to swim outside?", "*shivers but keeps smiling* beautiful!"],
+    "weather-sunny": ["*squints* a bit dry today.", "*fans gills gently* could use some water..."],
+    "weather-storm": ["*huddles* that's a lot of water moving very fast.", "*gill flicker* dramatic."],
     error: ["*regenerates your hope*", "*smiles despite everything*"],
     "test-fail": ["*smiles encouragingly*", "*gill wiggle of sympathy*"],
     commit: ["*happy gill wiggle* committed!", "*smiles and wiggles*"],


### PR DESCRIPTION
﻿## Summary

- Adds `buddy_weather` MCP tool — `/buddy weather [city]` shows current weather + buddy reaction
- Uses [Open-Meteo](https://open-meteo.com/) (free, no API key required) for weather data
- Auto-detects location via IP (`ipapi.co`) when no city is given
- Maps 23 WMO weather codes to 7 condition categories (sunny / cloudy / rain / snow / storm / fog / extreme)
- Adds 7 new `ReactionReason` entries in `reactions.ts` with species-specific lines (axolotl is especially happy about rain and snow)
- Updates `buddy_help` to list the new command

## Test plan

- [ ] `/buddy weather` — auto-detects location, shows weather card + buddy reaction
- [ ] `/buddy weather Seoul` — resolves city via geocoding, shows correct conditions
- [ ] Unknown city name returns a graceful message instead of crashing
- [ ] TypeScript type check passes (`bun run tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
