### PR TITLE
ci: TUI golden render check for the statusline

### DIFF
--- a/.github/workflows/tui-golden.yml
+++ b/.github/workflows/tui-golden.yml
@@ -1,0 +1,35 @@
+name: TUI Golden
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  statusline:
+    name: Statusline golden render
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install jq
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+
+      - name: Golden check (text assertions)
+        run: bash scripts/ci/check-statusline.sh
+
+      - name: Install vhs
+        uses: charmbracelet/vhs-action@v2
+        with:
+          path: scripts/ci/statusline.tape
+
+      - name: Upload render artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: statusline-render
+          path: |
+            scripts/ci/statusline.png
+            scripts/ci/statusline.gif
+          if-no-files-found: warn

--- a/scripts/ci/check-statusline.sh
+++ b/scripts/ci/check-statusline.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# CI golden check for the Claude Code statusline: renders buddy-status.sh
+# against the committed fixture state and asserts the output shape.
+# Run from the repo root: bash scripts/ci/check-statusline.sh
+set -euo pipefail
+
+fixture_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/statusline-fixture" && pwd)"
+payload='{"session_id":"ci","model":{"display_name":"CI"},"workspace":{"current_dir":"."}}'
+
+start=$(date +%s)
+output="$(printf '%s' "$payload" | CLAUDE_CONFIG_DIR="$fixture_dir" bash statusline/buddy-status.sh)"
+elapsed=$(( $(date +%s) - start ))
+
+plain="$(printf '%s' "$output" | sed $'s/\x1b\[[0-9;]*m//g')"
+lines=$(printf '%s\n' "$plain" | wc -l | tr -d ' ')
+
+fail() { echo "FAIL: $1" >&2; printf '%s\n' "$plain" >&2; exit 1; }
+
+name="$(jq -r .name "$fixture_dir/buddy-state/status.json")"
+printf '%s' "$plain" | grep -q "$name" || fail "pet name '$name' missing from output"
+[ "$lines" -ge 4 ] || fail "expected >=4 output lines, got $lines"
+[ "$elapsed" -le 10 ] || fail "statusline took ${elapsed}s (budget 10s)"
+
+echo "OK: statusline rendered $lines lines with '$name' in ${elapsed}s"

--- a/scripts/ci/statusline-fixture/buddy-state/config.json
+++ b/scripts/ci/statusline-fixture/buddy-state/config.json
@@ -1,0 +1,1 @@
+{"useCombinedStatus": false}

--- a/scripts/ci/statusline-fixture/buddy-state/status.json
+++ b/scripts/ci/statusline-fixture/buddy-state/status.json
@@ -1,0 +1,39 @@
+{
+  "name": "Cobalt",
+  "species": "pikachu",
+  "rarity": "uncommon",
+  "stars": "★★",
+  "face": "(@ω@)",
+  "eye": "@",
+  "shiny": false,
+  "hat": "wizard",
+  "reaction": "*does a little dance*",
+  "muted": false,
+  "achievement": "",
+  "frames": [
+    "    /^\\     \n   /\\_/\\   \n  (@ @)  \n   (  ω )   \n   (__)    ",
+    "    /^\\     \n   /\\_/\\   \n   (- -)   \n   (  ω )   \n   (__)    ",
+    "    /^\\     \n   /\\_/\\   \n  (@ @)  \n   (  ~ )   \n   (__)    ",
+    "    /^\\     \n   /\\_/\\   \n  (- -)  \n   (  ω )   \n   (__)    "
+  ],
+  "frameSequence": [
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    0,
+    0,
+    3,
+    0,
+    0,
+    2,
+    0,
+    0,
+    0
+  ],
+  "level": 1,
+  "xp": 0,
+  "mood": "tired"
+}

--- a/scripts/ci/statusline.tape
+++ b/scripts/ci/statusline.tape
@@ -1,0 +1,9 @@
+Output scripts/ci/statusline.gif
+Set Width 1400
+Set Height 500
+Set FontSize 14
+Set Shell "bash"
+Type "echo '{\"session_id\":\"ci\",\"model\":{\"display_name\":\"CI\"},\"workspace\":{\"current_dir\":\".\"}}' | CLAUDE_CONFIG_DIR=scripts/ci/statusline-fixture bash statusline/buddy-status.sh"
+Enter
+Sleep 12s
+Screenshot scripts/ci/statusline.png


### PR DESCRIPTION
Adds a PR-gated golden check: renders the statusline against a committed fixture (text assertions on pet name, line count, and time budget) and uploads a vhs PNG/GIF render as an artifact for visual inspection. First step of the TUI-capture CI discussed while dogfooding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTZg5SvK4q3JNq24aKZAVR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI golden render check for the statusline
> - Adds a GitHub Actions workflow ([tui-golden.yml](.github/workflows/tui-golden.yml)) that runs on PRs to `main`, validating statusline output and uploading GIF/PNG renders as artifacts.
> - [check-statusline.sh](scripts/ci/check-statusline.sh) runs `statusline/buddy-status.sh` against a fixture directory and asserts: output contains the fixture pet name, produces at least 4 lines, and completes within 10 seconds.
> - [statusline.tape](scripts/ci/statusline.tape) uses [VHS](https://github.com/charmbracelet/vhs) to render a terminal capture of the statusline, producing `statusline.gif` and `statusline.png` uploaded even on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9add7ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks for statusline content, rendering speed, and minimum output.
  * Added visual snapshot testing to verify statusline rendering.
  * CI now captures and uploads statusline screenshots and animations for review.

* **Chores**
  * Added fixed test fixtures covering buddy status, configuration, and animation frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->