### PR TITLE
fix: allow empty array for rainbow reset in buddy_style

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -456,11 +456,11 @@ server.tool(
       .describe("Right-side margin between buddy and terminal edge (0–20, default 3)"),
     rainbow: z
       .array(z.string().regex(/^#[0-9a-fA-F]{6}$/, "Must be a hex color like #ff0000"))
-      .min(1)
+      .min(0)
       .max(16)
       .optional()
       .describe(
-        "Custom rainbow gradient for shiny buddies — array of 1–16 hex colors (e.g. [\"#ff0000\",\"#00ff00\"]). Omit to reset to default ROYGBIV.",
+        "Custom rainbow gradient for shiny buddies — array of 1–16 hex colors (e.g. [\"#ff0000\",\"#00ff00\"]). Pass [] to reset to default ROYGBIV.",
       ),
   },
   async ({ style, position, showRarity, width, margin, rainbow }) => {


### PR DESCRIPTION
The `/buddy rainbow reset` command passes `[]` to `buddy_style`, but the Zod schema had `.min(1)` which rejected empty arrays at validation time — the handler never ran. The fix is `.min(0)`. The handler at line 494 already correctly treats `[]` as a reset signal.