### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ Thumbs.db
 coverage/
 .nyc_output/
 
+# Worktrees
+.worktrees/
+
 # Local / Python dev
 .envrc
 .python-version


### PR DESCRIPTION
## Summary
- Adds `.worktrees/` to `.gitignore` so git worktree checkouts created under the project root aren't tracked as untracked files

## Test plan
- [ ] Verify `.worktrees/` directory does not appear in `git status` after creating a worktree under that path