### PR TITLE
Update links after Coding Buddy repository rename

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "name": "coding-buddy",
     "owner": {
-        "name": "1270011"
+        "name": "ramarivera"
     },
     "metadata": {
         "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi (requires bun: https://bun.sh/install)",
@@ -14,10 +14,10 @@
             "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality. Requires bun runtime (https://bun.sh/install).",
             "version": "0.6.0",
             "author": {
-                "name": "1270011"
+                "name": "ramarivera"
             },
-            "homepage": "https://github.com/1270011/claude-buddy#readme",
-            "repository": "https://github.com/1270011/claude-buddy",
+            "homepage": "https://github.com/ramarivera/coding-buddy#readme",
+            "repository": "https://github.com/ramarivera/coding-buddy",
             "license": "MIT",
             "keywords": [
                 "coding-buddy",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,11 +3,11 @@
     "version": "0.6.0",
     "description": "Persistent coding companion for Claude Code, Pi, and Oh My Pi. MCP-based terminal pet with ASCII art, stats, reactions, and personality.",
     "author": {
-        "name": "1270011"
+        "name": "ramarivera"
     },
     "license": "MIT",
-    "repository": "https://github.com/1270011/claude-buddy",
-    "homepage": "https://github.com/1270011/claude-buddy#readme",
+    "repository": "https://github.com/ramarivera/coding-buddy",
+    "homepage": "https://github.com/ramarivera/coding-buddy#readme",
     "keywords": [
         "coding-buddy",
         "claude-code",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ you need: setup, DCO sign-off, tests, and what happens when you open a PR.
 ## Quick Setup
 
 ```bash
-git clone https://github.com/1270011/claude-buddy.git coding-buddy
+git clone https://github.com/ramarivera/coding-buddy.git coding-buddy
 cd coding-buddy
 bun install
 bun run install-buddy

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 <!-- BADGES                                                        -->
 <!-- ============================================================ -->
 
-[![Version](https://img.shields.io/github/v/release/1270011/claude-buddy?style=flat-square&color=6366f1)](https://github.com/1270011/claude-buddy/releases)
-[![License](https://img.shields.io/github/license/1270011/claude-buddy?style=flat-square&color=10b981)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/1270011/claude-buddy?style=flat-square&color=f59e0b)](https://github.com/1270011/claude-buddy/stargazers)
+[![Version](https://img.shields.io/github/v/release/ramarivera/coding-buddy?style=flat-square&color=6366f1)](https://github.com/ramarivera/coding-buddy/releases)
+[![License](https://img.shields.io/github/license/ramarivera/coding-buddy?style=flat-square&color=10b981)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/ramarivera/coding-buddy?style=flat-square&color=f59e0b)](https://github.com/ramarivera/coding-buddy/stargazers)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-v2.1.80%2B-8b5cf6?style=flat-square)](https://claude.ai/code)
 [![Platform](https://img.shields.io/badge/platform-linux%20%7C%20macOS-blue?style=flat-square)](#requirements)
 [![MCP](https://img.shields.io/badge/powered%20by-MCP-ec4899?style=flat-square)](https://modelcontextprotocol.io)
@@ -124,7 +124,7 @@ OMP registers the package's native extension and stores companion state under `~
 ### From source
 
 ```bash
-git clone https://github.com/1270011/claude-buddy coding-buddy
+git clone https://github.com/ramarivera/coding-buddy coding-buddy
 cd coding-buddy
 bun install
 bun run install-buddy
@@ -389,7 +389,7 @@ jq '.mcpServers["claude-buddy"]' ~/.claude.json
 Known MVP issue on some terminal/platform combos — different terminals render Braille Pattern Blank (U+2800) at different widths.
 
 To help us fix it:
-1. Run `bun run doctor` and paste output in a [new issue](https://github.com/1270011/claude-buddy/issues/new)
+1. Run `bun run doctor` and paste output in a [new issue](https://github.com/ramarivera/coding-buddy/issues/new)
 2. Run `bun run test-statusline` and screenshot the result
 3. Then `bun run test-statusline restore`
 
@@ -443,15 +443,15 @@ bun run uninstall           # full clean removal
 
 Thank you to everyone who helped bring buddies back to life.
 
-<a href="https://github.com/1270011/claude-buddy/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=1270011/claude-buddy" alt="Contributors" />
+<a href="https://github.com/ramarivera/coding-buddy/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=ramarivera/coding-buddy" alt="Contributors" />
 </a>
 
-<sub>Automatically generated from the [contributors graph](https://github.com/1270011/claude-buddy/graphs/contributors) via [contrib.rocks](https://contrib.rocks).</sub>
+<sub>Automatically generated from the [contributors graph](https://github.com/ramarivera/coding-buddy/graphs/contributors) via [contrib.rocks](https://contrib.rocks).</sub>
 
 <br>
 
-Want to help? New species, better reactions, bugfixes, wild new features — [PRs welcome](https://github.com/1270011/claude-buddy/pulls).
+Want to help? New species, better reactions, bugfixes, wild new features — [PRs welcome](https://github.com/ramarivera/coding-buddy/pulls).
 
 <br>
 

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ramarivera/claude-buddy.git"
+    "url": "git+https://github.com/ramarivera/coding-buddy.git"
   },
-  "homepage": "https://github.com/ramarivera/claude-buddy#readme",
+  "homepage": "https://github.com/ramarivera/coding-buddy#readme",
   "license": "MIT",
   "dependencies": {
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",


### PR DESCRIPTION
## Summary

- point package and plugin metadata at `ramarivera/coding-buddy`
- update README badges, clone commands, issue links, contributors, and PR links
- update Claude marketplace owner and author metadata to `ramarivera`

Legacy runtime and state identifiers remain unchanged for compatibility.

## Verification

- `bun test`: 324 passed
- `bun run typecheck`: passed
- `npm pack --dry-run`: passed
- no stale `1270011/claude-buddy` or `ramarivera/claude-buddy` repository URL remains

🤖 *This content was generated with AI assistance using OpenAI GPT-5.6 Sol.*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update repository links after Coding Buddy rename from `1270011/claude-buddy` to `ramarivera/coding-buddy`
> Updates all references to the old repository name and owner across metadata and documentation files, including [marketplace.json](.claude-plugin/marketplace.json), [plugin.json](.claude-plugin/plugin.json), [package.json](https://github.com/ramarivera/coding-buddy/pull/134/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [README.md](https://github.com/ramarivera/coding-buddy/pull/134/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), and [CONTRIBUTING.md](https://github.com/ramarivera/coding-buddy/pull/134/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80877fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->