### PR TITLE
Preserve coding-buddy executable when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ]
   },
   "bin": {
-    "coding-buddy": "./cli/index.ts"
+    "coding-buddy": "cli/index.ts"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.cjs",
@@ -66,7 +66,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/1270011/claude-buddy.git"
+    "url": "git+https://github.com/1270011/claude-buddy.git"
   },
   "homepage": "https://github.com/1270011/claude-buddy#readme",
   "license": "MIT",
@@ -103,9 +103,17 @@
     "@oh-my-pi/pi-coding-agent": "17.0.9"
   },
   "peerDependenciesMeta": {
-    "@mariozechner/pi-coding-agent": { "optional": true },
-    "@oh-my-pi/pi-agent-core": { "optional": true },
-    "@oh-my-pi/pi-ai": { "optional": true },
-    "@oh-my-pi/pi-coding-agent": { "optional": true }
+    "@mariozechner/pi-coding-agent": {
+      "optional": true
+    },
+    "@oh-my-pi/pi-agent-core": {
+      "optional": true
+    },
+    "@oh-my-pi/pi-ai": {
+      "optional": true
+    },
+    "@oh-my-pi/pi-coding-agent": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

- normalize the npm bin target so publishing retains the `coding-buddy` executable
- normalize the repository URL using npm's canonical form

## Verification

- `npm publish --dry-run --access public` succeeds without manifest-correction warnings

🤖 *This content was generated with AI assistance using OpenAI GPT-5.6 Sol.*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/claude-buddy/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `coding-buddy` executable path when publishing
> Fixes the `coding-buddy` bin path in [package.json](https://github.com/ramarivera/claude-buddy/pull/132/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) by removing the leading `./`, which caused the executable to be dropped during publish. Also adds a `git+` prefix to the repository URL and reformats `optionalDependencies` to multi-line style.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef47114.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->