### PR TITLE
fix: resolve OMP rendering and statusline color washout

### DIFF
--- a/adapters/omp/renderers.test.ts
+++ b/adapters/omp/renderers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import type { Companion, ReactionState } from "../../core/model.ts";
+import { renderBuddyStatus, renderBuddyWidget } from "./renderers.ts";
+
+const companion: Companion = {
+  name: "Nimbus",
+  personality: "quietly observant",
+  userId: "test-user",
+  hatchedAt: 0,
+  bones: {
+    rarity: "uncommon",
+    species: "blob",
+    eye: "°",
+    hat: "none",
+    shiny: false,
+    peak: "WISDOM",
+    dump: "CHAOS",
+    stats: { DEBUGGING: 50, PATIENCE: 50, CHAOS: 40, WISDOM: 90, SNARK: 40 },
+  },
+};
+
+const reaction: ReactionState = {
+  reaction: "*watching closely*",
+  reason: "turn",
+  timestamp: Date.now(),
+};
+
+describe("OMP buddy renderers", () => {
+  test("keeps reactions out of the compact status line", () => {
+    expect(renderBuddyStatus(companion)).not.toContain(reaction.reaction);
+  });
+
+  test("renders the reaction exactly once inside a framed bubble", () => {
+    const rendered = renderBuddyWidget(companion, reaction).join("\n");
+
+    expect(rendered.split(reaction.reaction)).toHaveLength(2);
+    expect(rendered).toContain("╭──────────────────────────────────────────────╮");
+    expect(rendered).toContain(`│ 💬 ${reaction.reaction} `);
+    expect(rendered).toContain("╰──────────────────────────────────────────────╯");
+    expect(rendered).not.toContain(`“${reaction.reaction}”`);
+  });
+
+  test("wraps long reactions at word boundaries", () => {
+    const longReaction = "the stray new PiBuddyStorage() on every turn_end — silent wrong-directory config reads — that is the crack in the file";
+    const lines = renderBuddyWidget(companion, { ...reaction, reaction: longReaction });
+    const start = lines.indexOf("╭──────────────────────────────────────────────╮");
+    const end = lines.indexOf("╰──────────────────────────────────────────────╯");
+
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(lines.slice(start, end + 1)).toEqual([
+      "╭──────────────────────────────────────────────╮",
+      "│ 💬 the stray new PiBuddyStorage() on every   │",
+      "│ turn_end — silent wrong-directory config     │",
+      "│ reads — that is the crack in the file        │",
+      "╰──────────────────────────────────────────────╯",
+    ]);
+  });
+});

--- a/adapters/omp/renderers.ts
+++ b/adapters/omp/renderers.ts
@@ -7,11 +7,68 @@ function trimArt(line: string): string {
   return line.replace(/\s+$/g, "");
 }
 
-export function renderBuddyStatus(companion: Companion, reaction?: ReactionState | null): string {
+const REACTION_WIDTH = 44;
+
+function displayWidth(text: string): number {
+  let width = 0;
+  for (const character of text) {
+    width += /\p{Emoji_Presentation}/u.test(character) ? 2 : 1;
+  }
+  return width;
+}
+
+function truncateToWidth(text: string, width: number): string {
+  let result = "";
+  let currentWidth = 0;
+  for (const character of text) {
+    const characterWidth = /\p{Emoji_Presentation}/u.test(character) ? 2 : 1;
+    if (currentWidth + characterWidth > width) break;
+    result += character;
+    currentWidth += characterWidth;
+  }
+  return result;
+}
+
+function wrapReaction(reaction: string): string[] {
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of reaction.trim().split(/\s+/)) {
+    if (!word) continue;
+    if (displayWidth(word) > REACTION_WIDTH) {
+      if (current) lines.push(current);
+      lines.push(`${truncateToWidth(word, REACTION_WIDTH - 1)}…`);
+      current = "";
+      continue;
+    }
+
+    const candidate = current ? `${current} ${word}` : word;
+    if (displayWidth(candidate) > REACTION_WIDTH) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+
+  if (current) lines.push(current);
+  return lines;
+}
+
+function renderReactionBubble(reaction: string): string[] {
+  const lines = wrapReaction(`💬 ${reaction}`);
+  const border = `╭${"─".repeat(REACTION_WIDTH + 2)}╮`;
+  return [
+    border,
+    ...lines.map((line) => `│ ${line}${" ".repeat(Math.max(0, REACTION_WIDTH - displayWidth(line)))} │`),
+    `╰${"─".repeat(REACTION_WIDTH + 2)}╯`,
+  ];
+}
+
+export function renderBuddyStatus(companion: Companion): string {
   const shiny = companion.bones.shiny ? " ✨" : "";
   const stars = RARITY_STARS[companion.bones.rarity];
-  const suffix = reaction?.reaction ? ` — ${reaction.reaction}` : "";
-  return `${trimArt(getArtFrame(companion.bones.species, companion.bones.eye, Date.now())[0])} ${companion.name} ${stars}${shiny}${suffix}`;
+  return `${trimArt(getArtFrame(companion.bones.species, companion.bones.eye, Date.now())[0])} ${companion.name} ${stars}${shiny}`;
 }
 
 export function renderBuddyWidget(
@@ -33,7 +90,7 @@ export function renderBuddyWidget(
   ];
 
   if (reaction?.reaction) {
-    lines.push("", `“${reaction.reaction}”`);
+    lines.push("", ...renderReactionBubble(reaction.reaction));
   }
 
   if (achievements.length > 0) {

--- a/adapters/omp/ui.ts
+++ b/adapters/omp/ui.ts
@@ -27,7 +27,7 @@ export class OmpBuddyUI {
   ): void {
     const currentReaction = reaction ?? null;
     const muted = this.storage.isMuted();
-    const status = renderBuddyStatus(companion, muted ? null : currentReaction);
+    const status = renderBuddyStatus(companion);
     ctx.ui.setStatus("buddy", muted ? `${status} [muted]` : status);
     ctx.ui.setWidget(
       "buddy",

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -32,6 +32,7 @@ NAME=$(jq -r '.name // ""' "$STATE" 2>/dev/null)
 [ -z "$NAME" ] && exit 0
 
 RARITY=$(jq -r '.rarity // "common"' "$STATE" 2>/dev/null)
+STARS=$(jq -r '.stars // ""' "$STATE" 2>/dev/null)
 SHINY=$(jq -r '.shiny // false' "$STATE" 2>/dev/null)
 REACTION=$(jq -r '.reaction // ""' "$STATE" 2>/dev/null)
 ACHIEVEMENT=$(jq -r '.achievement // ""' "$STATE" 2>/dev/null)
@@ -67,6 +68,7 @@ if [ -f "$CONFIG_FILE" ]; then
 fi
 
 NC=$'\033[0m'
+NEUTRAL=$'\033[39m'
 case "$RARITY" in
   common)
     [ "$_THEME" = "light" ] && C=$'\033[38;2;90;90;90m' || C=$'\033[38;2;153;153;153m' ;;
@@ -189,6 +191,7 @@ fi
 # so the geometric center sits at col 6.
 NAME_WITH_LEVEL="$NAME"
 [ "$LEVEL" -gt 1 ] 2>/dev/null && NAME_WITH_LEVEL="${NAME} [L${LEVEL}]"
+[ -n "$STARS" ] && NAME_WITH_LEVEL="${NAME_WITH_LEVEL} ${STARS}"
 case "$MOOD" in
     happy)       MOOD_EMOJI="" ;;
     focused)     MOOD_EMOJI="" ;;
@@ -215,11 +218,11 @@ for line in "${ART_LINES[@]}"; do
     if [ "$SHINY" = "true" ]; then
         ALL_COLORS+=("${RAINBOW[$(( (_arc + RAINBOW_OFFSET) % RAINBOW_LEN ))]}")
     else
-        ALL_COLORS+=("$C")
+        ALL_COLORS+=("$NEUTRAL")
     fi
     _arc=$(( _arc + 1 ))
 done
-ALL_LINES+=("$NAME_LINE"); ALL_COLORS+=("$DIM")
+ALL_LINES+=("$NAME_LINE"); ALL_COLORS+=("$C")
 
 ART_W=14
 ART_COUNT=${#ALL_LINES[@]}
@@ -372,18 +375,18 @@ for (( i=0; i<MAX_LINES; i++ )); do
 
             # Connector: "-- " on the middle text line, spaces otherwise
             if [ $bi -eq $CONNECTOR_BI ]; then
-                gap="${C}--${NC} "
+                gap="${NEUTRAL}--${NC} "
             else
                 gap="   "
             fi
 
             if [ "$btype" = "border" ]; then
-                echo "${SPACER}${C}${bline}${NC}${gap}${art_part}"
+                echo "${SPACER}${NEUTRAL}${bline}${NC}${gap}${art_part}"
             else
                 pipe_l="${bline:0:1}"
                 pipe_r="${bline: -1}"
                 inner="${bline:1:$(( ${#bline} - 2 ))}"
-                echo "${SPACER}${C}${pipe_l}${NC}${DIM}${inner}${NC}${C}${pipe_r}${NC}${gap}${art_part}"
+                echo "${SPACER}${NEUTRAL}${pipe_l}${NC}${DIM}${inner}${NC}${NEUTRAL}${pipe_r}${NC}${gap}${art_part}"
             fi
         else
             empty=$(printf '%*s' "$BOX_W" '')

--- a/statusline/buddy-status.test.ts
+++ b/statusline/buddy-status.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("buddy statusline colors", () => {
+  test("uses rarity color for the name and stars, not the art", () => {
+    const configDir = mkdtempSync(join(tmpdir(), "coding-buddy-statusline-"));
+    temporaryDirectories.push(configDir);
+    const stateDir = join(configDir, "buddy-state");
+    mkdirSync(stateDir);
+    writeFileSync(join(stateDir, "config.json"), JSON.stringify({ theme: "dark" }));
+    writeFileSync(join(stateDir, "status.json"), JSON.stringify({
+      name: "Nimbus",
+      rarity: "uncommon",
+      stars: "★★",
+      shiny: false,
+      reaction: "",
+      achievement: "",
+      level: 1,
+      mood: "focused",
+      frames: ["  art\n (°°)"],
+      frameSequence: [0],
+    }));
+
+    const result = Bun.spawnSync(["bash", join(import.meta.dir, "buddy-status.sh")], {
+      env: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: configDir,
+        BUDDY_FAKE_NOW: "0",
+        COLUMNS: "80",
+        BUDDY_SHELL: "",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = result.stdout.toString();
+    const green = "\x1b[38;2;78;186;101m";
+    const greenLines = output.split("\n").filter((line) => line.includes(green));
+
+    expect(result.exitCode).toBe(0);
+    expect(greenLines).toHaveLength(1);
+    expect(greenLines[0]).toContain("Nimbus ★★");
+    expect(output).not.toContain(`${green}  art`);
+    expect(output).not.toContain(`${green} (°°)`);
+  });
+});


### PR DESCRIPTION
Fixes #136

## What changed

- OMP reactions now render exactly once inside the widget-framed speech bubble. The compact status line no longer appends the reaction, and the widget wraps reaction text at terminal-width-aware word boundaries with clean ellipsizing for oversized tokens.
- Claude Code statusline now uses terminal-neutral coloring for the pre-rendered sprite and speech bubble. Rarity color is reserved for the buddy name and rarity stars, while shiny sprites retain their rainbow treatment.

## Verification

- bun test — 328 pass, 0 fail
- bun run typecheck — passed
- bash -n statusline/buddy-status.sh — passed

🤖 Generated with AI (GPT-5.6 Codex via multi:codex-execute)