### PR TITLE
fix(omp): rebuild compact widget layout

### DIFF
--- a/adapters/omp/renderers.test.ts
+++ b/adapters/omp/renderers.test.ts
@@ -26,15 +26,19 @@ const reaction: ReactionState = {
 };
 
 describe("OMP buddy renderers", () => {
-  test("composes intact art and details horizontally within the SDK height budget", () => {
+  test("composes details left and intact art right within the SDK height budget", () => {
     const lines = renderBuddyWidget(companion, reaction, [], 64);
     const plain = lines.join("\n").replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+    const artLine = plain.split("\n").find((line) => /\.-{2,6}\./.test(line)) ?? "";
 
     expect(lines).toHaveLength(5);
     expect(lines.length).toBeLessThanOrEqual(OMP_WIDGET_MAX_LINES);
     expect(plain).toMatch(/\.-{2,6}\./);
     expect(plain).toContain("Nimbus ★★");
     expect(plain).toContain("💬 *watching closely*");
+    expect(artLine).toMatch(/\.-{2,6}\./);
+    expect(artLine.indexOf("uncommon")).toBeLessThan(artLine.indexOf(".-"));
+    expect(displayWidth(artLine)).toBe(64);
     expect(lines.every((line) => displayWidth(line) <= 64)).toBe(true);
   });
 

--- a/adapters/omp/renderers.test.ts
+++ b/adapters/omp/renderers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Companion, ReactionState } from "../../core/model.ts";
-import { renderBuddyStatus, renderBuddyWidget } from "./renderers.ts";
+import { displayWidth, OMP_WIDGET_MAX_LINES, renderBuddyWidget } from "./renderers.ts";
 
 const companion: Companion = {
   name: "Nimbus",
@@ -26,34 +26,43 @@ const reaction: ReactionState = {
 };
 
 describe("OMP buddy renderers", () => {
-  test("keeps reactions out of the compact status line", () => {
-    expect(renderBuddyStatus(companion)).not.toContain(reaction.reaction);
+  test("composes intact art and details horizontally within the SDK height budget", () => {
+    const lines = renderBuddyWidget(companion, reaction, [], 64);
+    const plain = lines.join("\n").replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+
+    expect(lines).toHaveLength(5);
+    expect(lines.length).toBeLessThanOrEqual(OMP_WIDGET_MAX_LINES);
+    expect(plain).toMatch(/\.-{2,6}\./);
+    expect(plain).toContain("Nimbus ★★");
+    expect(plain).toContain("💬 *watching closely*");
+    expect(lines.every((line) => displayWidth(line) <= 64)).toBe(true);
   });
 
-  test("renders the reaction exactly once inside a framed bubble", () => {
-    const rendered = renderBuddyWidget(companion, reaction).join("\n");
-
-    expect(rendered.split(reaction.reaction)).toHaveLength(2);
-    expect(rendered).toContain("╭──────────────────────────────────────────────╮");
-    expect(rendered).toContain(`│ 💬 ${reaction.reaction} `);
-    expect(rendered).toContain("╰──────────────────────────────────────────────╯");
-    expect(rendered).not.toContain(`“${reaction.reaction}”`);
-  });
-
-  test("wraps long reactions at word boundaries", () => {
+  test("renders one wrapped reaction without a second bubble or status copy", () => {
     const longReaction = "the stray new PiBuddyStorage() on every turn_end — silent wrong-directory config reads — that is the crack in the file";
-    const lines = renderBuddyWidget(companion, { ...reaction, reaction: longReaction });
-    const start = lines.indexOf("╭──────────────────────────────────────────────╮");
-    const end = lines.indexOf("╰──────────────────────────────────────────────╯");
+    const lines = renderBuddyWidget(companion, { ...reaction, reaction: longReaction }, [], 64);
+    const rendered = lines.join("\n");
+    const plain = rendered.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
 
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-    expect(lines.slice(start, end + 1)).toEqual([
-      "╭──────────────────────────────────────────────╮",
-      "│ 💬 the stray new PiBuddyStorage() on every   │",
-      "│ turn_end — silent wrong-directory config     │",
-      "│ reads — that is the crack in the file        │",
-      "╰──────────────────────────────────────────────╯",
-    ]);
+    expect(plain.match(/💬/g)).toHaveLength(1);
+    expect(plain.match(/PiBuddyStorage\(\)/g)).toHaveLength(1);
+    expect(rendered).not.toContain("╭");
+    expect(rendered).not.toContain("╰");
+    expect(lines.length).toBeLessThanOrEqual(OMP_WIDGET_MAX_LINES);
+  });
+
+  test("keeps rarity ANSI and embedded per-part art ANSI intact", () => {
+    const wyvern: Companion = {
+      ...companion,
+      name: "Ember",
+      bones: { ...companion.bones, rarity: "legendary", species: "wyvern" },
+    };
+    const rendered = renderBuddyWidget(wyvern, reaction, [], 72).join("\n");
+
+    expect(rendered).toContain("\x1b[38;2;");
+    expect(rendered).toContain("\x1b[2;3m");
+    expect(rendered).toContain("Ember");
+    expect(rendered).toContain("★★★★★");
+    expect(rendered).toContain("|\\^```^/|");
   });
 });

--- a/adapters/omp/renderers.ts
+++ b/adapters/omp/renderers.ts
@@ -96,10 +96,8 @@ function renderDetails(
   companion: Companion,
   reaction: ReactionState | null | undefined,
   achievements: Achievement[],
-  width: number,
-  artWidth: number,
+  sideWidth: number,
 ): string[] {
-  const sideWidth = Math.max(8, width - artWidth - ART_GAP.length);
   const color = getRarityColor(companion.bones.rarity);
   const stars = RARITY_STARS[companion.bones.rarity];
   const shiny = companion.bones.shiny ? " ✨" : "";
@@ -129,13 +127,15 @@ export function renderBuddyWidget(
 ): string[] {
   const art = getFullArtFrame(companion, Math.floor(Date.now() / 700));
   const artWidth = Math.max(...art.map(displayWidth), 0);
-  const details = renderDetails(companion, reaction, achievements, Math.max(24, width), artWidth);
+  const widgetWidth = Math.max(24, width);
+  const sideWidth = Math.max(8, widgetWidth - artWidth - ART_GAP.length);
+  const details = renderDetails(companion, reaction, achievements, sideWidth);
   const rows = Math.max(art.length, details.length);
 
   return Array.from({ length: Math.min(OMP_WIDGET_MAX_LINES, rows) }, (_, index) => {
     const artLine = art[index] ?? "";
     const detailLine = details[index] ?? "";
-    return `${artLine}${" ".repeat(Math.max(0, artWidth - displayWidth(artLine)))}${ART_GAP}${detailLine}`.trimEnd();
+    return `${detailLine}${" ".repeat(Math.max(0, sideWidth - displayWidth(detailLine)))}${ART_GAP}${artLine}${" ".repeat(Math.max(0, artWidth - displayWidth(artLine)))}`;
   });
 }
 

--- a/adapters/omp/renderers.ts
+++ b/adapters/omp/renderers.ts
@@ -2,49 +2,68 @@ import { RARITY_STARS } from "../../core/engine.ts";
 import { getArtFrame, HAT_ART } from "../../core/render-model.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
 import type { Achievement } from "../../core/achievements.ts";
+import { getRarityColor } from "../../server/theme.ts";
+
+export const OMP_WIDGET_MAX_LINES = 10;
+
+const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const RESET = "\x1b[0m";
+const DIM_ITALIC = "\x1b[2;3m";
+const ART_GAP = "  ";
+const DEFAULT_WIDGET_WIDTH = 78;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, "");
+}
+
+function characterWidth(character: string, next?: string): number {
+  if (character === "\u200d" || /[\uFE00-\uFE0F]/u.test(character)) return 0;
+  if (next === "\uFE0F" && /\p{Emoji}/u.test(character)) return 2;
+  return /\p{Emoji_Presentation}/u.test(character) ? 2 : 1;
+}
+
+export function displayWidth(text: string): number {
+  const characters = [...stripAnsi(text)];
+  let width = 0;
+  for (let index = 0; index < characters.length; index += 1) {
+    width += characterWidth(characters[index]!, characters[index + 1]);
+  }
+  return width;
+}
 
 function trimArt(line: string): string {
   return line.replace(/\s+$/g, "");
 }
 
-const REACTION_WIDTH = 44;
-
-function displayWidth(text: string): number {
-  let width = 0;
-  for (const character of text) {
-    width += /\p{Emoji_Presentation}/u.test(character) ? 2 : 1;
-  }
-  return width;
-}
-
 function truncateToWidth(text: string, width: number): string {
+  if (width <= 0) return "";
   let result = "";
   let currentWidth = 0;
-  for (const character of text) {
-    const characterWidth = /\p{Emoji_Presentation}/u.test(character) ? 2 : 1;
-    if (currentWidth + characterWidth > width) break;
+  for (const character of [...stripAnsi(text)]) {
+    const nextWidth = characterWidth(character);
+    if (currentWidth + nextWidth > width) break;
     result += character;
-    currentWidth += characterWidth;
+    currentWidth += nextWidth;
   }
   return result;
 }
 
-function wrapReaction(reaction: string): string[] {
+function wrapReaction(reaction: string, width: number, maxLines: number): string[] {
   const lines: string[] = [];
   let current = "";
 
-  for (const word of reaction.trim().split(/\s+/)) {
+  for (const word of `💬 ${reaction.trim()}`.split(/\s+/)) {
     if (!word) continue;
-    if (displayWidth(word) > REACTION_WIDTH) {
+    if (displayWidth(word) > width) {
       if (current) lines.push(current);
-      lines.push(`${truncateToWidth(word, REACTION_WIDTH - 1)}…`);
+      lines.push(`${truncateToWidth(word, Math.max(1, width - 1))}…`);
       current = "";
       continue;
     }
 
     const candidate = current ? `${current} ${word}` : word;
-    if (displayWidth(candidate) > REACTION_WIDTH) {
-      lines.push(current);
+    if (displayWidth(candidate) > width) {
+      if (current) lines.push(current);
       current = word;
     } else {
       current = candidate;
@@ -52,52 +71,72 @@ function wrapReaction(reaction: string): string[] {
   }
 
   if (current) lines.push(current);
-  return lines;
+  if (lines.length <= maxLines) return lines;
+
+  const bounded = lines.slice(0, maxLines);
+  const last = bounded[maxLines - 1] ?? "";
+  bounded[maxLines - 1] = `${truncateToWidth(last, Math.max(1, width - 1))}…`;
+  return bounded;
 }
 
-function renderReactionBubble(reaction: string): string[] {
-  const lines = wrapReaction(`💬 ${reaction}`);
-  const border = `╭${"─".repeat(REACTION_WIDTH + 2)}╮`;
-  return [
-    border,
-    ...lines.map((line) => `│ ${line}${" ".repeat(Math.max(0, REACTION_WIDTH - displayWidth(line)))} │`),
-    `╰${"─".repeat(REACTION_WIDTH + 2)}╯`,
-  ];
+function getWidgetWidth(): number {
+  const columns = process.stdout.columns;
+  return columns && columns > 0 ? Math.max(24, columns - 2) : DEFAULT_WIDGET_WIDTH;
 }
 
-export function renderBuddyStatus(companion: Companion): string {
-  const shiny = companion.bones.shiny ? " ✨" : "";
+function getFullArtFrame(companion: Companion, frame: number): string[] {
+  const art = getArtFrame(companion.bones.species, companion.bones.eye, frame);
+  if (companion.bones.hat !== "none" && !stripAnsi(art[0] ?? "").trim()) {
+    art[0] = HAT_ART[companion.bones.hat];
+  }
+  return art.map(trimArt);
+}
+
+function renderDetails(
+  companion: Companion,
+  reaction: ReactionState | null | undefined,
+  achievements: Achievement[],
+  width: number,
+  artWidth: number,
+): string[] {
+  const sideWidth = Math.max(8, width - artWidth - ART_GAP.length);
+  const color = getRarityColor(companion.bones.rarity);
   const stars = RARITY_STARS[companion.bones.rarity];
-  return `${trimArt(getArtFrame(companion.bones.species, companion.bones.eye, Date.now())[0])} ${companion.name} ${stars}${shiny}`;
+  const shiny = companion.bones.shiny ? " ✨" : "";
+  const lines = [
+    `${color}${companion.name} ${stars}${shiny}${RESET}`,
+    `${companion.bones.rarity} ${companion.bones.species}`,
+  ];
+
+  if (reaction?.reaction) {
+    const remainingLines = Math.max(1, OMP_WIDGET_MAX_LINES - lines.length);
+    lines.push(...wrapReaction(reaction.reaction, sideWidth, remainingLines).map((line) => `${DIM_ITALIC}${line}${RESET}`));
+  }
+
+  for (const achievement of achievements) {
+    if (lines.length >= OMP_WIDGET_MAX_LINES) break;
+    lines.push(`🏆 ${achievement.name}`);
+  }
+
+  return lines;
 }
 
 export function renderBuddyWidget(
   companion: Companion,
   reaction?: ReactionState | null,
   achievements: Achievement[] = [],
+  width: number = getWidgetWidth(),
 ): string[] {
-  const frame = Math.floor(Date.now() / 700);
-  const art = getArtFrame(companion.bones.species, companion.bones.eye, frame).map(trimArt);
-  const hat = companion.bones.hat === "none" ? [] : [trimArt(HAT_ART[companion.bones.hat])];
-  const stars = RARITY_STARS[companion.bones.rarity];
-  const shiny = companion.bones.shiny ? " ✨" : "";
-  const lines = [
-    `buddy · ${companion.name}`,
-    `${companion.bones.rarity} ${companion.bones.species} ${stars}${shiny}`,
-    "",
-    ...hat,
-    ...art,
-  ];
+  const art = getFullArtFrame(companion, Math.floor(Date.now() / 700));
+  const artWidth = Math.max(...art.map(displayWidth), 0);
+  const details = renderDetails(companion, reaction, achievements, Math.max(24, width), artWidth);
+  const rows = Math.max(art.length, details.length);
 
-  if (reaction?.reaction) {
-    lines.push("", ...renderReactionBubble(reaction.reaction));
-  }
-
-  if (achievements.length > 0) {
-    lines.push("", ...achievements.map((achievement) => `🏆 ${achievement.name}`));
-  }
-
-  return lines;
+  return Array.from({ length: Math.min(OMP_WIDGET_MAX_LINES, rows) }, (_, index) => {
+    const artLine = art[index] ?? "";
+    const detailLine = details[index] ?? "";
+    return `${artLine}${" ".repeat(Math.max(0, artWidth - displayWidth(artLine)))}${ART_GAP}${detailLine}`.trimEnd();
+  });
 }
 
 export function renderBuddyStats(companion: Companion): string[] {

--- a/adapters/omp/ui.ts
+++ b/adapters/omp/ui.ts
@@ -1,7 +1,7 @@
 import type { OmpBuddyUiContext } from "./context.ts";
 import type { Achievement } from "../../core/achievements.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
-import { renderAchievementsSummary, renderBuddyStatus, renderBuddyWidget } from "./renderers.ts";
+import { renderAchievementsSummary, renderBuddyWidget } from "./renderers.ts";
 import { OmpBuddyStorage } from "./storage.ts";
 
 export class OmpBuddyUI {
@@ -27,8 +27,7 @@ export class OmpBuddyUI {
   ): void {
     const currentReaction = reaction ?? null;
     const muted = this.storage.isMuted();
-    const status = renderBuddyStatus(companion);
-    ctx.ui.setStatus("buddy", muted ? `${status} [muted]` : status);
+    ctx.ui.setStatus("buddy", undefined);
     ctx.ui.setWidget(
       "buddy",
       renderBuddyWidget(companion, muted ? null : currentReaction, achievements),


### PR DESCRIPTION
Fixes #141

## What changed

Rebuilt the Oh My Pi companion widget as a compact horizontal composition:

- Full `SPECIES_ART` frames stay intact on the right, with no squishing or partial-art extraction.
- Name, rarity stars, species, and the wrapped reaction sit to the left of the art.
- The widget renderer enforces OMP's ten-line array-widget budget, so it cannot emit the extra row that triggers `(widget truncated)`.
- Rarity colors apply to the name and stars; species art keeps its per-part ANSI palette; reactions use dim + italic ANSI styling.
- The old bare `buddy` status entry is cleared instead of floating a duplicate `Ember ★` line in the transcript.
- The old hardcoded 44-column reaction width is gone. OMP does not expose available width on `ExtensionUIContext`, so the adapter uses `process.stdout.columns - 2` (accounting for OMP Text's one-column side padding) with a 78-column fallback, and tests can pass an explicit width.

## OMP constraints verified

These references are from the installed OMP SDK/package used by the adapter (`@oh-my-pi/pi-coding-agent@17.0.9`; the live `omp` binary is `17.1.2`):

- `node_modules/@oh-my-pi/pi-coding-agent/src/modes/controllers/extension-ui-controller.ts:33,296-325` defines `MAX_WIDGET_LINES = 10`, renders string-array widgets as `Text` rows, and appends `... (widget truncated)` when more than ten rows are supplied.
- `node_modules/@oh-my-pi/pi-coding-agent/src/extensibility/extensions/types.ts:202-210,224-259` defines string-array `setWidget` content and `setStatus` as footer/status-bar text. The `ExtensionUIContext` interface has no width, columns, or rows signal.
- `node_modules/@oh-my-pi/pi-tui/src/components/text.ts:74-103` renders each widget row at the terminal width and explicitly wraps with `wrapTextWithAnsi`, preserving ANSI escape sequences.
- The installed `omp://extensions.md` documentation describes `setWidget` as rendering above/below the editor and confirms that string-array content is capped at ten lines.

## Before / after

Before, the widget stacked header, rarity, blank lines, art, framed reaction, and achievements vertically; it exceeded OMP's ten-row budget, used a fixed 44-column bubble, duplicated a bare status line, and made the art look wrong in the compact status row.

After, the metadata/reaction occupies the left side and the full art remains intact on the right in a bounded ten-row widget. The art column is right-aligned to the computed widget width; the status bar entry is cleared, and the renderer is width-aware using the best live signal available outside the SDK context.

## Verification

- `bun test` — 340 passed, 0 failed, 30,019 assertions.
- `bun test adapters/omp/renderers.test.ts` — 3 passed, 0 failed.
- `bun run typecheck` — passed.
- `git diff --check` — passed.
- Signed follow-up commit: `757cebd9a4bc7cfa5444310e37c61a11488dff9e`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rebuild OMP buddy widget layout to side-by-side details and art
> - Replaces the framed bubble and `renderBuddyStatus` compact status line with a side-by-side layout: details (name, rarity, reaction, achievements) on the left, art on the right.
> - Adds `OMP_WIDGET_MAX_LINES` (10) as a public constant capping widget height, and `getWidgetWidth` to adapt layout to terminal width.
> - Reaction text is now wrapped using a display-width-aware `wrapReaction` with a `💬` prefix, replacing the removed `renderReactionBubble`.
> - `displayWidth` and related ANSI/emoji utilities are updated to correctly handle ANSI codes, zero-width joiners, and variation selectors.
> - Behavioral Change: the `buddy` status line is now cleared (`undefined`) rather than populated; all buddy info is presented in the widget only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 757cebd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

🤖 Generated with AI (GPT-5.6 Codex via multi:codex-execute)
