### PR TITLE
Preserve coding-buddy executable when publishing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,18 @@
 {
-    "name": "claude-buddy",
+    "name": "coding-buddy",
     "owner": {
         "name": "1270011"
     },
     "metadata": {
-        "description": "Permanent coding companion for Claude Code (requires bun: https://bun.sh/install)",
-        "version": "0.3.0"
+        "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi (requires bun: https://bun.sh/install)",
+        "version": "0.6.0"
     },
     "plugins": [
         {
-            "name": "claude-buddy",
+            "name": "coding-buddy",
             "source": "./",
-            "description": "Permanent coding companion for Claude Code \u2014 survives any update. MCP-based terminal pet with ASCII art, stats, reactions, and personality. Requires bun runtime (https://bun.sh/install).",
-            "version": "0.3.0",
+            "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality. Requires bun runtime (https://bun.sh/install).",
+            "version": "0.6.0",
             "author": {
                 "name": "1270011"
             },
@@ -20,7 +20,11 @@
             "repository": "https://github.com/1270011/claude-buddy",
             "license": "MIT",
             "keywords": [
+                "coding-buddy",
                 "claude-code",
+                "pi",
+                "oh-my-pi",
+                "omp",
                 "buddy",
                 "companion",
                 "mcp",
@@ -29,6 +33,7 @@
             ],
             "category": "companion",
             "tags": [
+                "coding-buddy",
                 "buddy",
                 "companion",
                 "mcp",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-    "name": "claude-buddy",
-    "version": "0.3.0",
-    "description": "Permanent coding companion for Claude Code \u2014 survives any update. MCP-based terminal pet with ASCII art, stats, reactions, and personality.",
+    "name": "coding-buddy",
+    "version": "0.6.0",
+    "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality.",
     "author": {
         "name": "1270011"
     },
@@ -9,7 +9,11 @@
     "repository": "https://github.com/1270011/claude-buddy",
     "homepage": "https://github.com/1270011/claude-buddy#readme",
     "keywords": [
+        "coding-buddy",
         "claude-code",
+        "pi",
+        "oh-my-pi",
+        "omp",
         "buddy",
         "companion",
         "mcp",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to claude-buddy
+# Contributing to coding-buddy
 
 Thanks for wanting to help bring buddies back to life!
 
@@ -8,8 +8,8 @@ you need: setup, DCO sign-off, tests, and what happens when you open a PR.
 ## Quick Setup
 
 ```bash
-git clone https://github.com/1270011/claude-buddy.git
-cd claude-buddy
+git clone https://github.com/1270011/claude-buddy.git coding-buddy
+cd coding-buddy
 bun install
 bun run install-buddy
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 claude-buddy contributors
+Copyright (c) 2026 coding-buddy contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 <!-- LOGO / HERO                                                  -->
 <!-- Later replace with: docs/logo.png                            -->
 <!-- ============================================================ -->
-<img src="https://placehold.co/120x120/6366f1/ffffff?text=%F0%9F%A6%89" alt="claude-buddy logo" width="120" />
+<img src="https://placehold.co/120x120/6366f1/ffffff?text=%F0%9F%A6%89" alt="coding-buddy logo" width="120" />
 
-# Claude Code Buddy
-
-### Your Claude Code buddy — permanently. Survives every update.
+# Coding Buddy
+### Your persistent coding companion — for Claude Code, Pi, and Oh My Pi. Survives every update.
 
 <!-- ============================================================ -->
 <!-- BADGES                                                        -->
@@ -27,7 +26,7 @@
 
 <br>
 
-<img src="docs/hero.gif" alt="claude-buddy in action" width="800" />
+<img src="docs/hero.gif" alt="coding-buddy in action" width="800" />
 
 <br><br>
 
@@ -72,43 +71,77 @@
 <!-- QUICK START                                                  -->
 <!-- ============================================================ -->
 
+<!-- ============================================================ -->
+<!-- CONTINUITY / MIGRATION                                      -->
+<!-- ============================================================ -->
+
+## 📦 Continuity / Migration
+
+The `claude-buddy` package ended at **v0.5.2**.  
+**`@ramarivera/coding-buddy` begins at v0.6.0** and is its continuation.
+
+- Your existing buddy identity, menagerie, stats, and unlocks remain fully compatible.
+- Legacy state and config identifiers (for example `~/.claude-buddy/`, `mcpServers["claude-buddy"]`) are intentionally preserved so current installs keep working without reconfiguration.
+
+<!-- ============================================================ -->
 ## 📋 Requirements
 
-- **[bun](https://bun.sh/install)** on `PATH` — claude-buddy's MCP server runs on bun. Install once: `curl -fsSL https://bun.sh/install | bash`
-- **Claude Code v2.1.80+**
+- **[bun](https://bun.sh/install)** on `PATH` — the MCP server and extension runtime require Bun. Install once: `curl -fsSL https://bun.sh/install | bash`
 - **Linux or macOS** (Windows is experimental)
+
+| Host | Minimum version | Identity source |
+|---|---|---|
+| **Claude Code** | v2.1.80+ | `accountUuid` from `~/.claude.json` |
+| **Pi** | `mariozechner/pi-coding-agent` workspace | Stable random UUID persisted in `~/.pi/agent/buddy/identity.json` |
+| **Oh My Pi (OMP)** | OMP harness with `omp.extensions` support | Stable random UUID persisted in `~/.omp/agent/buddy/identity.json` |
 
 ## 🚀 Quick Start
 
+### Claude Code
+
 ```bash
-git clone https://github.com/1270011/claude-buddy
-cd claude-buddy
+npx -y @ramarivera/coding-buddy
+```
+
+This installs the MCP server, skill, hooks, and status line. Restart Claude Code and type `/buddy`.
+
+### Pi
+
+```bash
+pi install npm:@ramarivera/coding-buddy
+```
+
+Pi registers the package's native extension and stores companion state under `~/.pi/agent/buddy`.
+
+### Oh My Pi
+
+```bash
+omp plugin install @ramarivera/coding-buddy
+```
+
+OMP registers the package's native extension and stores companion state under `~/.omp/agent/buddy`.
+
+### From source
+
+```bash
+git clone https://github.com/1270011/claude-buddy coding-buddy
+cd coding-buddy
 bun install
 bun run install-buddy
 ```
 
-Then restart Claude Code and type `/buddy`. That's it.
-
-<sub>💡 Want a global `claude-buddy` command? → `bun link`</sub>
+<sub>💡 Want a global `coding-buddy` command? → `bun link`</sub>
 <br>
-<sub>💡 Need help? → `bun run help` or `claude-buddy help` (if linked) in terminal · `/buddy help` in Claude Code</sub>
+<sub>💡 Need help? → `bun run help`, `npx -y @ramarivera/coding-buddy help`, or `coding-buddy help` (if linked) · `/buddy help` in Claude Code</sub>
 
-### Pi and Oh My Pi extensions
-
-This package also ships native coding-agent extensions:
-
-- **Pi:** `pi.extensions` loads `./adapters/pi/index.ts`; the checkout-local shim is `.pi/extensions/coding-buddy.ts`.
-- **Oh My Pi (OMP):** preferred `omp.extensions` metadata loads `./adapters/omp/index.ts`; the checkout-local shim is `.omp/extensions/coding-buddy.ts`.
-
-Both expose `/buddy`, native lifecycle reactions, and status/widget rendering without installing Claude hooks, tmux helpers, or popup machinery. Pi stores its state under `~/.pi/agent/buddy`; OMP uses the separate `~/.omp/agent/buddy` root.
 
 ### Multiple Claude profiles?
 
 If you run Claude Code with `CLAUDE_CONFIG_DIR` set (e.g. separate work and personal accounts), pass the same env var to install so buddy lands in the active profile and gets its own menagerie:
 
 ```bash
-CLAUDE_CONFIG_DIR=~/.claude-personal bun run install-buddy
-CLAUDE_CONFIG_DIR=~/.claude-personal bun run uninstall
+CLAUDE_CONFIG_DIR=~/.claude-personal npx -y @ramarivera/coding-buddy install
+CLAUDE_CONFIG_DIR=~/.claude-personal npx -y @ramarivera/coding-buddy uninstall
 ```
 
 The installer prints `Target profile: <path>` at the top so you can see at a glance which profile you're targeting. Each profile gets its own MCP entry, skill, hooks, status line, and `$CLAUDE_CONFIG_DIR/buddy-state/` menagerie — installs in one profile don't touch another. With `CLAUDE_CONFIG_DIR` unset, behaviour is identical to single-profile (`~/.claude/`, `~/.claude-buddy/`).
@@ -126,7 +159,7 @@ The installer prints `Target profile: <path>` at the top so you can see at a gla
 
 <br>
 
-Every buddy is uniquely generated from your Claude Code account — same species, same stats, same personality every time. 19 species, each with 3 idle animation frames + a blink.
+Every buddy is uniquely generated — same species, same stats, same personality every time. On **Claude Code** the seed is derived from your `accountUuid` in `~/.claude.json`; on **Pi** and **Oh My Pi** a stable random UUID is generated once and persisted in `~/.pi/agent/buddy/identity.json` or `~/.omp/agent/buddy/identity.json` (deleting the file and letting it regenerate will change your buddy). 19 species, each with 3 idle animation frames + a blink.
 
 <!-- Later replace with: docs/species-grid.png -->
 <p align="center">
@@ -180,7 +213,7 @@ High SNARK buddies are sarcastic. High WISDOM ones are insightful. High CHAOS on
 
 <br>
 
-Five integration points, zero binary dependencies. When Claude Code updates, your buddy stays.
+Five integration points, zero binary dependencies. When Claude Code, Pi, or Oh My Pi updates, your buddy stays.
 
 ```
 ┌────────────── Claude Code (any version) ──────────────┐
@@ -190,7 +223,7 @@ Five integration points, zero binary dependencies. When Claude Code updates, you
 └───────────────────────┬────────────────────────────────┘
                         │ stable extension points
              ┌──────────┴──────────┐
-             │    claude-buddy     │
+             │    coding-buddy     │
              │                     │
              │  wyhash + mulberry32│
              │  18 species, 3 anim │
@@ -212,14 +245,14 @@ Five integration points, zero binary dependencies. When Claude Code updates, you
 |---|:---:|:---:|:---:|---|
 | Binary patching | ❌ | ❌ | ❌ | Breaks on update |
 | Pin old version | ❌ | ✅ | ✅ | No security fixes |
-| **claude-buddy** | **✅** | **✅** | **✅** | **None** |
+| **coding-buddy** | **✅** | **✅** | **✅** | **None** |
 
 MCP is an industry-standard protocol. Skills are Markdown files. Hooks and status line are shell scripts. Nothing depends on Claude Code's binary internals.
 
 ### Repository Layout
 
 ```
-claude-buddy/
+coding-buddy/
 ├── server/          # MCP server — tools, engine, art, reactions, state
 ├── skills/buddy/    # /buddy slash command
 ├── hooks/           # PostToolUse + Stop hooks (error & comment detection)
@@ -250,7 +283,7 @@ claude-buddy/
 | `/buddy save [slot]` | Save current buddy to a named slot |
 | `/buddy list` | List all saved buddies |
 | `/buddy dismiss <slot>` | Remove a saved buddy slot |
-| `/buddy pick` | Launch interactive TUI picker (`! bun run pick`) |
+| `/buddy pick` | Launch interactive TUI picker (`! npx -y @ramarivera/coding-buddy pick`) |
 | `/buddy frequency [seconds]` | Show or set comment cooldown |
 | `/buddy style [classic\|round]` | Bubble border style (tmux only) |
 | `/buddy position [top\|left]` | Bubble position (tmux only) |
@@ -263,10 +296,13 @@ claude-buddy/
 | `/buddy help` | Show all buddy commands |
 
 ### CLI
+You can run any command with `npx -y @ramarivera/coding-buddy <command>` from anywhere, or `bun run <script>` from a local clone.
+
 
 | Command | Description |
 |---|---|
 | `bun run install-buddy` | Automated setup |
+| `bun run upgrade` | Pull latest version and reinstall integrations |
 | `bun run show` | Show buddy in terminal |
 | `bun run pick` | Interactive TUI to find and save your dream buddy |
 | `bun run hunt` | Legacy search (use `pick` instead) |
@@ -277,16 +313,16 @@ claude-buddy/
 | `bun run disable` | Temporarily deactivate buddy |
 | `bun run enable` | Re-enable buddy |
 | `bun run help` | Full CLI reference |
-| `bun run cli/uninstall.ts` | Clean removal |
+| `bun run uninstall` | Clean removal |
 
-<sub>💡 Want a global `claude-buddy` command? → `cd claude-buddy && bun link`</sub>
+<sub>💡 Want a global `coding-buddy` command? → `cd coding-buddy && bun link`</sub>
 
 ### 🎯 Buddy Pick
 
 Want a specific species, rarity, or stat distribution?
 
 ```bash
-bun run pick
+npx -y @ramarivera/coding-buddy pick
 ```
 
 Interactive TUI with saved buddies, criteria search, vim keys, and two-pane preview. Uses the exact same `wyhash + mulberry32` algorithm as Claude Code.
@@ -300,7 +336,7 @@ Interactive TUI with saved buddies, criteria search, vim keys, and two-pane prev
 
 <br>
 
-claude-buddy ships with built-in diagnostics for debugging across terminals and platforms.
+coding-buddy ships with built-in diagnostics for debugging across terminals and platforms.
 
 ### `bun run doctor`
 Complete diagnostic — environment, terminal info, state, settings, padding test, live status line output. **Always run this first when filing a bug report.**
@@ -315,7 +351,7 @@ bun run test-statusline restore  # restore buddy
 ```
 
 ### `bun run backup`
-Snapshot all claude-buddy state to a timestamped backup. Use before experiments.
+Snapshot all coding-buddy state to a timestamped backup. Use before experiments.
 
 ```bash
 bun run backup              # create snapshot
@@ -342,7 +378,7 @@ bun run backup restore <ts> # restore specific
 
 ### Buddy comments not showing
 
-The buddy comment mechanism uses an MCP server `instructions` field that Claude only reads at **session start**. If you installed claude-buddy in an existing session, restart Claude Code.
+The buddy comment mechanism uses an MCP server `instructions` field that Claude only reads at **session start**. If you installed coding-buddy in an existing session, restart Claude Code.
 
 ```bash
 jq '.mcpServers["claude-buddy"]' ~/.claude.json
@@ -361,7 +397,7 @@ To help us fix it:
 
 ```bash
 bun run backup restore      # restore latest backup
-bun run cli/uninstall.ts    # full clean removal
+bun run uninstall           # full clean removal
 ```
 
 </details>
@@ -379,7 +415,7 @@ bun run cli/uninstall.ts    # full clean removal
 | **Claude Code** v2.1.80+ | Any version with MCP support |
 | **jq** | `apt install jq` / `brew install jq` / [`windows: download and add 'jq.exe' from jqlang/jq to path`](https://github.com/jqlang/jq/releases/latest)|
 
-> **Will I get the same buddy I had?** Yes. claude-buddy uses the exact same algorithm as the original (`wyhash + mulberry32`, same salt, same identity resolution). If your `~/.claude.json` still has your `accountUuid`, you'll get the identical species, rarity, stats, and cosmetics.
+> **Will I get the same buddy I had?** Yes. coding-buddy uses the exact same algorithm as the original (`wyhash + mulberry32`, same salt, same identity resolution). For Claude Code, if your `~/.claude.json` still has your `accountUuid`, you'll get the identical species, rarity, stats, and cosmetics. For Pi/OMP, keep `~/.pi/agent/buddy/identity.json` or `~/.omp/agent/buddy/identity.json`; the same stable UUID produces the same buddy. Resetting (deleting) that identity file generates a new random UUID and changes your buddy.
 
 </details>
 
@@ -397,7 +433,7 @@ bun run cli/uninstall.ts    # full clean removal
 - [x] **Achievement badges** — "1000 lines reviewed", "week streak", etc. 💜[ndcorder](https://github.com/ndcorder)💜
 - [ ] **Light theme colors** — auto-detect and match light theme RGB
 - [x] **New species + community art** — wyvern added 💜[@jpmalone0](https://github.com/jpmalone0)💜 (community contributions welcome)
-- [ ] **`npx claude-buddy`** — one-command install without cloning
+- [ ] **`npx -y @ramarivera/coding-buddy <command>`** — one-command usage without cloning
 
 <br>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-claude-buddy runs locally on your machine. It consists of:
+coding-buddy runs locally on your machine. It consists of:
 - An MCP server (stdio, local only — no network listeners)
 - Shell scripts for status line and hooks
 - State files in `~/.claude-buddy/`

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,4 +1,4 @@
-# Testing claude-buddy
+# Testing coding-buddy
 
 This document lists exactly what the test suite covers. For a walk-through of
 the contribution workflow (DCO, CI, commit style), see
@@ -74,7 +74,7 @@ produce the same companion.
 
 These pin the exact bones output for three fixed user IDs. If any of these
 fail, the generation algorithm has changed in a way that would give every
-existing user a different buddy — which is the one thing claude-buddy
+existing user a different buddy — which is the one thing coding-buddy
 promises never to do. Stop and ask "did I mean to do that?" before
 updating the snapshots.
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,14 +3,10 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "claude-buddy",
+      "name": "@ramarivera/coding-buddy",
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
-        "@mariozechner/pi-coding-agent": "0.66.1",
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "@oh-my-pi/pi-agent-core": "17.0.9",
-        "@oh-my-pi/pi-ai": "17.0.9",
-        "@oh-my-pi/pi-coding-agent": "17.0.9",
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
         "ink": "^7.0.0",
@@ -18,12 +14,28 @@
         "react": "^19.2.5",
       },
       "devDependencies": {
+        "@mariozechner/pi-coding-agent": "0.66.1",
+        "@oh-my-pi/pi-agent-core": "17.0.9",
+        "@oh-my-pi/pi-ai": "17.0.9",
         "@oh-my-pi/pi-catalog": "17.0.9",
+        "@oh-my-pi/pi-coding-agent": "17.0.9",
         "@types/react": "^19.2.14",
         "bun-types": "^1.3.11",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
       },
+      "peerDependencies": {
+        "@mariozechner/pi-coding-agent": "0.66.1",
+        "@oh-my-pi/pi-agent-core": "17.0.9",
+        "@oh-my-pi/pi-ai": "17.0.9",
+        "@oh-my-pi/pi-coding-agent": "17.0.9",
+      },
+      "optionalPeers": [
+        "@mariozechner/pi-coding-agent",
+        "@oh-my-pi/pi-agent-core",
+        "@oh-my-pi/pi-ai",
+        "@oh-my-pi/pi-coding-agent",
+      ],
     },
   },
   "trustedDependencies": [

--- a/cli/backup.ts
+++ b/cli/backup.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * claude-buddy backup — snapshot all claude-buddy related state
+ * coding-buddy backup — snapshot all coding-buddy related state
  *
  * Usage:
  *   bun run backup                 Create a new snapshot
@@ -150,7 +150,7 @@ function cmdList() {
     info(`Run '${BOLD}bun run backup${NC}' to create one.`);
     return;
   }
-  console.log(`\n${BOLD}claude-buddy backups${NC}\n`);
+  console.log(`\n${BOLD}coding-buddy backups${NC}\n`);
   for (const ts of backups) {
     const manifestPath = join(BACKUPS_DIR, ts, "manifest.json");
     const manifest = tryRead(manifestPath);
@@ -266,7 +266,7 @@ const arg = process.argv[3];
 switch (action) {
   case "create":
   case undefined: {
-    console.log(`\n${BOLD}Creating claude-buddy backup...${NC}\n`);
+    console.log(`\n${BOLD}Creating coding-buddy backup...${NC}\n`);
     const ts = createBackup();
     console.log(`\n${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}`);
     console.log(`${GREEN}  Backup created: ${ts}${NC}`);
@@ -319,7 +319,7 @@ switch (action) {
   case "--help":
   case "-h":
     console.log(`
-${BOLD}claude-buddy backup${NC} — snapshot and restore all claude-buddy state
+${BOLD}coding-buddy backup${NC} — snapshot and restore all coding-buddy state
 
 ${BOLD}Commands:${NC}
   bun run backup                 Create a new snapshot

--- a/cli/disable.ts
+++ b/cli/disable.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * claude-buddy disable — temporarily deactivate buddy without losing data
+ * coding-buddy disable — temporarily deactivate buddy without losing data
  *
  * Removes: MCP server, status line, hooks
  * Keeps: companion data, backups, skill files
@@ -28,7 +28,7 @@ const CLAUDE_JSON = claudeUserConfigPath();
 const SETTINGS = claudeSettingsPath();
 const STATE_DIR = buddyStateDir();
 
-console.log(`\n${BOLD}Disabling claude-buddy...${NC}\n`);
+console.log(`\n${BOLD}Disabling coding-buddy...${NC}\n`);
 
 // 1. Remove MCP server from ~/.claude.json
 try {
@@ -61,7 +61,7 @@ try {
       if (settings.hooks[hookType]) {
         const before = settings.hooks[hookType].length;
         settings.hooks[hookType] = settings.hooks[hookType].filter(
-          (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+          (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("coding-buddy") || hh.command?.includes("claude-buddy")),
         );
         if (settings.hooks[hookType].length < before) changed = true;
         if (settings.hooks[hookType].length === 0) delete settings.hooks[hookType];

--- a/cli/doctor.ts
+++ b/cli/doctor.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * claude-buddy doctor — comprehensive diagnostic report
+ * coding-buddy doctor — comprehensive diagnostic report
  *
  * Run: bun run doctor
  *
@@ -68,7 +68,7 @@ function tryParseJson(text: string | null): any | null {
 
 console.log(`${CYAN}${BOLD}
 ╔══════════════════════════════════════════════════════════╗
-║  claude-buddy doctor — diagnostic report                 ║
+║  coding-buddy doctor — diagnostic report                 ║
 ╚══════════════════════════════════════════════════════════╝${NC}`);
 
 console.log(`\n${DIM}Copy this entire output into your GitHub issue.${NC}`);
@@ -108,9 +108,9 @@ row(`${STATE_DIR} exists`, existsSync(STATE_DIR) ? "yes" : "no");
 row("Project root", PROJECT_ROOT);
 row("Status script exists", existsSync(STATUS_SCRIPT) ? "yes" : `${RED}no${NC}`);
 
-// ─── claude-buddy state ─────────────────────────────────────────────────────
+// ─── coding-buddy state ─────────────────────────────────────────────────────
 
-section("claude-buddy state");
+section("coding-buddy state");
 const menagerie = tryParseJson(tryRead(join(STATE_DIR, "menagerie.json")));
 const status = tryParseJson(tryRead(join(STATE_DIR, "status.json")));
 

--- a/cli/hunt.ts
+++ b/cli/hunt.ts
@@ -1,5 +1,5 @@
 /**
- * claude-buddy hunt — brute-force search for a specific buddy
+ * coding-buddy hunt — brute-force search for a specific buddy
  *
  * Rules:
  *   - Asks for a name before saving
@@ -45,7 +45,7 @@ function pickFromList<T extends string>(label: string, items: readonly T[]): Pro
 async function main() {
   console.log(`
 ${CYAN}╔══════════════════════════════════════════════════════════╗${NC}
-${CYAN}║${NC}  ${BOLD}claude-buddy hunt${NC} — find your perfect companion          ${CYAN}║${NC}
+${CYAN}║${NC}  ${BOLD}coding-buddy hunt${NC} — find your perfect companion          ${CYAN}║${NC}
 ${CYAN}╚══════════════════════════════════════════════════════════╝${NC}
 `);
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env bun
 /**
- * claude-buddy CLI
+ * coding-buddy CLI
  *
  * Usage:
- *   npx claude-buddy              Interactive install
- *   npx claude-buddy install      Install MCP + skill + hooks + statusline
- *   npx claude-buddy show         Show current buddy
- *   npx claude-buddy pick         Interactive two-pane buddy picker (saved + search)
- *   npx claude-buddy hunt         Search for a specific buddy (non-interactive)
- *   npx claude-buddy upgrade     Pull latest + reinstall
- *   npx claude-buddy uninstall    Remove all integrations
- *   npx claude-buddy verify       Verify what buddy your ID produces
+ *   npx -y @ramarivera/coding-buddy              Interactive install
+ *   npx -y @ramarivera/coding-buddy install      Install MCP + skill + hooks + statusline
+ *   npx -y @ramarivera/coding-buddy show         Show current buddy
+ *   npx -y @ramarivera/coding-buddy pick         Interactive two-pane buddy picker (saved + search)
+ *   npx -y @ramarivera/coding-buddy hunt         Search for a specific buddy (non-interactive)
+ *   npx -y @ramarivera/coding-buddy upgrade      Pull latest + reinstall
+ *   npx -y @ramarivera/coding-buddy uninstall     Remove all integrations
+ *   npx -y @ramarivera/coding-buddy verify       Verify what buddy your ID produces
  */
 
 export {}; // Make this file a module for TypeScript top-level await
@@ -71,14 +71,14 @@ switch (command) {
 
 function showHelp() {
   console.log(`
-claude-buddy — permanent coding companion for Claude Code
+coding-buddy — permanent coding companion for Claude Code, Pi, and Oh My Pi
 
 Setup:
   install-buddy     Set up MCP server, skill, hooks, and status line
   upgrade           Pull latest version and reinstall integrations
   enable            Same as install-buddy (re-enable after disable)
   disable           Temporarily deactivate buddy (data preserved)
-  uninstall         Remove all claude-buddy integrations
+  uninstall         Remove all coding-buddy integrations
 
 Buddy:
   show              Display your current buddy
@@ -96,7 +96,7 @@ Settings:
 Diagnostics:
   doctor            Run diagnostic report (paste output in bug reports)
   test-statusline   Test status line rendering in Claude Code
-  backup            Snapshot or restore all claude-buddy state
+  backup            Snapshot or restore all coding-buddy state
 
 In Claude Code:
   /buddy            Show companion card with ASCII art + stats
@@ -118,8 +118,9 @@ In Claude Code:
   /buddy width      Set bubble text width in chars (10-60, tmux only)
 
 Usage:
-  bun run <command>           e.g. bun run show, bun run doctor
-  claude-buddy <command>      if globally linked (bun link)
-  bun run help                Show this help
+  npx -y @ramarivera/coding-buddy <command>  Run from the registry without cloning
+  bun run <command>                           e.g. bun run show, bun run doctor (in repo)
+  coding-buddy <command>                      if globally linked (bun link)
+  bun run help                                Show this help
 `);
 }

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -1,5 +1,5 @@
 /**
- * claude-buddy installer
+ * coding-buddy installer
  *
  * Registers: MCP server (in Claude's user config), skill, hooks, status line
  * (in settings.json). All paths resolve via server/paths.ts, so the installer
@@ -39,7 +39,7 @@ const PROJECT_ROOT = resolve(dirname(import.meta.dir));
 function banner() {
   console.log(`
 ${CYAN}╔══════════════════════════════════════════════════════════╗${NC}
-${CYAN}║${NC}  ${BOLD}claude-buddy${NC} — permanent coding companion              ${CYAN}║${NC}
+${CYAN}║${NC}  ${BOLD}coding-buddy${NC} — permanent coding companion              ${CYAN}║${NC}
 ${CYAN}║${NC}  ${DIM}MCP + Skill + StatusLine + Hooks${NC}                        ${CYAN}║${NC}
 ${CYAN}╚══════════════════════════════════════════════════════════╝${NC}
 `);
@@ -194,7 +194,7 @@ function installHooks(settings: Record<string, any>) {
   // plus file-type specific reactions on Write/Edit.
   if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
   settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(
-    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("coding-buddy") || hh.command?.includes("claude-buddy")),
   );
   settings.hooks.PostToolUse.push({
     matcher: "Bash",
@@ -208,7 +208,7 @@ function installHooks(settings: Record<string, any>) {
   // Stop: extract <!-- buddy: --> comment from Claude's response
   if (!settings.hooks.Stop) settings.hooks.Stop = [];
   settings.hooks.Stop = settings.hooks.Stop.filter(
-    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("coding-buddy") || hh.command?.includes("claude-buddy")),
   );
   settings.hooks.Stop.push({
     hooks: [{ type: "command", command: toUnixPath(commentHook) }],
@@ -221,7 +221,7 @@ function installHooks(settings: Record<string, any>) {
   // reaction, plus mood-react based on prompt content.
   if (!settings.hooks.UserPromptSubmit) settings.hooks.UserPromptSubmit = [];
   settings.hooks.UserPromptSubmit = settings.hooks.UserPromptSubmit.filter(
-    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("coding-buddy") || hh.command?.includes("claude-buddy")),
   );
   settings.hooks.UserPromptSubmit.push({
     hooks: [{ type: "command", command: toUnixPath(nameHook) }],
@@ -292,7 +292,7 @@ if (!preflight()) {
 }
 
 console.log("");
-info("Installing claude-buddy...\n");
+info("Installing coding-buddy...\n");
 
 const settings = loadSettings();
 

--- a/cli/pick.ts
+++ b/cli/pick.ts
@@ -296,7 +296,7 @@ function drawScreen(s: State): void {
   let out = "\x1b[2J\x1b[H"; // clear + home
 
   // Title bar
-  const title    = ` claude-buddy pick `;
+  const title    = ` coding-buddy pick `;
   const fill     = "─".repeat(Math.max(0, cols - title.length - 2));
   out += `${CY}─${B}${title}${N}${CY}${fill}─${N}\n`;
 

--- a/cli/settings.ts
+++ b/cli/settings.ts
@@ -16,7 +16,7 @@ const value = args[1];
 if (!key) {
   const cfg = loadConfig();
   console.log(`
-  claude-buddy settings
+  coding-buddy settings
   ─────────────────────
   Comment cooldown:  ${cfg.commentCooldown}s    (0 = no throttling, default 30)
   Reaction TTL:      ${cfg.reactionTTL}s    (0 = permanent, default 0)

--- a/cli/show.ts
+++ b/cli/show.ts
@@ -1,5 +1,5 @@
 /**
- * claude-buddy show — display current companion in terminal
+ * coding-buddy show — display current companion in terminal
  */
 
 import { renderBuddy, renderFace, RARITY_STARS } from "../core/engine.ts"
@@ -12,7 +12,7 @@ const NC = "\x1b[0m";
 const companion = loadCompanion();
 
 if (!companion) {
-  console.log("No companion found. Run 'claude-buddy install' first.");
+  console.log("No companion found. Run 'coding-buddy install' first.");
   process.exit(1);
 }
 

--- a/cli/test-statusline.sh
+++ b/cli/test-statusline.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# claude-buddy diagnostic test status line
+# coding-buddy diagnostic test status line
 # Outputs multiple padding strategies + multi-line check + width check
 
 cat > /dev/null  # drain stdin
@@ -12,7 +12,7 @@ GREEN=$'\033[38;2;78;186;101m'
 BLUE=$'\033[38;2;87;105;247m'
 
 # Header
-echo "${DIM}--- claude-buddy statusline test ---${NC}"
+echo "${DIM}--- coding-buddy statusline test ---${NC}"
 
 # Multi-line check
 echo "LINE_1_top"

--- a/cli/test-statusline.ts
+++ b/cli/test-statusline.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * claude-buddy test-statusline — temporarily install a test status line
+ * coding-buddy test-statusline — temporarily install a test status line
  *
  * Run: bun run test-statusline           # install test
  *      bun run test-statusline restore   # restore original
@@ -39,7 +39,7 @@ const action = process.argv[2] || "install";
 // ─── Install ────────────────────────────────────────────────────────────────
 
 if (action === "install") {
-  console.log(`\n${BOLD}claude-buddy test status line installer${NC}\n`);
+  console.log(`\n${BOLD}coding-buddy test status line installer${NC}\n`);
 
   if (!existsSync(SETTINGS)) {
     err(`${SETTINGS} not found`);
@@ -99,7 +99,7 @@ ${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━�
 // ─── Restore ────────────────────────────────────────────────────────────────
 
 if (action === "restore") {
-  console.log(`\n${BOLD}claude-buddy test status line restore${NC}\n`);
+  console.log(`\n${BOLD}coding-buddy test status line restore${NC}\n`);
 
   if (!existsSync(BACKUP)) {
     err(`No backup found at ${BACKUP}`);

--- a/cli/tui.tsx
+++ b/cli/tui.tsx
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * cli/tui.tsx — fullscreen 3-pane dashboard for claude-buddy (Ink/React)
+ * cli/tui.tsx — fullscreen 3-pane dashboard for coding-buddy (Ink/React)
  *
  * Layout: persistent sidebar | content list | detail preview
  * The sidebar is always visible. Selecting a section opens the
@@ -139,7 +139,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
     key: "backup", icon: "💾", label: "Backup",
     description: [
       "Create and browse snapshots of your",
-      "claude-buddy state — settings, hooks,",
+      "coding-buddy state — settings, hooks,",
       "skill, menagerie, status, and config.",
       "",
       "Restore is currently manual (copy from",
@@ -149,7 +149,7 @@ const SIDEBAR_ITEMS: SidebarItem[] = [
   {
     key: "system", icon: "🚨", label: "System",
     description: [
-      "Manage claude-buddy's installation:",
+      "Manage coding-buddy's installation:",
       "",
       "• Re-Enable — runs install-buddy",
       "• Disable  — keeps data, removes MCP",
@@ -167,7 +167,7 @@ function Sidebar({ cursor, section, focus }: {
   const isFocused = focus === "sidebar";
   return (
     <Box flexDirection="column" paddingX={1}>
-      <Text bold color="cyan">{" 🐢 claude-buddy"}</Text>
+      <Text bold color="cyan">{" 🐢 coding-buddy"}</Text>
       <Text>{""}</Text>
       {SIDEBAR_ITEMS.map((item, i) => {
         const isActive = item.key === section && focus !== "sidebar";
@@ -784,7 +784,7 @@ function BackupDetailPane({ backups, cursor }: {
         <Text bold color="cyan">➕ Create Backup</Text>
         <Text>{""}</Text>
         <Text dimColor>Creates a snapshot of all</Text>
-        <Text dimColor>claude-buddy state files:</Text>
+        <Text dimColor>coding-buddy state files:</Text>
         <Text>{""}</Text>
         <Text>{" "}• settings.json</Text>
         <Text>{" "}• MCP server config</Text>
@@ -946,7 +946,7 @@ function EnableDetailPane({ result, running }: {
   return (
     <Box flexDirection="column" paddingLeft={1}>
       <Text>{""}</Text>
-      <Text bold color="green">🔄 Re-Enable claude-buddy</Text>
+      <Text bold color="green">🔄 Re-Enable coding-buddy</Text>
       <Text>{""}</Text>
       <Text dimColor>This will register:</Text>
       <Text>{"  "}• MCP server in {CLAUDE_JSON}</Text>
@@ -1002,7 +1002,7 @@ function UninstallDetailPane({ stage, typed, result, keepState }: {
   return (
     <Box flexDirection="column" paddingLeft={1}>
       <Text>{""}</Text>
-      <Text bold color="red">💥 Uninstall claude-buddy</Text>
+      <Text bold color="red">💥 Uninstall coding-buddy</Text>
       <Text>{""}</Text>
       <Text color="yellow">⚠  This will remove:</Text>
       <Text>{"  "}• MCP server registration</Text>
@@ -1045,7 +1045,7 @@ function DisableConfirmPane({ result, confirming }: {
   return (
     <Box flexDirection="column" paddingLeft={1}>
       <Text>{""}</Text>
-      <Text bold color="red">☠ Disable claude-buddy</Text>
+      <Text bold color="red">☠ Disable coding-buddy</Text>
       <Text>{""}</Text>
       <Text dimColor>This will remove:</Text>
       <Text>{"  "}• MCP server from {CLAUDE_JSON}</Text>
@@ -1107,7 +1107,7 @@ function disableBuddy(): DisableResult {
         if (settings.hooks[hookType]) {
           const before = settings.hooks[hookType].length;
           settings.hooks[hookType] = settings.hooks[hookType].filter(
-            (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+            (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("coding-buddy") || hh.command?.includes("claude-buddy")),
           );
           if (settings.hooks[hookType].length < before) changed = true;
           if (settings.hooks[hookType].length === 0) delete settings.hooks[hookType];
@@ -2294,7 +2294,7 @@ function App() {
   return (
     <Box flexDirection="column" height={rows}>
       <Box>
-        <Text color="cyan" bold>{"─ claude-buddy "}{"─".repeat(Math.max(0, cols - 17))}</Text>
+        <Text color="cyan" bold>{"─ coding-buddy "}{"─".repeat(Math.max(0, cols - 17))}</Text>
       </Box>
       <Box flexGrow={1}>
         <Box width={sidebarWidth} flexDirection="column" borderStyle="single" borderColor={focus === "sidebar" ? "cyan" : "gray"}>
@@ -2326,7 +2326,7 @@ function App() {
 // ─── Entry ──────────────────────────────────────────────────────────────────
 
 if (!process.stdin.isTTY) {
-  console.error("claude-buddy tui requires an interactive terminal (TTY)");
+  console.error("coding-buddy tui requires an interactive terminal (TTY)");
   process.exit(1);
 }
 

--- a/cli/uninstall.ts
+++ b/cli/uninstall.ts
@@ -1,5 +1,5 @@
 /**
- * claude-buddy uninstall — remove all integrations
+ * coding-buddy uninstall — remove all integrations
  */
 
 import { readFileSync, writeFileSync, existsSync, rmSync, readdirSync } from "fs";
@@ -23,7 +23,7 @@ const SKILL_DIR = claudeSkillDir("buddy");
 const STATE_DIR = buddyStateDir();
 const CLAUDE_JSON_PATH = claudeUserConfigPath();
 
-console.log("\nclaude-buddy uninstall\n");
+console.log("\ncoding-buddy uninstall\n");
 
 // Stop all popup reopen loops and close any running popup
 try {
@@ -80,7 +80,7 @@ try {
     if (settings.hooks?.[hookType]) {
       const before = settings.hooks[hookType].length;
       settings.hooks[hookType] = settings.hooks[hookType].filter(
-        (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("claude-buddy")),
+        (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("coding-buddy") || hh.command?.includes("claude-buddy")),
       );
       if (settings.hooks[hookType].length < before) {
         ok(`${hookType} hooks removed`);

--- a/cli/upgrade.ts
+++ b/cli/upgrade.ts
@@ -40,7 +40,7 @@ function getCurrentVersion(): string {
 function banner() {
   console.log(`
 ${CYAN}╔══════════════════════════════════════════════════════════╗${NC}
-${CYAN}║${NC}  ${BOLD}claude-buddy upgrade${NC}                                    ${CYAN}║${NC}
+${CYAN}║${NC}  ${BOLD}coding-buddy upgrade${NC}                                    ${CYAN}║${NC}
 ${CYAN}╚══════════════════════════════════════════════════════════╝${NC}
 `);
 }
@@ -48,7 +48,7 @@ ${CYAN}╚═══════════════════════�
 function checkGitRepo(): boolean {
   const isRepo = tryExec("git rev-parse --is-inside-work-tree 2>/dev/null");
   if (isRepo !== "true") {
-    err("Not inside a git repository. Upgrade requires a git clone of claude-buddy.");
+    err("Not inside a git repository. Upgrade requires a git clone of coding-buddy.");
     return false;
   }
   return true;

--- a/cli/verify.ts
+++ b/cli/verify.ts
@@ -1,5 +1,5 @@
 /**
- * claude-buddy verify — show what buddy a user ID produces
+ * coding-buddy verify — show what buddy a user ID produces
  */
 
 import { generateBones, renderBuddy, STAT_NAMES } from "../core/engine.ts"

--- a/core/engine.ts
+++ b/core/engine.ts
@@ -1,5 +1,5 @@
 /**
- * claude-buddy engine — deterministic companion generation
+ * coding-buddy engine — deterministic companion generation
  * Matches Claude Code's exact algorithm: wyhash → mulberry32 → species/stats
  */
 

--- a/hooks/name-react.sh
+++ b/hooks/name-react.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# claude-buddy UserPromptSubmit hook
+# coding-buddy UserPromptSubmit hook
 # Detects the buddy's name in the user's message → status line reaction.
 # No cooldown — name mentions are intentional.
 

--- a/hooks/suggest.sh
+++ b/hooks/suggest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# claude-buddy Stop hook — proactive suggestion detection
+# coding-buddy Stop hook — proactive suggestion detection
 # Detects coding patterns and offers suggestions when relevant.
 #
 # Combined with buddy-comment.sh to avoid running two separate Stop hooks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "claude-buddy",
-  "version": "0.5.2",
+  "name": "@ramarivera/coding-buddy",
+  "version": "0.6.0",
   "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi",
   "type": "module",
   "omp": {
@@ -14,7 +14,7 @@
     ]
   },
   "bin": {
-    "claude-buddy": "./cli/index.ts"
+    "coding-buddy": "./cli/index.ts"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.cjs",
@@ -51,7 +51,11 @@
     "!**/*.test.ts"
   ],
   "keywords": [
+    "coding-buddy",
     "claude-code",
+    "pi",
+    "oh-my-pi",
+    "omp",
     "buddy",
     "companion",
     "mcp",
@@ -67,10 +71,6 @@
   "homepage": "https://github.com/1270011/claude-buddy#readme",
   "license": "MIT",
   "dependencies": {
-    "@mariozechner/pi-coding-agent": "0.66.1",
-    "@oh-my-pi/pi-agent-core": "17.0.9",
-    "@oh-my-pi/pi-ai": "17.0.9",
-    "@oh-my-pi/pi-coding-agent": "17.0.9",
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@xterm/addon-serialize": "^0.14.0",
@@ -80,6 +80,10 @@
     "react": "^19.2.5"
   },
   "devDependencies": {
+    "@mariozechner/pi-coding-agent": "0.66.1",
+    "@oh-my-pi/pi-agent-core": "17.0.9",
+    "@oh-my-pi/pi-ai": "17.0.9",
+    "@oh-my-pi/pi-coding-agent": "17.0.9",
     "@oh-my-pi/pi-catalog": "17.0.9",
     "@types/react": "^19.2.14",
     "bun-types": "^1.3.11",
@@ -88,5 +92,20 @@
   },
   "trustedDependencies": [
     "@homebridge/node-pty-prebuilt-multiarch"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "0.66.1",
+    "@oh-my-pi/pi-agent-core": "17.0.9",
+    "@oh-my-pi/pi-ai": "17.0.9",
+    "@oh-my-pi/pi-coding-agent": "17.0.9"
+  },
+  "peerDependenciesMeta": {
+    "@mariozechner/pi-coding-agent": { "optional": true },
+    "@oh-my-pi/pi-agent-core": { "optional": true },
+    "@oh-my-pi/pi-ai": { "optional": true },
+    "@oh-my-pi/pi-coding-agent": { "optional": true }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ]
   },
   "bin": {
-    "coding-buddy": "./cli/index.ts"
+    "coding-buddy": "cli/index.ts"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.cjs",
@@ -66,7 +66,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/1270011/claude-buddy.git"
+    "url": "git+https://github.com/1270011/claude-buddy.git"
   },
   "homepage": "https://github.com/1270011/claude-buddy#readme",
   "license": "MIT",
@@ -103,9 +103,17 @@
     "@oh-my-pi/pi-coding-agent": "17.0.9"
   },
   "peerDependenciesMeta": {
-    "@mariozechner/pi-coding-agent": { "optional": true },
-    "@oh-my-pi/pi-agent-core": { "optional": true },
-    "@oh-my-pi/pi-ai": { "optional": true },
-    "@oh-my-pi/pi-coding-agent": { "optional": true }
+    "@mariozechner/pi-coding-agent": {
+      "optional": true
+    },
+    "@oh-my-pi/pi-agent-core": {
+      "optional": true
+    },
+    "@oh-my-pi/pi-ai": {
+      "optional": true
+    },
+    "@oh-my-pi/pi-coding-agent": {
+      "optional": true
+    }
   }
 }

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Path resolvers for claude-buddy shell scripts.
+# Path resolvers for coding-buddy shell scripts.
 #
 # Must stay in sync with server/path.ts. Source this file early:
 #   source "$(dirname "$0")/../scripts/paths.sh"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * claude-buddy MCP server
+ * coding-buddy MCP server
  *
  * Exposes the buddy companion as MCP tools + resources.
  * Runs as a stdio transport — Claude Code spawns it automatically.
@@ -117,8 +117,8 @@ function getInstructions(): string {
 
 const server = new McpServer(
   {
-    name: "claude-buddy",
-    version: "0.3.0",
+    name: "coding-buddy",
+    version: "0.6.0",
   },
   {
     instructions: getInstructions(),
@@ -378,7 +378,7 @@ server.tool(
   {},
   async () => {
     const help = [
-      "claude-buddy commands",
+      "coding-buddy commands",
       "",
       "In Claude Code:",
       "  /buddy            Show companion card with ASCII art + stats",
@@ -696,17 +696,17 @@ server.tool(
 
 server.tool(
   "buddy_uninstall",
-  "Clean up claude-buddy's writes to Claude Code's settings.json and transient session files in the buddy state dir (resolved via CLAUDE_CONFIG_DIR), in preparation for `claude plugin uninstall`. Companion data (menagerie, status, config) is intentionally preserved so reinstalling restores the buddy. The tool only cleans the plugin's own settings — it never removes a foreign statusLine.",
+  "Clean up coding-buddy's writes to Claude Code's settings.json and transient session files in the buddy state dir (resolved via CLAUDE_CONFIG_DIR), in preparation for `claude plugin uninstall`. Companion data (menagerie, status, config) is intentionally preserved so reinstalling restores the buddy. The tool only cleans the plugin's own settings — it never removes a foreign statusLine.",
   {},
   async () => {
     const result = cleanupPluginState();
 
     const settingsPath = claudeSettingsPath();
     const stateDir = buddyStateDir();
-    const pluginsCacheDir = join(claudeConfigDir(), "plugins", "cache", "claude-buddy");
+    const pluginsCacheDir = join(claudeConfigDir(), "plugins", "cache", "coding-buddy");
 
     const lines: string[] = [];
-    lines.push("claude-buddy: settings.json cleanup complete.");
+    lines.push("coding-buddy: settings.json cleanup complete.");
     lines.push("");
     lines.push(
       result.statusLineRemoved
@@ -725,8 +725,8 @@ server.tool(
     lines.push("");
     lines.push("Now run these commands via the Bash tool, in order:");
     lines.push("");
-    lines.push("  claude plugin uninstall claude-buddy@claude-buddy");
-    lines.push("  claude plugin marketplace remove claude-buddy");
+    lines.push("  claude plugin uninstall coding-buddy@coding-buddy");
+    lines.push("  claude plugin marketplace remove coding-buddy");
     lines.push(`  rm -rf ${pluginsCacheDir}`);
     lines.push("");
     lines.push(

--- a/server/mcp-launcher.sh
+++ b/server/mcp-launcher.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# claude-buddy MCP server launcher — preflight checks bun, then execs the server.
+# coding-buddy MCP server launcher — preflight checks bun, then execs the server.
 # Failing here with a clear stderr message is much easier to debug than a silent
 # "MCP tools not available" from Claude Code.
 
@@ -7,9 +7,9 @@ set -eu
 
 if ! command -v bun >/dev/null 2>&1; then
   cat >&2 <<'EOF'
-[claude-buddy] ERROR: 'bun' was not found on PATH.
+[coding-buddy] ERROR: 'bun' was not found on PATH.
 
-claude-buddy's MCP server runs on bun. Install it with:
+coding-buddy's MCP server runs on bun. Install it with:
 
   Linux / macOS:
     curl -fsSL https://bun.sh/install | bash

--- a/server/path.ts
+++ b/server/path.ts
@@ -4,7 +4,7 @@
 //   1. Path normalization (Windows compat) — toUnixPath().
 //   2. Resolution of Claude Code config / state paths — claudeConfigDir,
 //      claudeSettingsPath, claudeSkillDir, claudeUserConfigPath, buddyStateDir.
-//      These honor CLAUDE_CONFIG_DIR so claude-buddy works with Claude Code's
+//      These honor CLAUDE_CONFIG_DIR so coding-buddy works with Claude Code's
 //      multi-account layout (one CLAUDE_CONFIG_DIR per profile).
 //
 // The shell counterpart of (2) lives in scripts/paths.sh and MUST stay in sync.

--- a/server/xp.ts
+++ b/server/xp.ts
@@ -1,5 +1,5 @@
 /**
- * XP and leveling system for claude-buddy.
+ * XP and leveling system for coding-buddy.
  *
  * Awards XP for coding events, computes levels, and manages unlockables.
  * State persists to xp.json in the buddy state directory.

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -7,11 +7,11 @@ allowed-tools: mcp__claude_buddy__*, Bash
 
 # Buddy — Your Coding Companion
 
-Handle the user's `/buddy` command using the claude-buddy MCP tools.
+Handle the user's `/buddy` command using the coding-buddy MCP tools.
 
 ## Fallback: MCP Tools Unavailable
 
-**Before routing any command, check whether `mcp__claude_buddy__*` tools are registered in this session.** If they are NOT — Claude Code was unable to start the claude-buddy MCP server — do not attempt to call any buddy tool. The tool calls will fail with an unhelpful "tool not found" error. Instead, run this diagnostic and report the result to the user so they can fix the underlying cause:
+**Before routing any command, check whether `mcp__claude_buddy__*` tools are registered in this session.** If they are NOT — Claude Code was unable to start the coding-buddy MCP server — do not attempt to call any buddy tool. The tool calls will fail with an unhelpful "tool not found" error. Instead, run this diagnostic and report the result to the user so they can fix the underlying cause:
 
 1. Check bun availability:
    ```bash
@@ -21,13 +21,13 @@ Handle the user's `/buddy` command using the claude-buddy MCP tools.
 
 2. If bun IS present, run the launcher directly to capture whatever error it emits. The launcher path depends on which marketplace installed the plugin; locate it first:
    ```bash
-   find ~/.claude/plugins/cache -name mcp-launcher.sh -path '*claude-buddy*' 2>/dev/null
+   find ~/.claude/plugins/cache -name mcp-launcher.sh -path '*coding-buddy*' 2>/dev/null
    ```
    Then execute the first result with stdin closed so it exits cleanly:
    ```bash
    <launcher-path> < /dev/null; echo "exit=$?"
    ```
-   Report the stdout/stderr and exit code verbatim. Common causes: missing `bun`, corrupted plugin cache (suggest `claude plugin uninstall claude-buddy@claude-buddy && claude plugin install claude-buddy@claude-buddy`), or a `bun`-level error loading `server/index.ts`.
+   Common causes: missing `bun`, corrupted plugin cache (suggest `claude plugin uninstall coding-buddy@coding-buddy && claude plugin install coding-buddy@coding-buddy`), or a `bun`-level error loading `server/index.ts`.
 
 3. If `$CLAUDE_CONFIG_DIR` is set in the environment, use that directory instead of `~/.claude` when searching for the launcher.
 
@@ -53,7 +53,7 @@ Based on `$ARGUMENTS`:
 | `save [slot]`            | Call `buddy_save` with optional slot name                                                    |
 | `list`                   | Call `buddy_list`                                                                            |
 | `dismiss <slot>`         | Call `buddy_dismiss` with the slot name                                                      |
-| `pick`                   | Tell user to run `! bun run pick` from the claude-buddy directory (launches interactive TUI) |
+| `pick`                   | Tell user to run `! bun run pick` from the coding-buddy directory (launches interactive TUI) |
 | `frequency`              | Call `buddy_frequency` with no args (show current)                                           |
 | `frequency <seconds>`    | Call `buddy_frequency` with cooldown=seconds                                                 |
 | `style`                  | Call `buddy_style` with no args (show current)                                               |
@@ -93,9 +93,9 @@ If the user mentions the buddy's name in normal conversation, call `buddy_react`
 When the user invokes `/buddy uninstall`, run this sequence **in order** — do not skip steps, do not ask for confirmation between steps:
 
 1. Call the MCP tool `buddy_uninstall`. Display its output verbatim.
-2. Run via Bash tool: `claude plugin uninstall claude-buddy@claude-buddy`
-3. Run via Bash tool: `claude plugin marketplace remove claude-buddy`
-4. Run via Bash tool: `rm -rf ~/.claude/plugins/cache/claude-buddy`
+2. Run via Bash tool: `claude plugin uninstall coding-buddy@coding-buddy`
+3. Run via Bash tool: `claude plugin marketplace remove coding-buddy`
+4. Run via Bash tool: `rm -rf ~/.claude/plugins/cache/coding-buddy`
 5. Tell the user: uninstall is complete; companion data is kept at `~/.claude-buddy/`; restart Claude Code to release the plugin.
 
 If any Bash step fails (non-zero exit), report the error but continue with the remaining steps — each step is independent and always-safe to run.

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# claude-buddy status line — animated, right-aligned multi-line companion
+# coding-buddy status line — animated, right-aligned multi-line companion
 #
 # Art rendering: the server (writeStatusState in server/state.ts) pre-bakes
 # every frame with eye, hat overlay, and blink resolved, and writes them into


### PR DESCRIPTION
## Summary

- normalize the npm bin target so publishing retains the `coding-buddy` executable
- normalize the repository URL using npm's canonical form

## Verification

- `npm publish --dry-run --access public` succeeds without manifest-correction warnings

🤖 *This content was generated with AI assistance using OpenAI GPT-5.6 Sol.*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename package and binary from `claude-buddy` to `coding-buddy` for publishing
> - Renames the npm package to `@ramarivera/coding-buddy` v0.6.0, updates the `bin` entry to `coding-buddy`, and adds `publishConfig` with public access in [package.json](https://github.com/ramarivera/claude-buddy/pull/131/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
> - Updates all user-facing CLI banners, TUI labels, MCP server identity, and plugin manifests to use the new name.
> - Fixes hook de-duplication and removal in install, disable, and uninstall flows to match hooks registered under either `coding-buddy` or the legacy `claude-buddy` name.
> - Adds Pi and Oh My Pi packages as optional peer dependencies.
> - Behavioral Change: the MCP server now registers as `coding-buddy` v0.6.0; existing Claude Code hooks registered as `claude-buddy` will be cleaned up on next install/uninstall/disable run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0bc2ff7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rebranded the product as **coding-buddy**, version 0.6.0.
  * Added documented support for Claude Code, Pi, and Oh My Pi, including multi-profile setup.
  * Added updated installation, migration, continuity, troubleshooting, and uninstall guidance.
  * Renamed the published package and command to `@ramarivera/coding-buddy` and `coding-buddy`.

* **Bug Fixes**
  * Improved disable, reinstall, and uninstall cleanup to recognize both legacy and current branding.

* **Documentation**
  * Updated CLI help, setup instructions, examples, terminology, and licensing references throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->