### PR TITLE
fix(statusline): stop sub-status temp litter and refresh thrash

### DIFF
--- a/server/state.test.ts
+++ b/server/state.test.ts
@@ -24,6 +24,13 @@ describe("normalizeConfig", () => {
     expect(normalizeConfig({ subStatusCommand: "  " }).subStatusCommand).toBeUndefined();
     expect(normalizeConfig({ subStatusCommand: null }).subStatusCommand).toBeUndefined();
   });
+
+  test("defaults and validates subStatusRefreshSeconds", () => {
+    expect(normalizeConfig({}).subStatusRefreshSeconds).toBe(15);
+    expect(normalizeConfig({ subStatusRefreshSeconds: 30 }).subStatusRefreshSeconds).toBe(30);
+    expect(normalizeConfig({ subStatusRefreshSeconds: "30" }).subStatusRefreshSeconds).toBe(15);
+    expect(normalizeConfig({ subStatusRefreshSeconds: 0 }).subStatusRefreshSeconds).toBe(15);
+  });
 });
 
 describe("slugify", () => {

--- a/server/state.ts
+++ b/server/state.ts
@@ -325,6 +325,7 @@ export interface BuddyConfig {
   bubbleMargin: number;
   useCombinedStatus: boolean;
   subStatusCommand?: string;
+  subStatusRefreshSeconds: number;
   rainbowColors?: string[];
   theme: "dark" | "light" | "auto";
   moodEnabled: boolean;
@@ -343,6 +344,7 @@ const DEFAULT_CONFIG: BuddyConfig = {
   bubbleWidth: 28,
   bubbleMargin: 8,
   useCombinedStatus: false,
+  subStatusRefreshSeconds: 15,
   theme: "auto",
   moodEnabled: true,
   memoryEnabled: true,
@@ -357,6 +359,9 @@ export function normalizeConfig(data: unknown): BuddyConfig {
   const config = { ...DEFAULT_CONFIG, ...values } as BuddyConfig;
   if (typeof config.subStatusCommand !== "string" || config.subStatusCommand.trim() === "") {
     delete config.subStatusCommand;
+  }
+  if (!Number.isInteger(config.subStatusRefreshSeconds) || config.subStatusRefreshSeconds <= 0) {
+    config.subStatusRefreshSeconds = DEFAULT_CONFIG.subStatusRefreshSeconds;
   }
   return config;
 }

--- a/statusline/buddy-status.test.ts
+++ b/statusline/buddy-status.test.ts
@@ -1,10 +1,67 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 const temporaryDirectories: string[] = [];
+const statuslineScript = join(import.meta.dir, "buddy-status.sh");
+
+function createStatuslineFixture(config: Record<string, unknown>) {
+  const configDir = mkdtempSync(join(tmpdir(), "coding-buddy-substatus-"));
+  temporaryDirectories.push(configDir);
+  const stateDir = join(configDir, "buddy-state");
+  mkdirSync(stateDir);
+  writeFileSync(join(stateDir, "config.json"), JSON.stringify(config));
+  writeFileSync(join(stateDir, "status.json"), JSON.stringify({
+    name: "Nimbus",
+    rarity: "common",
+    stars: "",
+    shiny: false,
+    reaction: "",
+    achievement: "",
+    level: 1,
+    mood: "focused",
+    frames: ["  art"],
+    frameSequence: [0],
+  }));
+  return { configDir, stateDir };
+}
+
+function runStatusline(configDir: string, input = "{}\n") {
+  return spawnSync("bash", [statuslineScript], {
+    env: {
+      ...process.env,
+      CLAUDE_CONFIG_DIR: configDir,
+      CLAUDE_CODE_SESSION_ID: "",
+      TMUX_PANE: "",
+      BUDDY_FAKE_NOW: "0",
+      COLUMNS: "80",
+      BUDDY_SHELL: "",
+    },
+    input,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 3000) {
+  const attempts = Math.ceil(timeoutMs / 50);
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (condition()) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`condition was not met within ${timeoutMs}ms`);
+}
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
@@ -59,42 +116,13 @@ describe("buddy statusline colors", () => {
 
 describe("buddy sub-status cache", () => {
   test("returns immediately and refreshes the cache with the same stdin payload", async () => {
-    const configDir = mkdtempSync(join(tmpdir(), "coding-buddy-substatus-"));
-    temporaryDirectories.push(configDir);
-    const stateDir = join(configDir, "buddy-state");
-    mkdirSync(stateDir);
-    writeFileSync(join(stateDir, "config.json"), JSON.stringify({
+    const { configDir, stateDir } = createStatuslineFixture({
       subStatusCommand: "sleep 1; cat",
-    }));
-    writeFileSync(join(stateDir, "status.json"), JSON.stringify({
-      name: "Nimbus",
-      rarity: "common",
-      stars: "",
-      shiny: false,
-      reaction: "",
-      achievement: "",
-      level: 1,
-      mood: "focused",
-      frames: ["  art"],
-      frameSequence: [0],
-    }));
+    });
 
     const input = '{"payload":"same-input"}\n';
     const started = performance.now();
-    const first = spawnSync("bash", [join(import.meta.dir, "buddy-status.sh")], {
-      env: {
-        ...process.env,
-        CLAUDE_CONFIG_DIR: configDir,
-        CLAUDE_CODE_SESSION_ID: "",
-        TMUX_PANE: "",
-        BUDDY_FAKE_NOW: "0",
-        COLUMNS: "80",
-        BUDDY_SHELL: "",
-      },
-      input,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    const first = runStatusline(configDir, input);
     const elapsedMs = performance.now() - started;
 
     expect(first.status).toBe(0);
@@ -110,21 +138,66 @@ describe("buddy sub-status cache", () => {
 
     expect(readFileSync(join(stateDir, ".substatus.default"), "utf8").trim()).toBe(input.trim());
     await Bun.sleep(200);
-    const second = spawnSync("bash", [join(import.meta.dir, "buddy-status.sh")], {
-      env: {
-        ...process.env,
-        CLAUDE_CONFIG_DIR: configDir,
-        CLAUDE_CODE_SESSION_ID: "",
-        TMUX_PANE: "",
-        BUDDY_FAKE_NOW: "0",
-        COLUMNS: "80",
-        BUDDY_SHELL: "",
-      },
-      input,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    const second = runStatusline(configDir, input);
 
     expect(second.stdout.toString()).toContain(input.trim());
+  });
+
+  test("uses one temp path and cleans it up after a failed refresh", async () => {
+    const { configDir, stateDir } = createStatuslineFixture({
+      subStatusCommand: "sleep 1; exit 1",
+    });
+    const tempFile = join(stateDir, ".substatus.default.tmp");
+    const lockDir = join(stateDir, ".substatus.default.lock");
+
+    expect(runStatusline(configDir).status).toBe(0);
+    await waitFor(() => existsSync(tempFile));
+    expect(readdirSync(stateDir).filter((name) => name.startsWith(".substatus.default.")).sort())
+      .toEqual([".substatus.default.lock", ".substatus.default.tmp"]);
+
+    await waitFor(() => !existsSync(tempFile) && !existsSync(lockDir));
+    expect(existsSync(tempFile)).toBe(false);
+    expect(readdirSync(stateDir).filter((name) => name.startsWith(".substatus.default.")).sort())
+      .toEqual([]);
+  });
+
+  test("sweeps old temp files without deleting the cache or lock", () => {
+    const { configDir, stateDir } = createStatuslineFixture({});
+    const cacheFile = join(stateDir, ".substatus.default");
+    const staleTemp = join(stateDir, ".substatus.default.old");
+    const lockDir = join(stateDir, ".substatus.default.lock");
+    const oldDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+    writeFileSync(cacheFile, "cached\n");
+    writeFileSync(staleTemp, "orphan\n");
+    mkdirSync(lockDir);
+    utimesSync(staleTemp, oldDate, oldDate);
+
+    expect(runStatusline(configDir).status).toBe(0);
+    expect(existsSync(staleTemp)).toBe(false);
+    expect(readFileSync(cacheFile, "utf8")).toBe("cached\n");
+    expect(existsSync(lockDir)).toBe(true);
+  });
+
+  test("uses the 15-second default and honors a numeric TTL override", async () => {
+    const { configDir, stateDir } = createStatuslineFixture({
+      subStatusCommand: "printf refreshed",
+      subStatusRefreshSeconds: "invalid",
+    });
+    const cacheFile = join(stateDir, ".substatus.default");
+    const oldDate = new Date(Date.now() - 10 * 1000);
+    writeFileSync(cacheFile, "cached\n");
+    utimesSync(cacheFile, oldDate, oldDate);
+
+    expect(runStatusline(configDir).status).toBe(0);
+    await Bun.sleep(200);
+    expect(readFileSync(cacheFile, "utf8")).toBe("cached\n");
+
+    writeFileSync(join(stateDir, "config.json"), JSON.stringify({
+      subStatusCommand: "printf refreshed",
+      subStatusRefreshSeconds: 5,
+    }));
+    expect(runStatusline(configDir).status).toBe(0);
+    await waitFor(() => readFileSync(cacheFile, "utf8") === "refreshed");
   });
 });

--- a/statusline/substatus.sh
+++ b/statusline/substatus.sh
@@ -25,11 +25,23 @@ append_substatus() {
     local cache_file="$state_dir/.substatus.$sid"
     local lock_dir="$state_dir/.substatus.$sid.lock"
     local command=""
-    local now cache_age lock_age
+    local now cache_age lock_age refresh_seconds configured_refresh_seconds
+
+    # Remove abandoned refresh output without touching the complete cache or
+    # the lock directory. The refresh path below uses the same deterministic
+    # temp filename, so this also cleans up files from older implementations.
+    find "$state_dir" -type f -name ".substatus.$sid.*" -mmin +60 -exec rm -f {} \; 2>/dev/null
 
     [ -f "$config_file" ] || return 0
     command=$(jq -r '.subStatusCommand // ""' "$config_file" 2>/dev/null)
     [ -n "$command" ] || return 0
+
+    refresh_seconds=15
+    configured_refresh_seconds=$(jq -r '.subStatusRefreshSeconds // empty' "$config_file" 2>/dev/null)
+    case "$configured_refresh_seconds" in
+        ''|*[!0-9]*) ;;
+        *) [ "$configured_refresh_seconds" -gt 0 ] && refresh_seconds="$configured_refresh_seconds" ;;
+    esac
 
     # Always show the last complete result first. A missing or stale cache is
     # allowed to be blank; the refresh below will populate the next tick.
@@ -41,7 +53,7 @@ append_substatus() {
         cache_age=$(( now - $(_substatus_mtime "$cache_file") ))
         [ "$cache_age" -lt 0 ] && cache_age=0
     fi
-    [ "$cache_age" -lt 5 ] && return 0
+    [ "$cache_age" -lt "$refresh_seconds" ] && return 0
 
     # mkdir is the portable atomic lock primitive. Only remove locks that are
     # over a minute old, so a slow but healthy command is never duplicated.
@@ -58,9 +70,18 @@ append_substatus() {
     # The explicit /dev/null stdin makes this process independent of Claude's
     # killed statusline process; the captured payload is piped to the command.
     (
-        local tmp_file="$cache_file.$$"
-        printf '%s' "${BUDDY_STATUSLINE_INPUT:-}" | sh -c "$command" > "$tmp_file" 2>/dev/null
-        mv "$tmp_file" "$cache_file" 2>/dev/null || rm -f "$tmp_file" 2>/dev/null
-        rmdir "$lock_dir" 2>/dev/null || rm -rf "$lock_dir" 2>/dev/null
+        tmp_file="$state_dir/.substatus.$sid.tmp"
+        cleanup_substatus_refresh() {
+            rm -f "$tmp_file" 2>/dev/null
+            rmdir "$lock_dir" 2>/dev/null || rm -rf "$lock_dir" 2>/dev/null
+        }
+        trap cleanup_substatus_refresh EXIT
+        trap 'exit 1' HUP INT TERM
+
+        if printf '%s' "${BUDDY_STATUSLINE_INPUT:-}" | sh -c "$command" > "$tmp_file" 2>/dev/null; then
+            mv "$tmp_file" "$cache_file" 2>/dev/null || exit 1
+        else
+            exit 1
+        fi
     ) </dev/null > /dev/null 2>/dev/null &
 }


### PR DESCRIPTION
## Summary

- Use one deterministic per-session temp file, atomically replace the cache on success, and clean temp/lock state via an exit trap on failure.
- Sweep stale `.substatus.$SID.*` regular files older than an hour without touching the cache or lock.
- Raise the default refresh TTL to 15 seconds and honor a positive integer `subStatusRefreshSeconds` override with malformed-value fallback.

## Verification

- `bun test` — 356 pass, 0 fail
- `bun run typecheck` — passed
- Bash syntax and `git diff --check` — passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ramarivera/coding-buddy/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with AI (GPT-5.6 Codex via multi:codex-execute)