### PR TITLE
ci(tui-golden): make the vhs visual render non-blocking

### DIFF
--- a/.github/workflows/tui-golden.yml
+++ b/.github/workflows/tui-golden.yml
@@ -19,7 +19,12 @@ jobs:
       - name: Golden check (text assertions)
         run: bash scripts/ci/check-statusline.sh
 
-      - name: Install vhs
+      - name: Preinstall vhs dependencies
+        continue-on-error: true
+        run: sudo apt-get install -y -qq ffmpeg ttyd
+
+      - name: Render with vhs (non-blocking visual artifact)
+        continue-on-error: true
         uses: charmbracelet/vhs-action@v2
         with:
           path: scripts/ci/statusline.tape


### PR DESCRIPTION
First TUI Golden run failed in vhs-action's ffmpeg install, not in the assertions. Preinstalls ffmpeg/ttyd and marks render steps continue-on-error so the deterministic text golden stays the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTZg5SvK4q3JNq24aKZAVR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make vhs visual render non-blocking in the tui-golden CI workflow
> Sets `continue-on-error: true` on both the vhs dependency installation step (ffmpeg and ttyd) and the `charmbracelet/vhs-action@v2` render step in [tui-golden.yml](.github/workflows/tui-golden.yml), so failures in either step no longer fail the job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12900b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->