### PR TITLE
fix: bun pick UI improvements (width fix, remove buddy option)

### DIFF
--- a/cli/pick.ts
+++ b/cli/pick.ts
@@ -17,7 +17,7 @@
 
 import {
   loadActiveSlot, saveActiveSlot, listCompanionSlots,
-  loadCompanionSlot, saveCompanionSlot, slugify, unusedName, writeStatusState,
+  loadCompanionSlot, saveCompanionSlot, deleteCompanionSlot, slugify, unusedName, writeStatusState,
 } from "../server/state.ts";
 import {
   generateBones, generatePersonality, SPECIES, RARITIES, STAT_NAMES, RARITY_STARS, EYES, HATS,
@@ -125,6 +125,7 @@ interface State {
   searchStatus:  string;
   nameInput:     string;
   pendingResult: BuddyResult | null;
+  confirmDelete: boolean;
   message:       string;
 }
 
@@ -143,6 +144,7 @@ function fresh(): State {
     searchStatus:  "",
     nameInput:     "",
     pendingResult: null,
+    confirmDelete: false,
     message:       "",
   };
 }
@@ -153,7 +155,7 @@ const LEFT_W = 36;
 
 function savedPane(s: State): string[] {
   const lines: string[] = [];
-  lines.push(`${B}  Your Menagerie${N}  ${GR}[s] search${N}`);
+  lines.push(`${B}  Your Menagerie${N}  ${GR}[s] search  [d] remove${N}`);
   lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
 
   if (s.savedSlots.length === 0) {
@@ -176,6 +178,10 @@ function savedPane(s: State): string[] {
   }
 
   lines.push(GR + "  " + "─".repeat(LEFT_W - 2) + N);
+  if (s.confirmDelete) {
+    const entry = s.savedSlots[s.savedCursor];
+    lines.push(`  ${YL}remove ${B}${entry?.companion.name ?? "?"}${N}${YL}? [d/y] yes  [any] no${N}`);
+  }
   return lines;
 }
 
@@ -309,7 +315,7 @@ function drawScreen(s: State): void {
 
   // Footer — mode-specific help
   const helpText =
-    s.mode === "saved"     ? "↑↓ navigate  enter summon  r random  s search  q quit" :
+    s.mode === "saved"     ? "↑↓ navigate  enter summon  r random  s search  d remove  q quit" :
     s.mode === "criteria"  ? "↑↓ field  ←→ value  enter search  esc back" :
     s.mode === "searching" ? "any key to stop and show results so far" :
     s.mode === "results"   ? "↑↓ navigate  enter name+save  esc back  q quit" :
@@ -438,12 +444,26 @@ function onKey(key: string, s: State): boolean {
     }
 
     case "saved": {
+      if (s.confirmDelete) {
+        if (key === "d" || key === "y") {
+          const entry = s.savedSlots[s.savedCursor];
+          if (entry) {
+            deleteCompanionSlot(entry.slot);
+            s.savedSlots  = listCompanionSlots();
+            s.activeSlot  = loadActiveSlot();
+            s.savedCursor = clamp(s.savedCursor, 0, Math.max(0, s.savedSlots.length - 1));
+            s.message     = `✗ ${entry.companion.name} removed`;
+          }
+        }
+        s.confirmDelete = false;
+        break;
+      }
       if (key === "q")                          return true;
       if (key === "s")                          { s.mode = "criteria"; break; }
+      if (key === "d" && s.savedSlots.length > 0) { s.confirmDelete = true; break; }
       if (key === "\x1b[A" || key === "k")      s.savedCursor = clamp(s.savedCursor - 1, 0, s.savedSlots.length - 1);
       else if (key === "\x1b[B" || key === "j") s.savedCursor = clamp(s.savedCursor + 1, 0, s.savedSlots.length - 1);
       else if (key === "r") {
-        // Random pick from menagerie
         if (s.savedSlots.length > 0) {
           const entry = s.savedSlots[Math.floor(Math.random() * s.savedSlots.length)];
           s.savedCursor = s.savedSlots.indexOf(entry);

--- a/cli/pick.ts
+++ b/cli/pick.ts
@@ -275,9 +275,7 @@ function previewPane(s: State): string[] {
   }
 
   if (!c) return [`  ${GR}no preview${N}`];
-  // Calculate available width for the right pane (total cols - left pane - separator)
-  const cols = Math.max(80, process.stdout.columns || 80);
-  const rightW = cols - LEFT_W - 3;
+  const rightW = 34;
   return renderCompanionCard(c.bones, c.name, c.personality, undefined, 0, rightW).split("\n");
 }
 


### PR DESCRIPTION
## Summary
- Fixes the right pane preview width in `bun run pick` to use a fixed 34-char width, rendering more reliably on smaller screen sizes
- Adds a `[d] remove` option in the menagerie view of the picker — press `d` on any saved buddy to get a confirm prompt, then `d`/`y` to confirm or any other key to cancel

## Test plan
- [ ] Run `bun run pick`, verify right pane renders cleanly at narrow terminal widths
- [ ] In saved menagerie view, press `d` on a buddy — confirm prompt appears
- [ ] Confirm deletion removes the buddy from the list
- [ ] Cancel (any key other than `d`/`y`) leaves buddy intact