### PR TITLE
feat(statusline): show context-token usage below the buddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Five integration points, zero binary dependencies. When Claude Code updates, you
 
 - **MCP Server** — companion tools + system prompt that instructs Claude to write buddy comments
 - **Skill** — routes `/buddy`, `/buddy pet`, `/buddy stats`, `/buddy off`, `/buddy rename`
-- **Status Line** — animated ASCII art, right-aligned, with rarity color and speech bubble
+- **Status Line** — animated ASCII art, right-aligned, with rarity color, speech bubble, and a context-token readout (e.g. `77.3k 7%`) below the name
 - **PostToolUse Hook** — detects errors, test failures, large diffs in Bash output
 - **Stop Hook** — extracts invisible `<!-- buddy: ... -->` comments from Claude's responses
 

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -38,7 +38,33 @@ ACHIEVEMENT=$(jq -r '.achievement // ""' "$STATE" 2>/dev/null)
 LEVEL=$(jq -r '.level // 1' "$STATE" 2>/dev/null)
 MOOD=$(jq -r '.mood // "focused"' "$STATE" 2>/dev/null)
 
-cat > /dev/null  # drain stdin
+INPUT=$(cat)  # capture Claude Code status JSON from stdin
+
+# ─── Token usage from transcript ─────────────────────────────────────────────
+TOKEN_LINE=""
+if [ -n "$INPUT" ]; then
+    TRANSCRIPT=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
+    MODEL_ID=$(printf '%s' "$INPUT" | jq -r '.model.id // ""' 2>/dev/null)
+    if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+        # Last line of JSONL with a usage block — sum input + cache tokens = context size
+        USAGE=$(tac "$TRANSCRIPT" 2>/dev/null | grep -m1 '"usage"' || tail -r "$TRANSCRIPT" 2>/dev/null | grep -m1 '"usage"')
+        if [ -n "$USAGE" ]; then
+            IN=$(printf '%s' "$USAGE" | jq -r '..|.usage?|select(.)|.input_tokens // 0' 2>/dev/null | head -1)
+            CR=$(printf '%s' "$USAGE" | jq -r '..|.usage?|select(.)|.cache_read_input_tokens // 0' 2>/dev/null | head -1)
+            CC=$(printf '%s' "$USAGE" | jq -r '..|.usage?|select(.)|.cache_creation_input_tokens // 0' 2>/dev/null | head -1)
+            TOTAL=$(( ${IN:-0} + ${CR:-0} + ${CC:-0} ))
+            case "$MODEL_ID" in
+                *1m*|*"[1m]"*) LIMIT=1000000 ;;
+                *)             LIMIT=200000  ;;
+            esac
+            if [ "$TOTAL" -gt 0 ]; then
+                PCT=$(( TOTAL * 100 / LIMIT ))
+                DISPLAY=$(awk -v t="$TOTAL" 'BEGIN{ if(t>=1000) printf "%.1fk", t/1000; else printf "%d", t }')
+                TOKEN_LINE="${DISPLAY} ${PCT}%"
+            fi
+        fi
+    fi
+fi
 
 # ─── Animation: pick current frame from server-rendered frames ──────────────
 NOW=${BUDDY_FAKE_NOW:-$(date +%s)}
@@ -220,6 +246,14 @@ for line in "${ART_LINES[@]}"; do
     _arc=$(( _arc + 1 ))
 done
 ALL_LINES+=("$NAME_LINE"); ALL_COLORS+=("$DIM")
+
+if [ -n "$TOKEN_LINE" ]; then
+    TOKEN_LEN=${#TOKEN_LINE}
+    TOKEN_PAD=$(( ART_CENTER - TOKEN_LEN / 2 ))
+    [ "$TOKEN_PAD" -lt 0 ] && TOKEN_PAD=0
+    TOKEN_RENDER="$(printf '%*s%s' "$TOKEN_PAD" '' "$TOKEN_LINE")"
+    ALL_LINES+=("$TOKEN_RENDER"); ALL_COLORS+=("$DIM")
+fi
 
 ART_W=14
 ART_COUNT=${#ALL_LINES[@]}


### PR DESCRIPTION
## What

Adds a small context-token readout under the buddy in the status line, e.g.:

```
   /^\
  /\_/\
 ( ×   ×)
 (  ω  )
 (")_(")
    BBQ
  77.3k 7%      ← new: current context tokens + % of the model's window
```

## How

The status line script already received Claude Code's status JSON on stdin but discarded it (`cat > /dev/null`). This captures it instead and:

1. Reads `transcript_path` + `model.id` from the status JSON.
2. Greps the **last** `usage` block in the transcript JSONL and sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` to approximate the live context size.
3. Picks the denominator from the model id — `1m`/`[1m]` → 1,000,000, otherwise 200,000 — and renders `<tokens> <pct>%`, centered under the name.

## Safety / compatibility

- **Degrades silently.** No transcript, no `usage` block, or empty stdin → no line is added, so behaviour is unchanged when the data isn't there.
- Touches only the two existing insertion points (stdin drain + the name-line append); the server-rendered frame pipeline is untouched.
- `bash -n` clean; verified rendering against a synthetic transcript on both 1M and 200k models.

## Open question for maintainers

It's currently always-on. Happy to gate it behind a `showTokens` flag in `config.json` (and a `/buddy statusline tokens on|off` toggle) if you'd prefer it opt-in — let me know and I'll add it.