### PR TITLE
feat(statusline): add cached sub-status and stable install

### DIFF
--- a/cli/install.ts
+++ b/cli/install.ts
@@ -8,12 +8,13 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, cpSync } from "fs";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import { resolve, dirname, join } from "path";
 
 import { generateBones, renderBuddy, renderFace, RARITY_STARS } from "../core/engine.ts"
 import {
   claudeConfigDir,
+  buddyStateDir,
   claudeSettingsPath,
   claudeSkillDir,
   claudeUserConfigPath,
@@ -21,6 +22,7 @@ import {
 } from "../server/path.ts";
 import { loadCompanion, saveCompanion, resolveUserId, writeStatusState } from "../server/state.ts";
 import { generateFallbackName } from "../core/reactions.ts"
+import { copyRuntimeApp, stableRuntimePaths } from "./runtime-app.ts";
 
 const CYAN = "\x1b[36m";
 const GREEN = "\x1b[32m";
@@ -116,8 +118,8 @@ function saveSettings(settings: Record<string, any>) {
 
 // ─── Step 1: Register MCP server (in ~/.claude.json) ────────────────────────
 
-function installMcp() {
-  const serverPath = join(PROJECT_ROOT, "server", "index.ts");
+function installMcp(appDir: string) {
+  const serverPath = stableRuntimePaths(appDir).mcpServer;
 
   let claudeJson: Record<string, any> = {};
   try {
@@ -129,7 +131,7 @@ function installMcp() {
   claudeJson.mcpServers["claude-buddy"] = {
     command: "bun",
     args: [toUnixPath(serverPath)],
-    cwd: toUnixPath(PROJECT_ROOT),
+    cwd: toUnixPath(appDir),
   };
 
   writeFileSync(CLAUDE_JSON_PATH, JSON.stringify(claudeJson, null, 2));
@@ -147,8 +149,8 @@ function installSkill() {
 
 // ─── Step 3: Configure status line (with animation refresh) ─────────────────
 
-function installStatusLine(settings: Record<string, any>) {
-  const statusScript = join(PROJECT_ROOT, "statusline", "buddy-status.sh");
+function installStatusLine(settings: Record<string, any>, appDir: string) {
+  const statusScript = stableRuntimePaths(appDir).statusline;
 
   settings.statusLine = {
     type: "command",
@@ -181,13 +183,14 @@ function stripLegacyPopupHooks(settings: Record<string, any>) {
 
 // ─── Step 4: Register hooks ─────────────────────────────────────────────────
 
-function installHooks(settings: Record<string, any>) {
-  const reactHook     = join(PROJECT_ROOT, "hooks", "react.sh");
-  const fileTypeHook  = join(PROJECT_ROOT, "hooks", "file-type-react.sh");
-  const commentHook   = join(PROJECT_ROOT, "hooks", "buddy-comment.sh");
-  const suggestHook   = join(PROJECT_ROOT, "hooks", "suggest.sh");
-  const nameHook      = join(PROJECT_ROOT, "hooks", "name-react.sh");
-  const moodHook      = join(PROJECT_ROOT, "hooks", "mood-react.sh");
+function installHooks(settings: Record<string, any>, appDir: string) {
+  const hooksDir = stableRuntimePaths(appDir).hooks;
+  const reactHook     = join(hooksDir, "react.sh");
+  const fileTypeHook  = join(hooksDir, "file-type-react.sh");
+  const commentHook   = join(hooksDir, "buddy-comment.sh");
+  const suggestHook   = join(hooksDir, "suggest.sh");
+  const nameHook      = join(hooksDir, "name-react.sh");
+  const moodHook      = join(hooksDir, "mood-react.sh");
   const commandHook = (command: string) => ({
     type: "command",
     command: toUnixPath(command),
@@ -237,6 +240,15 @@ function installHooks(settings: Record<string, any>) {
   });
 
   ok("Hooks registered: PostToolUse (Bash + Write/Edit) + Stop (comment + suggest) + UserPromptSubmit (name + mood)");
+}
+
+function installRuntimeApp(): string {
+  const appDir = copyRuntimeApp(PROJECT_ROOT, buddyStateDir());
+  const installArgs = ["install", "--production", "--ignore-scripts"];
+  if (existsSync(join(appDir, "bun.lock"))) installArgs.push("--frozen-lockfile");
+  execFileSync("bun", installArgs, { cwd: appDir, stdio: "ignore" });
+  ok(`Stable runtime installed: ${appDir}`);
+  return appDir;
 }
 
 // ─── Step 5: Ensure MCP tools are allowed ───────────────────────────────────
@@ -301,14 +313,15 @@ console.log("");
 info("Installing coding-buddy...\n");
 
 const settings = loadSettings();
+const appDir = installRuntimeApp();
 
-installMcp();
+installMcp(appDir);
 installSkill();
 
 stripLegacyPopupHooks(settings);
-installStatusLine(settings);
+installStatusLine(settings, appDir);
 
-installHooks(settings);
+installHooks(settings, appDir);
 ensurePermissions(settings);
 saveSettings(settings);
 

--- a/cli/runtime-app.test.ts
+++ b/cli/runtime-app.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { copyRuntimeApp, stableRuntimeAppDir, stableRuntimePaths } from "./runtime-app.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("stable runtime app", () => {
+  test("derives all registrations below the per-user app directory", () => {
+    const paths = stableRuntimePaths("/home/user/.claude-buddy/app");
+
+    expect(paths.mcpServer).toBe("/home/user/.claude-buddy/app/server/index.ts");
+    expect(paths.mcpLauncher).toBe("/home/user/.claude-buddy/app/server/mcp-launcher.sh");
+    expect(paths.statusline).toBe("/home/user/.claude-buddy/app/statusline/buddy-status.sh");
+    expect(paths.combinedStatusline).toBe("/home/user/.claude-buddy/app/statusline/combined-status.sh");
+    expect(paths.hooks).toBe("/home/user/.claude-buddy/app/hooks");
+  });
+
+  test("refreshes the copy and removes stale runtime files", () => {
+    const root = mkdtempSync(join(tmpdir(), "coding-buddy-runtime-app-"));
+    temporaryDirectories.push(root);
+    for (const directory of ["core", "server", "hooks", "statusline", "scripts"]) {
+      mkdirSync(join(root, directory), { recursive: true });
+      writeFileSync(join(root, directory, "runtime.txt"), directory);
+    }
+    writeFileSync(join(root, "package.json"), "{\"name\":\"test\"}");
+
+    const stateDir = join(root, "state");
+    const appDir = copyRuntimeApp(root, stateDir);
+    const stale = join(appDir, "stale.txt");
+    writeFileSync(stale, "remove me");
+    writeFileSync(join(root, "statusline", "runtime.txt"), "updated");
+
+    expect(copyRuntimeApp(root, stateDir)).toBe(stableRuntimeAppDir(stateDir));
+    expect(existsSync(stale)).toBe(false);
+    expect(readFileSync(join(appDir, "statusline", "runtime.txt"), "utf8")).toBe("updated");
+  });
+});

--- a/cli/runtime-app.ts
+++ b/cli/runtime-app.ts
@@ -1,0 +1,49 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+
+export const RUNTIME_DIRECTORIES = [
+  "core",
+  "server",
+  "hooks",
+  "statusline",
+  "scripts",
+] as const;
+
+export const RUNTIME_FILES = ["package.json", "bun.lock"] as const;
+
+export function stableRuntimeAppDir(stateDir: string): string {
+  return join(stateDir, "app");
+}
+
+export function stableRuntimePaths(appDir: string) {
+  return {
+    mcpServer: join(appDir, "server", "index.ts"),
+    mcpLauncher: join(appDir, "server", "mcp-launcher.sh"),
+    statusline: join(appDir, "statusline", "buddy-status.sh"),
+    combinedStatusline: join(appDir, "statusline", "combined-status.sh"),
+    hooks: join(appDir, "hooks"),
+  };
+}
+
+/**
+ * Replace the stable runtime copy. The app directory is owned by the
+ * installer, so removing it first also removes files deleted by an upgrade.
+ */
+export function copyRuntimeApp(sourceRoot: string, stateDir: string): string {
+  const appDir = stableRuntimeAppDir(stateDir);
+  rmSync(appDir, { recursive: true, force: true });
+  mkdirSync(appDir, { recursive: true });
+
+  for (const directory of RUNTIME_DIRECTORIES) {
+    const source = join(sourceRoot, directory);
+    if (!existsSync(source)) throw new Error(`Missing runtime directory: ${source}`);
+    cpSync(source, join(appDir, directory), { recursive: true, force: true });
+  }
+
+  for (const file of RUNTIME_FILES) {
+    const source = join(sourceRoot, file);
+    if (existsSync(source)) cpSync(source, join(appDir, file), { force: true });
+  }
+
+  return appDir;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { existsSync } from "fs";
 import { join, resolve, dirname } from "path";
 
 import { generateBones,
@@ -45,6 +46,7 @@ import {
 } from "./state";
 import {
   buddyStateDir,
+  buddyAppDir,
   claudeConfigDir,
   claudeSettingsPath,
 } from "./path";
@@ -622,7 +624,7 @@ server.tool("buddy_unmute", "Unmute buddy reactions", {}, async () => {
 
 server.tool(
   "buddy_statusline",
-  "Enable or disable the buddy status line, and toggle combined mode (shows rate-limit usage bars alongside the buddy). Returns current status if called without arguments.",
+  "Enable or disable the buddy status line, toggle combined mode (shows rate-limit usage bars alongside the buddy), or set a cached asynchronous sub-status command. Returns current status if called without arguments.",
   {
     enabled: z
       .boolean()
@@ -636,17 +638,24 @@ server.tool(
       .describe(
         "true to show rate-limit usage bars alongside buddy (requires python3), false for buddy-only mode.",
       ),
+    subStatusCommand: z
+      .string()
+      .optional()
+      .describe(
+        "Shell command whose cached output is appended below the buddy panel. Empty string clears it; the command always runs asynchronously.",
+      ),
   },
-  async ({ enabled, combined }) => {
-    if (enabled === undefined && combined === undefined) {
+  async ({ enabled, combined, subStatusCommand }) => {
+    if (enabled === undefined && combined === undefined && subStatusCommand === undefined) {
       const cfg = loadConfig();
       const state = cfg.statusLineEnabled ? "enabled" : "disabled";
       const mode = cfg.useCombinedStatus ? "combined (with rate-limit bars)" : "basic (buddy only)";
+      const subStatus = cfg.subStatusCommand ?? "unset";
       return {
         content: [
           {
             type: "text",
-            text: `Status line: ${state}\nMode: ${mode}\nUse /buddy statusline on|off to toggle, /buddy statusline combined to add rate-limit bars.\nRestart Claude Code after changes for them to take effect.`,
+            text: `Status line: ${state}\nMode: ${mode}\nSub-status command: ${subStatus}\nUse /buddy statusline on|off to toggle, /buddy statusline combined to add rate-limit bars, or set subStatusCommand to append cached command output.\nRestart Claude Code after changes for them to take effect.`,
           },
         ],
       };
@@ -656,6 +665,10 @@ server.tool(
       saveConfig({ useCombinedStatus: combined });
     }
 
+    if (subStatusCommand !== undefined) {
+      saveConfig({ subStatusCommand: subStatusCommand.trim() ? subStatusCommand : undefined });
+    }
+
     if (enabled !== undefined) {
       saveConfig({ statusLineEnabled: enabled });
     }
@@ -663,7 +676,10 @@ server.tool(
     const cfg = loadConfig();
 
     if (cfg.statusLineEnabled) {
-      const pluginRoot = resolve(dirname(import.meta.dir));
+      const installedRoot = buddyAppDir();
+      const pluginRoot = existsSync(join(installedRoot, "statusline", "buddy-status.sh"))
+        ? installedRoot
+        : resolve(dirname(import.meta.dir));
       const scriptName = cfg.useCombinedStatus ? "combined-status.sh" : "buddy-status.sh";
       const statusScript = join(pluginRoot, "statusline", scriptName);
       setBuddyStatusLine(statusScript);

--- a/server/path.test.ts
+++ b/server/path.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "os";
 
 import {
   buddyStateDir,
+  buddyAppDir,
   claudeConfigDir,
   claudeSettingsPath,
   claudeSkillDir,
@@ -107,5 +108,14 @@ describe("buddyStateDir", () => {
   test("default is ~/.claude-buddy when CLAUDE_CONFIG_DIR is unset", () => {
     delete process.env.CLAUDE_CONFIG_DIR;
     expect(buddyStateDir()).toBe(join(homedir(), ".claude-buddy"));
+  });
+});
+
+describe("buddyAppDir", () => {
+  afterEach(restoreEnv);
+
+  test("places the stable runtime copy below the profile state dir", () => {
+    process.env.CLAUDE_CONFIG_DIR = "/tmp/profile";
+    expect(buddyAppDir()).toBe("/tmp/profile/buddy-state/app");
   });
 });

--- a/server/path.ts
+++ b/server/path.ts
@@ -80,3 +80,8 @@ export function buddyStateDir(): string {
   if (cfgDir) return join(cfgDir, "buddy-state");
   return join(homedir(), ".claude-buddy");
 }
+
+/** Stable per-profile runtime copy used by installer registrations. */
+export function buddyAppDir(): string {
+  return join(buddyStateDir(), "app");
+}

--- a/server/state.test.ts
+++ b/server/state.test.ts
@@ -8,7 +8,23 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { slugify } from "./state.ts";
+import { normalizeConfig, slugify } from "./state.ts";
+
+describe("normalizeConfig", () => {
+  test("leaves subStatusCommand unset by default", () => {
+    expect(normalizeConfig({}).subStatusCommand).toBeUndefined();
+  });
+
+  test("preserves a configured subStatusCommand", () => {
+    expect(normalizeConfig({ subStatusCommand: "ccstatusline" }).subStatusCommand)
+      .toBe("ccstatusline");
+  });
+
+  test("treats empty and non-string subStatusCommand values as unset", () => {
+    expect(normalizeConfig({ subStatusCommand: "  " }).subStatusCommand).toBeUndefined();
+    expect(normalizeConfig({ subStatusCommand: null }).subStatusCommand).toBeUndefined();
+  });
+});
 
 describe("slugify", () => {
   test("lowercases input", () => {

--- a/server/state.ts
+++ b/server/state.ts
@@ -324,6 +324,7 @@ export interface BuddyConfig {
   bubbleWidth: number;
   bubbleMargin: number;
   useCombinedStatus: boolean;
+  subStatusCommand?: string;
   rainbowColors?: string[];
   theme: "dark" | "light" | "auto";
   moodEnabled: boolean;
@@ -349,12 +350,22 @@ const DEFAULT_CONFIG: BuddyConfig = {
   suggestionCooldown: 180,
 };
 
+export function normalizeConfig(data: unknown): BuddyConfig {
+  const values = data && typeof data === "object" && !Array.isArray(data)
+    ? data
+    : {};
+  const config = { ...DEFAULT_CONFIG, ...values } as BuddyConfig;
+  if (typeof config.subStatusCommand !== "string" || config.subStatusCommand.trim() === "") {
+    delete config.subStatusCommand;
+  }
+  return config;
+}
+
 export function loadConfig(): BuddyConfig {
   try {
-    const data = JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
-    return { ...DEFAULT_CONFIG, ...data };
+    return normalizeConfig(JSON.parse(readFileSync(CONFIG_FILE, "utf8")));
   } catch {
-    return { ...DEFAULT_CONFIG };
+    return normalizeConfig({});
   }
 }
 
@@ -507,6 +518,7 @@ const TRANSIENT_PREFIXES = [
   "reaction.",
   ".last_reaction.",
   ".last_comment.",
+  ".substatus.",
 ];
 
 /**

--- a/statusline/buddy-status.sh
+++ b/statusline/buddy-status.sh
@@ -16,6 +16,7 @@
 
 # shellcheck source=../scripts/paths.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../scripts/paths.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/substatus.sh"
 
 STATE="$BUDDY_STATE_DIR/status.json"
 CONFIG_FILE="$BUDDY_STATE_DIR/config.json"
@@ -39,7 +40,7 @@ ACHIEVEMENT=$(jq -r '.achievement // ""' "$STATE" 2>/dev/null)
 LEVEL=$(jq -r '.level // 1' "$STATE" 2>/dev/null)
 MOOD=$(jq -r '.mood // "focused"' "$STATE" 2>/dev/null)
 
-cat > /dev/null  # drain stdin
+BUDDY_STATUSLINE_INPUT=$(cat)
 
 # ─── Animation: pick current frame from server-rendered frames ──────────────
 NOW=${BUDDY_FAKE_NOW:-$(date +%s)}
@@ -401,5 +402,9 @@ for (( i=0; i<MAX_LINES; i++ )); do
         echo "${SPACER}${art_part}"
     fi
 done
+
+# Append the last cached sub-status result below the buddy panel and refresh
+# it asynchronously when stale. The statusline itself never waits on it.
+append_substatus
 
 exit 0

--- a/statusline/buddy-status.test.ts
+++ b/statusline/buddy-status.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -35,6 +36,8 @@ describe("buddy statusline colors", () => {
       env: {
         ...process.env,
         CLAUDE_CONFIG_DIR: configDir,
+        CLAUDE_CODE_SESSION_ID: "",
+        TMUX_PANE: "",
         BUDDY_FAKE_NOW: "0",
         COLUMNS: "80",
         BUDDY_SHELL: "",
@@ -51,5 +54,77 @@ describe("buddy statusline colors", () => {
     expect(greenLines[0]).toContain("Nimbus ★★");
     expect(output).not.toContain(`${green}  art`);
     expect(output).not.toContain(`${green} (°°)`);
+  });
+});
+
+describe("buddy sub-status cache", () => {
+  test("returns immediately and refreshes the cache with the same stdin payload", async () => {
+    const configDir = mkdtempSync(join(tmpdir(), "coding-buddy-substatus-"));
+    temporaryDirectories.push(configDir);
+    const stateDir = join(configDir, "buddy-state");
+    mkdirSync(stateDir);
+    writeFileSync(join(stateDir, "config.json"), JSON.stringify({
+      subStatusCommand: "sleep 1; cat",
+    }));
+    writeFileSync(join(stateDir, "status.json"), JSON.stringify({
+      name: "Nimbus",
+      rarity: "common",
+      stars: "",
+      shiny: false,
+      reaction: "",
+      achievement: "",
+      level: 1,
+      mood: "focused",
+      frames: ["  art"],
+      frameSequence: [0],
+    }));
+
+    const input = '{"payload":"same-input"}\n';
+    const started = performance.now();
+    const first = spawnSync("bash", [join(import.meta.dir, "buddy-status.sh")], {
+      env: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: configDir,
+        CLAUDE_CODE_SESSION_ID: "",
+        TMUX_PANE: "",
+        BUDDY_FAKE_NOW: "0",
+        COLUMNS: "80",
+        BUDDY_SHELL: "",
+      },
+      input,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const elapsedMs = performance.now() - started;
+
+    expect(first.status).toBe(0);
+    // Includes launching a fresh bash process; the one-second sub-command is
+    // intentionally not part of this wall-clock measurement.
+    expect(elapsedMs).toBeLessThan(1500);
+    expect(existsSync(join(stateDir, ".substatus.default"))).toBe(false);
+
+    for (let attempt = 0; attempt < 30; attempt++) {
+      if (Bun.file(join(stateDir, ".substatus.default")).size > 0) break;
+      await Bun.sleep(100);
+    }
+
+    expect(readFileSync(join(stateDir, ".substatus.default"), "utf8").trim()).toBe(input.trim());
+    await Bun.sleep(200);
+    const second = spawnSync("bash", [join(import.meta.dir, "buddy-status.sh")], {
+      env: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: configDir,
+        CLAUDE_CODE_SESSION_ID: "",
+        TMUX_PANE: "",
+        BUDDY_FAKE_NOW: "0",
+        COLUMNS: "80",
+        BUDDY_SHELL: "",
+      },
+      input,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(second.stdout.toString()).toContain(input.trim());
   });
 });

--- a/statusline/combined-status.sh
+++ b/statusline/combined-status.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # statusline/combined-status.sh
 # Two-panel status line: rate-limit stats left, buddy art right.
-# buddy-status.sh is intentionally untouched (kept clean for upstream PR).
+# buddy-status.sh renders the buddy panel and shared cached sub-status below it.
 
 [ "$BUDDY_SHELL" = "1" ] && exit 0
 
@@ -54,7 +54,7 @@ except Exception:
 " 2>/dev/null)
 
 # ── Capture buddy art (buddy reads state files, not stdin) ───────────────────
-BUDDY_OUTPUT=$("$BUDDY_SCRIPT" </dev/null 2>/dev/null)
+BUDDY_OUTPUT=$(printf '%s' "$STDIN_DATA" | "$BUDDY_SCRIPT" 2>/dev/null)
 
 # No buddy output → exit silently (muted, no state, etc.)
 [ -z "$BUDDY_OUTPUT" ] && exit 0

--- a/statusline/substatus.sh
+++ b/statusline/substatus.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Shared cached sub-status renderer for the buddy statusline scripts.
+#
+# The command is intentionally launched from a detached process. Claude Code
+# kills a statusline process when the next one starts, so running the command
+# inline would make slow commands disappear before they can finish.
+
+_substatus_mtime() {
+    local path="$1"
+    local value
+    value=$(stat -f %m "$path" 2>/dev/null)
+    case "$value" in
+        ''|*[!0-9]*) value=$(stat -c %Y "$path" 2>/dev/null) ;;
+    esac
+    case "$value" in
+        ''|*[!0-9]*) echo 0 ;;
+        *) echo "$value" ;;
+    esac
+}
+
+append_substatus() {
+    local state_dir="$BUDDY_STATE_DIR"
+    local sid="${BUDDY_SID:-default}"
+    local config_file="$state_dir/config.json"
+    local cache_file="$state_dir/.substatus.$sid"
+    local lock_dir="$state_dir/.substatus.$sid.lock"
+    local command=""
+    local now cache_age lock_age
+
+    [ -f "$config_file" ] || return 0
+    command=$(jq -r '.subStatusCommand // ""' "$config_file" 2>/dev/null)
+    [ -n "$command" ] || return 0
+
+    # Always show the last complete result first. A missing or stale cache is
+    # allowed to be blank; the refresh below will populate the next tick.
+    [ -f "$cache_file" ] && cat "$cache_file"
+
+    now=$(date +%s)
+    cache_age=999999
+    if [ -f "$cache_file" ]; then
+        cache_age=$(( now - $(_substatus_mtime "$cache_file") ))
+        [ "$cache_age" -lt 0 ] && cache_age=0
+    fi
+    [ "$cache_age" -lt 5 ] && return 0
+
+    # mkdir is the portable atomic lock primitive. Only remove locks that are
+    # over a minute old, so a slow but healthy command is never duplicated.
+    if [ -d "$lock_dir" ]; then
+        lock_age=$(( now - $(_substatus_mtime "$lock_dir") ))
+        if [ "$lock_age" -gt 60 ]; then
+            rmdir "$lock_dir" 2>/dev/null || rm -rf "$lock_dir" 2>/dev/null
+        fi
+    fi
+
+    mkdir "$lock_dir" 2>/dev/null || return 0
+
+    # Keep the parent statusline fast even when the command takes minutes.
+    # The explicit /dev/null stdin makes this process independent of Claude's
+    # killed statusline process; the captured payload is piped to the command.
+    (
+        local tmp_file="$cache_file.$$"
+        printf '%s' "${BUDDY_STATUSLINE_INPUT:-}" | sh -c "$command" > "$tmp_file" 2>/dev/null
+        mv "$tmp_file" "$cache_file" 2>/dev/null || rm -f "$tmp_file" 2>/dev/null
+        rmdir "$lock_dir" 2>/dev/null || rm -rf "$lock_dir" 2>/dev/null
+    ) </dev/null > /dev/null 2>/dev/null &
+}


### PR DESCRIPTION
## Summary

Related to #136 (Claude Code statusline robustness) and #138 (stable installer paths and hook hardening).

- Adds `subStatusCommand` to the buddy config and `/buddy statusline`, with cached output appended below the buddy panel in both statusline modes.
- Refreshes sub-status output asynchronously behind a per-session cache and mkdir lock, so slow commands never block Claude Code's one-second statusline refresh.
- Copies the runtime into the profile-scoped `buddy-state/app` directory and registers stable MCP, statusline, and hook paths there.
- Re-running the installer replaces the runtime copy, installs production dependencies, and preserves the existing 15-second hook timeouts.

## Design notes

The statusline captures Claude Code's stdin payload once, prints the last complete cache, and starts a detached refresh only when the cache is older than five seconds. A stale lock older than 60 seconds is recoverable; refresh output is written through a temporary file before replacing the cache.

The installer copies `core/`, `server/`, `hooks/`, `statusline/`, `scripts/`, `package.json`, and `bun.lock` into the stable app directory. It runs a production-only Bun install there so pruning the npx cache cannot remove runtime dependencies.

## Verification

- `bun test` — 347 passing, 0 failing
- `bun run typecheck` — passing
- `bash -n statusline/buddy-status.sh statusline/combined-status.sh statusline/substatus.sh` — passing
- Slow-command integration test confirms the first invocation returns without waiting and the next invocation renders the cached stdin payload.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cached sub-status panel and stable per-user runtime install for buddy statusline
> - Introduces a stable per-user runtime copy under the buddy state directory and points MCP, statusline, and hook registrations to it.
> - Adds non-blocking cached sub-status rendering with per-session locking.
> - Persists and sanitizes the optional `subStatusCommand` configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e220dcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable sub-status commands to the status line.
  - Displays cached sub-status output while refreshing it asynchronously in the background.
  - Preserves status-line input when combining Buddy and rate-limit information.
  - Installs runtime assets in a stable application location for more reliable integrations.

- **Bug Fixes**
  - Improved configuration handling by ignoring blank or invalid sub-status settings.
  - Cleans up temporary sub-status data during plugin removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with AI (GPT-5.6 Codex via multi:codex-execute)
