### PR TITLE
fix(pi): rebuild buddy widget layout

### DIFF
--- a/adapters/omp/renderers.ts
+++ b/adapters/omp/renderers.ts
@@ -3,90 +3,27 @@ import { getArtFrame, HAT_ART } from "../../core/render-model.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
 import type { Achievement } from "../../core/achievements.ts";
 import { getRarityColor } from "../../server/theme.ts";
+import {
+  composeDetailsAndArt,
+  displayWidth,
+  getDetailsWidth,
+  getWidgetWidth,
+  WIDGET_MAX_LINES,
+  wrapReaction,
+} from "../shared/widget-layout.ts";
 
-export const OMP_WIDGET_MAX_LINES = 10;
-
-const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
 const RESET = "\x1b[0m";
 const DIM_ITALIC = "\x1b[2;3m";
-const ART_GAP = "  ";
-const DEFAULT_WIDGET_WIDTH = 78;
 
-function stripAnsi(text: string): string {
-  return text.replace(ANSI_PATTERN, "");
-}
-
-function characterWidth(character: string, next?: string): number {
-  if (character === "\u200d" || /[\uFE00-\uFE0F]/u.test(character)) return 0;
-  if (next === "\uFE0F" && /\p{Emoji}/u.test(character)) return 2;
-  return /\p{Emoji_Presentation}/u.test(character) ? 2 : 1;
-}
-
-export function displayWidth(text: string): number {
-  const characters = [...stripAnsi(text)];
-  let width = 0;
-  for (let index = 0; index < characters.length; index += 1) {
-    width += characterWidth(characters[index]!, characters[index + 1]);
-  }
-  return width;
-}
+export { displayWidth, WIDGET_MAX_LINES as OMP_WIDGET_MAX_LINES };
 
 function trimArt(line: string): string {
   return line.replace(/\s+$/g, "");
 }
 
-function truncateToWidth(text: string, width: number): string {
-  if (width <= 0) return "";
-  let result = "";
-  let currentWidth = 0;
-  for (const character of [...stripAnsi(text)]) {
-    const nextWidth = characterWidth(character);
-    if (currentWidth + nextWidth > width) break;
-    result += character;
-    currentWidth += nextWidth;
-  }
-  return result;
-}
-
-function wrapReaction(reaction: string, width: number, maxLines: number): string[] {
-  const lines: string[] = [];
-  let current = "";
-
-  for (const word of `💬 ${reaction.trim()}`.split(/\s+/)) {
-    if (!word) continue;
-    if (displayWidth(word) > width) {
-      if (current) lines.push(current);
-      lines.push(`${truncateToWidth(word, Math.max(1, width - 1))}…`);
-      current = "";
-      continue;
-    }
-
-    const candidate = current ? `${current} ${word}` : word;
-    if (displayWidth(candidate) > width) {
-      if (current) lines.push(current);
-      current = word;
-    } else {
-      current = candidate;
-    }
-  }
-
-  if (current) lines.push(current);
-  if (lines.length <= maxLines) return lines;
-
-  const bounded = lines.slice(0, maxLines);
-  const last = bounded[maxLines - 1] ?? "";
-  bounded[maxLines - 1] = `${truncateToWidth(last, Math.max(1, width - 1))}…`;
-  return bounded;
-}
-
-function getWidgetWidth(): number {
-  const columns = process.stdout.columns;
-  return columns && columns > 0 ? Math.max(24, columns - 2) : DEFAULT_WIDGET_WIDTH;
-}
-
 function getFullArtFrame(companion: Companion, frame: number): string[] {
   const art = getArtFrame(companion.bones.species, companion.bones.eye, frame);
-  if (companion.bones.hat !== "none" && !stripAnsi(art[0] ?? "").trim()) {
+  if (companion.bones.hat !== "none" && !(art[0] ?? "").trim()) {
     art[0] = HAT_ART[companion.bones.hat];
   }
   return art.map(trimArt);
@@ -107,12 +44,12 @@ function renderDetails(
   ];
 
   if (reaction?.reaction) {
-    const remainingLines = Math.max(1, OMP_WIDGET_MAX_LINES - lines.length);
+    const remainingLines = Math.max(1, WIDGET_MAX_LINES - lines.length);
     lines.push(...wrapReaction(reaction.reaction, sideWidth, remainingLines).map((line) => `${DIM_ITALIC}${line}${RESET}`));
   }
 
   for (const achievement of achievements) {
-    if (lines.length >= OMP_WIDGET_MAX_LINES) break;
+    if (lines.length >= WIDGET_MAX_LINES) break;
     lines.push(`🏆 ${achievement.name}`);
   }
 
@@ -126,17 +63,9 @@ export function renderBuddyWidget(
   width: number = getWidgetWidth(),
 ): string[] {
   const art = getFullArtFrame(companion, Math.floor(Date.now() / 700));
-  const artWidth = Math.max(...art.map(displayWidth), 0);
-  const widgetWidth = Math.max(24, width);
-  const sideWidth = Math.max(8, widgetWidth - artWidth - ART_GAP.length);
+  const sideWidth = getDetailsWidth(art, width);
   const details = renderDetails(companion, reaction, achievements, sideWidth);
-  const rows = Math.max(art.length, details.length);
-
-  return Array.from({ length: Math.min(OMP_WIDGET_MAX_LINES, rows) }, (_, index) => {
-    const artLine = art[index] ?? "";
-    const detailLine = details[index] ?? "";
-    return `${detailLine}${" ".repeat(Math.max(0, sideWidth - displayWidth(detailLine)))}${ART_GAP}${artLine}${" ".repeat(Math.max(0, artWidth - displayWidth(artLine)))}`;
-  });
+  return composeDetailsAndArt(details, art, width, WIDGET_MAX_LINES);
 }
 
 export function renderBuddyStats(companion: Companion): string[] {

--- a/adapters/omp/renderers.ts
+++ b/adapters/omp/renderers.ts
@@ -8,6 +8,7 @@ import {
   displayWidth,
   getDetailsWidth,
   getWidgetWidth,
+  stripAnsi,
   WIDGET_MAX_LINES,
   wrapReaction,
 } from "../shared/widget-layout.ts";
@@ -23,7 +24,7 @@ function trimArt(line: string): string {
 
 function getFullArtFrame(companion: Companion, frame: number): string[] {
   const art = getArtFrame(companion.bones.species, companion.bones.eye, frame);
-  if (companion.bones.hat !== "none" && !(art[0] ?? "").trim()) {
+  if (companion.bones.hat !== "none" && !stripAnsi(art[0] ?? "").trim()) {
     art[0] = HAT_ART[companion.bones.hat];
   }
   return art.map(trimArt);

--- a/adapters/pi/renderers.test.ts
+++ b/adapters/pi/renderers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { Achievement } from "../../core/achievements.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
 import { displayWidth } from "../shared/widget-layout.ts";
 import { PI_WIDGET_MAX_LINES, renderBuddyWidget } from "./renderers.ts";
@@ -24,6 +25,15 @@ const reaction: ReactionState = {
   reaction: "*watching closely*",
   reason: "turn",
   timestamp: Date.now(),
+};
+
+const achievement: Achievement = {
+  id: "test-achievement",
+  name: "Long Night Debugger",
+  description: "test",
+  icon: "🏆",
+  check: () => true,
+  secret: false,
 };
 
 describe("Pi buddy renderers", () => {
@@ -66,5 +76,21 @@ describe("Pi buddy renderers", () => {
     expect(rendered).toContain("Ember");
     expect(rendered).toContain("★★★★★");
     expect(rendered).toContain("|\\^```^/|");
+  });
+
+  test("keeps long detail labels within the width contract", () => {
+    const lines = renderBuddyWidget({ ...companion, name: "N".repeat(100) }, null, [], 64);
+
+    expect(lines).toHaveLength(5);
+    expect(lines.every((line) => displayWidth(line) <= 64)).toBe(true);
+    expect(lines.join("\n")).toMatch(/\.-{2,6}\./);
+  });
+
+  test("renders achievements in the shared details column", () => {
+    const plain = renderBuddyWidget(companion, null, [achievement], 64)
+      .join("\n")
+      .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+
+    expect(plain).toContain("🏆 Long Night Debugger");
   });
 });

--- a/adapters/pi/renderers.test.ts
+++ b/adapters/pi/renderers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { Companion, ReactionState } from "../../core/model.ts";
+import { displayWidth } from "../shared/widget-layout.ts";
+import { PI_WIDGET_MAX_LINES, renderBuddyWidget } from "./renderers.ts";
+
+const companion: Companion = {
+  name: "Nimbus",
+  personality: "quietly observant",
+  userId: "test-user",
+  hatchedAt: 0,
+  bones: {
+    rarity: "uncommon",
+    species: "blob",
+    eye: "°",
+    hat: "none",
+    shiny: false,
+    peak: "WISDOM",
+    dump: "CHAOS",
+    stats: { DEBUGGING: 50, PATIENCE: 50, CHAOS: 40, WISDOM: 90, SNARK: 40 },
+  },
+};
+
+const reaction: ReactionState = {
+  reaction: "*watching closely*",
+  reason: "turn",
+  timestamp: Date.now(),
+};
+
+describe("Pi buddy renderers", () => {
+  test("composes details left and intact art right within Pi's widget budget", () => {
+    const lines = renderBuddyWidget(companion, reaction, [], 64);
+    const plain = lines.join("\n").replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+    const artLine = plain.split("\n").find((line) => /\.-{2,6}\./.test(line)) ?? "";
+
+    expect(lines).toHaveLength(5);
+    expect(lines.length).toBeLessThanOrEqual(PI_WIDGET_MAX_LINES);
+    expect(plain).toContain("Nimbus ★★");
+    expect(plain).toContain("💬 *watching closely*");
+    expect(artLine).toMatch(/\.-{2,6}\./);
+    expect(artLine.indexOf("uncommon")).toBeLessThan(artLine.indexOf(".-"));
+    expect(displayWidth(artLine)).toBe(64);
+    expect(lines.every((line) => displayWidth(line) <= 64)).toBe(true);
+  });
+
+  test("renders one wrapped reaction and caps the widget height", () => {
+    const longReaction = "the stray new PiBuddyStorage() on every turn_end — silent wrong-directory config reads — that is the crack in the file";
+    const lines = renderBuddyWidget(companion, { ...reaction, reaction: longReaction }, [], 64);
+    const rendered = lines.join("\n");
+    const plain = rendered.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+
+    expect(plain.match(/💬/g)).toHaveLength(1);
+    expect(plain.match(/PiBuddyStorage\(\)/g)).toHaveLength(1);
+    expect(lines.length).toBeLessThanOrEqual(PI_WIDGET_MAX_LINES);
+  });
+
+  test("keeps rarity ANSI, dim-italic reaction, and full art intact", () => {
+    const wyvern: Companion = {
+      ...companion,
+      name: "Ember",
+      bones: { ...companion.bones, rarity: "legendary", species: "wyvern" },
+    };
+    const rendered = renderBuddyWidget(wyvern, reaction, [], 72).join("\n");
+
+    expect(rendered).toContain("\x1b[38;2;");
+    expect(rendered).toContain("\x1b[2;3m");
+    expect(rendered).toContain("Ember");
+    expect(rendered).toContain("★★★★★");
+    expect(rendered).toContain("|\\^```^/|");
+  });
+});

--- a/adapters/pi/renderers.ts
+++ b/adapters/pi/renderers.ts
@@ -2,45 +2,59 @@ import { RARITY_STARS } from "../../core/engine.ts";
 import { getArtFrame, HAT_ART } from "../../core/render-model.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
 import type { Achievement } from "../../core/achievements.ts";
+import { getRarityColor } from "../../server/theme.ts";
+import {
+  composeDetailsAndArt,
+  getDetailsWidth,
+  getWidgetWidth,
+  WIDGET_MAX_LINES,
+  wrapReaction,
+} from "../shared/widget-layout.ts";
+
+export const PI_WIDGET_MAX_LINES = WIDGET_MAX_LINES;
+
+const RESET = "\x1b[0m";
+const DIM_ITALIC = "\x1b[2;3m";
 
 function trimArt(line: string): string {
   return line.replace(/\s+$/g, "");
-}
-
-export function renderBuddyStatus(companion: Companion, reaction?: ReactionState | null): string {
-  const shiny = companion.bones.shiny ? " ✨" : "";
-  const stars = RARITY_STARS[companion.bones.rarity];
-  const suffix = reaction?.reaction ? ` — ${reaction.reaction}` : "";
-  return `${trimArt(getArtFrame(companion.bones.species, companion.bones.eye, Date.now())[0])} ${companion.name} ${stars}${shiny}${suffix}`;
 }
 
 export function renderBuddyWidget(
   companion: Companion,
   reaction?: ReactionState | null,
   achievements: Achievement[] = [],
+  width: number = getWidgetWidth(),
 ): string[] {
-  const frame = Math.floor(Date.now() / 700);
-  const art = getArtFrame(companion.bones.species, companion.bones.eye, frame).map(trimArt);
-  const hat = companion.bones.hat === "none" ? [] : [trimArt(HAT_ART[companion.bones.hat])];
+  const art = getFullArtFrame(companion, Math.floor(Date.now() / 700));
+  const sideWidth = getDetailsWidth(art, width);
+  const color = getRarityColor(companion.bones.rarity);
   const stars = RARITY_STARS[companion.bones.rarity];
   const shiny = companion.bones.shiny ? " ✨" : "";
-  const lines = [
-    `buddy · ${companion.name}`,
-    `${companion.bones.rarity} ${companion.bones.species} ${stars}${shiny}`,
-    "",
-    ...hat,
-    ...art,
+  const details = [
+    `${color}${companion.name} ${stars}${shiny}${RESET}`,
+    `${companion.bones.rarity} ${companion.bones.species}`,
   ];
 
   if (reaction?.reaction) {
-    lines.push("", `“${reaction.reaction}”`);
+    const remainingLines = Math.max(1, PI_WIDGET_MAX_LINES - details.length);
+    details.push(...wrapReaction(reaction.reaction, sideWidth, remainingLines).map((line) => `${DIM_ITALIC}${line}${RESET}`));
   }
 
-  if (achievements.length > 0) {
-    lines.push("", ...achievements.map((achievement) => `🏆 ${achievement.name}`));
+  for (const achievement of achievements) {
+    if (details.length >= PI_WIDGET_MAX_LINES) break;
+    details.push(`🏆 ${achievement.name}`);
   }
 
-  return lines;
+  return composeDetailsAndArt(details, art, width, PI_WIDGET_MAX_LINES);
+}
+
+function getFullArtFrame(companion: Companion, frame: number): string[] {
+  const art = getArtFrame(companion.bones.species, companion.bones.eye, frame);
+  if (companion.bones.hat !== "none" && !(art[0] ?? "").trim()) {
+    art[0] = HAT_ART[companion.bones.hat];
+  }
+  return art.map(trimArt);
 }
 
 export function renderBuddyStats(companion: Companion): string[] {

--- a/adapters/pi/ui.ts
+++ b/adapters/pi/ui.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Achievement } from "../../core/achievements.ts";
 import type { Companion, ReactionState } from "../../core/model.ts";
-import { renderAchievementsSummary, renderBuddyStatus, renderBuddyWidget } from "./renderers.ts";
+import { renderAchievementsSummary, renderBuddyWidget } from "./renderers.ts";
 import { PiBuddyStorage } from "./storage.ts";
 
 type PiBuddyUiContext = ExtensionContext & {
@@ -32,8 +32,7 @@ export class PiBuddyUI {
   ): void {
     const currentReaction = reaction ?? null;
     const muted = this.storage.isMuted();
-    const status = renderBuddyStatus(companion, muted ? null : currentReaction);
-    ctx.ui.setStatus("buddy", muted ? `${status} [muted]` : status);
+    ctx.ui.setStatus("buddy", undefined);
     ctx.ui.setWidget(
       "buddy",
       renderBuddyWidget(companion, muted ? null : currentReaction, achievements),

--- a/adapters/shared/widget-layout.ts
+++ b/adapters/shared/widget-layout.ts
@@ -1,0 +1,95 @@
+const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const ART_GAP = "  ";
+const DEFAULT_WIDGET_WIDTH = 78;
+
+export const WIDGET_MAX_LINES = 10;
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_PATTERN, "");
+}
+
+function characterWidth(character: string, next?: string): number {
+  if (character === "\u200d" || /[\uFE00-\uFE0F]/u.test(character)) return 0;
+  if (next === "\uFE0F" && /\p{Emoji}/u.test(character)) return 2;
+  return /\p{Emoji_Presentation}/u.test(character) ? 2 : 1;
+}
+
+export function displayWidth(text: string): number {
+  const characters = [...stripAnsi(text)];
+  let width = 0;
+  for (let index = 0; index < characters.length; index += 1) {
+    width += characterWidth(characters[index]!, characters[index + 1]);
+  }
+  return width;
+}
+
+export function truncateToWidth(text: string, width: number): string {
+  if (width <= 0) return "";
+  let result = "";
+  let currentWidth = 0;
+  for (const character of [...stripAnsi(text)]) {
+    const nextWidth = characterWidth(character);
+    if (currentWidth + nextWidth > width) break;
+    result += character;
+    currentWidth += nextWidth;
+  }
+  return result;
+}
+
+export function wrapReaction(reaction: string, width: number, maxLines: number): string[] {
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of `💬 ${reaction.trim()}`.split(/\s+/)) {
+    if (!word) continue;
+    if (displayWidth(word) > width) {
+      if (current) lines.push(current);
+      lines.push(`${truncateToWidth(word, Math.max(1, width - 1))}…`);
+      current = "";
+      continue;
+    }
+
+    const candidate = current ? `${current} ${word}` : word;
+    if (displayWidth(candidate) > width) {
+      if (current) lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+
+  if (current) lines.push(current);
+  if (lines.length <= maxLines) return lines;
+
+  const bounded = lines.slice(0, maxLines);
+  const last = bounded[maxLines - 1] ?? "";
+  bounded[maxLines - 1] = `${truncateToWidth(last, Math.max(1, width - 1))}…`;
+  return bounded;
+}
+
+export function getWidgetWidth(): number {
+  const columns = process.stdout.columns;
+  return columns && columns > 0 ? Math.max(24, columns - 2) : DEFAULT_WIDGET_WIDTH;
+}
+
+export function getDetailsWidth(art: string[], width: number = getWidgetWidth()): number {
+  const artWidth = Math.max(...art.map(displayWidth), 0);
+  return Math.max(8, Math.max(24, width) - artWidth - ART_GAP.length);
+}
+
+export function composeDetailsAndArt(
+  details: string[],
+  art: string[],
+  width: number = getWidgetWidth(),
+  maxLines: number = WIDGET_MAX_LINES,
+): string[] {
+  const artWidth = Math.max(...art.map(displayWidth), 0);
+  const sideWidth = getDetailsWidth(art, width);
+  const rows = Math.max(art.length, details.length);
+
+  return Array.from({ length: Math.min(maxLines, rows) }, (_, index) => {
+    const artLine = art[index] ?? "";
+    const detailLine = details[index] ?? "";
+    return `${detailLine}${" ".repeat(Math.max(0, sideWidth - displayWidth(detailLine)))}${ART_GAP}${artLine}${" ".repeat(Math.max(0, artWidth - displayWidth(artLine)))}`;
+  });
+}

--- a/adapters/shared/widget-layout.ts
+++ b/adapters/shared/widget-layout.ts
@@ -4,7 +4,7 @@ const DEFAULT_WIDGET_WIDTH = 78;
 
 export const WIDGET_MAX_LINES = 10;
 
-function stripAnsi(text: string): string {
+export function stripAnsi(text: string): string {
   return text.replace(ANSI_PATTERN, "");
 }
 
@@ -90,6 +90,7 @@ export function composeDetailsAndArt(
   return Array.from({ length: Math.min(maxLines, rows) }, (_, index) => {
     const artLine = art[index] ?? "";
     const detailLine = details[index] ?? "";
-    return `${detailLine}${" ".repeat(Math.max(0, sideWidth - displayWidth(detailLine)))}${ART_GAP}${artLine}${" ".repeat(Math.max(0, artWidth - displayWidth(artLine)))}`;
+    const boundedDetailLine = displayWidth(detailLine) > sideWidth ? truncateToWidth(detailLine, sideWidth) : detailLine;
+    return `${boundedDetailLine}${" ".repeat(Math.max(0, sideWidth - displayWidth(boundedDetailLine)))}${ART_GAP}${artLine}${" ".repeat(Math.max(0, artWidth - displayWidth(artLine)))}`;
   });
 }


### PR DESCRIPTION
## Summary

- Extracted the ANSI-aware widget layout engine from OMP into `adapters/shared/widget-layout.ts`.
- Refactored OMP to consume the shared width, wrapping, right-aligned art, and 10-line-cap logic without changing its tested output.
- Rebuilt the Pi adapter widget with rarity-colored name/stars, species, one wrapped dim-italic `💬` reaction, achievements, and full ASCII art on the right.
- Cleared Pi's legacy status-line renderer so it cannot duplicate the widget's old colorless/art-less summary.
- Added Pi renderer coverage for height, art placement/intactness, single reaction, ANSI, long-label width bounds, and achievements.

## Pi 0.82 SDK constraints inspected

Inspected the installed `@earendil-works/pi-coding-agent` 0.82.0 package at `/Volumes/ExtSSD/Caches/mise/installs/npm-earendil-works-pi-coding-agent/latest/lib/node_modules/@earendil-works/pi-coding-agent`:

- `docs/extensions.md:167-168` documents `setStatus` as footer status and `setWidget` as the widget above the editor by default, so Pi uses the same `setWidget` surface as OMP; no footer/overlay adaptation is needed.
- `dist/core/extensions/types.d.ts:95-99` types widgets as `string[]` or component factories, with `aboveEditor`/`belowEditor` placement in `:41-47`. The Pi adapter uses the string-array path already supported by its runtime.
- `dist/modes/interactive/interactive-mode.js:1482-1487` truncates string-array widgets to `InteractiveMode.MAX_WIDGET_LINES` and adds a truncation marker; `:1540` sets that limit to 10 lines.
- `docs/tui.md:310-326` requires rendered component lines to stay within the supplied width and defines ANSI-aware visible-width utilities. Since the string-array `setWidget` API does not pass a width argument, the shared engine uses `process.stdout.columns` with a safe fallback and bounds each composed detail line.
- `package.json:3` confirms the inspected SDK version is `0.82.0`.

## Verification

- `bun test` — 352 pass, 0 fail across 25 files.
- `bun run typecheck` — pass.
- No new dependencies.
- Commits are DCO-signed with `git commit -s`.

🤖 *This content was generated with AI assistance using GPT-5.6 Codex.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with AI (GPT-5.6 Codex via multi:codex-execute)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rebuild Pi buddy widget layout using shared column composition utilities
> - Rewrites `renderBuddyWidget` in [adapters/pi/renderers.ts](https://github.com/ramarivera/coding-buddy/pull/145/files#diff-eb248fc3f7fd408375114483dc38b6497db4a0eac828a8f675283847f3939f83) to lay out a details column (name, stars, rarity/species, reaction, achievements) beside art using new shared helpers.
> - Introduces [adapters/shared/widget-layout.ts](https://github.com/ramarivera/coding-buddy/pull/145/files#diff-3b3b01820a908e7a6d03f263c95c369f326dc6bff0f7083007e26671c62df508) with utilities for ANSI stripping, display-width calculation, truncation, reaction wrapping, and column composition (`composeDetailsAndArt`).
> - Removes `renderBuddyStatus` from the Pi adapter; the `buddy` status line is no longer populated — only the widget is updated.
> - Adds a hat art helper (`getFullArtFrame`) that inserts hat art on the top line when the line is empty.
> - Risk: `renderBuddyStatus` is no longer available; any callers of that function will need to be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b39ecd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved buddy widgets with aligned companion details and ASCII art.
  * Added support for colored rarity, formatted reactions, and achievement display.
  * Widgets now adapt to terminal width and preserve formatting across wrapped text.

* **Bug Fixes**
  * Long names and reactions are wrapped or truncated to remain within widget size limits.
  * Improved handling of emoji, ANSI formatting, and hat artwork.

* **Tests**
  * Added coverage for widget sizing, wrapping, formatting, achievements, and artwork integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->